### PR TITLE
After updating the setting, we now re-render all open apps, instead o…

### DIFF
--- a/lib/hitlocationtooltip.mjs
+++ b/lib/hitlocationtooltip.mjs
@@ -40,17 +40,7 @@ export default class HitLocationEquipmentTooltip {
     console.log('Equipment tooltip:' + currentValue)
     this.display = currentValue
 
-    // render all actors
-    for (const actor of game.actors.entities) {
-      console.log(actor.name)
-      // Foundry BUG? sheet.rendered is 'false' if opened in response to 
-      // double-clicking the token. In that case, the player will have to 
-      // close and reopen his character sheet.
-      if (actor.sheet.rendered) {
-        console.log('re-render ' + actor.name)
-        await actor.sheet.close()
-        await actor.sheet.render(true)
-      }
-    }
+    // render all open apps
+    Object.values(ui.windows).filter(it => it.rendered).forEach(app => app.render(true))
   }
 }


### PR DESCRIPTION
…f actors. This fixes the issue with actor.sheet.rendered = false.