### PR TITLE
Refactored parselink and performAction methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,18 @@
 
 
 ## Current Release Version 0.7.0
+To install the latest release, use this manifest URL:   https://raw.githubusercontent.com/crnormand/gurps/release/system.json
+
+#The 'main' branch is being actively developed... and it may break things.   
+#So if you are looking for the last stable release, use the manifest URL above.
 
 This is what we are currently working on:
 - 0.8.0
     - Enhanced Drag and Drop Damage Dialog.
+    - Simplified (convention one-shot) character sheet
+    - Enhanced On-the-Fly parsing for Skills, Spells and Attacks (melee & ranged)
+    - Apply On-the-Fly parsing to the chat.   Now roll tables can include OtF formulas.
+    - More explicit warning if a user tries to import a GCS file directly.
 
 ### History
 - 0.7.0

--- a/exportutils/Foundry VTT.xml
+++ b/exportutils/Foundry VTT.xml
@@ -169,6 +169,12 @@
 	<birthday type="string">@BIRTHDAY</birthday>
 	<hand type="string">@HAND</hand>
 
+	<generaldr>@GENERAL_DR</generaldr>
+	<currentdodge>@CURRENT_DODGE</currentdodge>
+	<currentmove>@CURRENT_MOVE</currentmove>
+	<bestblock>@BEST_CURRENT_BLOCK</bestblock>
+	<bestparry>@BEST_CURRENT_BLOCK</bestparry>
+
       <adslist>@ADVANTAGES_LOOP_START
         <id-@ID>
           <name type="string">@DESCRIPTION_PRIMARY</name>

--- a/lang/en.json
+++ b/lang/en.json
@@ -26,6 +26,7 @@
     "GURPS.vision" : "Vision",
     "GURPS.hearing" : "Hearing",
     "GURPS.tastesmell" : "Taste/Smell",
+    "GURPS.touch" : "Touch",
     "GURPS.frightcheck" : "Fright Check",
     "GURPS.basicspeed" : "Basic Speed",
     "GURPS.basicmove" : "Basic Move",

--- a/lib/damagemessage.js
+++ b/lib/damagemessage.js
@@ -10,15 +10,6 @@ export default class DamageChat {
   setup() {
     let self = this
 
-		Hooks.on('preCreateChatMessage', (data, options, userId) => {
-			let c = data.content;
-			console.log("PRE CHAT:");
-			console.log(c);
-			data.content = game.GURPS.gurpslink(c, game.GURPS.LastActor?.data);
-			console.log("AFTER:");
-			console.log(data.content);
-		});
-		
     Hooks.on('renderChatMessage', (app, html, msg) => {
       let damageMessage = html.find(".damage-message")[0]
       if (damageMessage) {
@@ -28,43 +19,8 @@ export default class DamageChat {
           return ev.dataTransfer.setData("text/plain", app.data.flags.transfer)
         })
       }
-			let e = html.find(".table-results,.results.text");
-			e.click(ev => { 
-						game.GURPS.onGurpslink(ev, game.GURPS.LastActor);
-					});
-/*		    tableResultHtml.find(".rollable").click(this._onClickRoll.bind(this));
-		    tableResultHtml.find(".pdflink").click(this._onClickPdf.bind(this));
-		    tableResultHtml.find(".gurpslink").click(this._onClickGurpslink.bind(this));
-		    tableResultHtml.find(".gmod").click(this._onClickGmod.bind(this));
-		    tableResultHtml.find(".glinkmod").click(this._onClickGmod.bind(this));
-		    tableResultHtml.find(".glinkmodplus").click(this._onClickGmod.bind(this));
-		    tableResultHtml.find(".glinkmodminus").click(this._onClickGmod.bind(this));
-*/			
     })
   }
-
-  async _onClickPdf(event) {
-    event.preventDefault();
-    game.GURPS.onPdf(event);
-  }
-
-  async _onClickRoll(event) {
-    event.preventDefault();
-    game.GURPS.onRoll(event, this.actor);
-  }
-
-  async _onClickGurpslink(event) {
-    event.preventDefault();
-    game.GURPS.onGurpslink(event, this.actor);
-  }
-
-  async _onClickGmod(event) {
-    let element = event.currentTarget;
-    event.preventDefault();
-    let desc = element.dataset.name;
-    game.GURPS.onGurpslink(event, this.actor, desc);
-  }
-
 
   async create(actor, diceText, damageType, overrideDiceText) {
     let formula = d6ify(diceText)

--- a/lib/damagemessage.js
+++ b/lib/damagemessage.js
@@ -10,6 +10,15 @@ export default class DamageChat {
   setup() {
     let self = this
 
+		Hooks.on('preCreateChatMessage', (data, options, userId) => {
+			let c = data.content;
+			console.log("PRE CHAT:");
+			console.log(c);
+			data.content = game.GURPS.gurpslink(c, game.GURPS.LastActor?.data);
+			console.log("AFTER:");
+			console.log(data.content);
+		});
+		
     Hooks.on('renderChatMessage', (app, html, msg) => {
       let damageMessage = html.find(".damage-message")[0]
       if (damageMessage) {
@@ -19,8 +28,43 @@ export default class DamageChat {
           return ev.dataTransfer.setData("text/plain", app.data.flags.transfer)
         })
       }
+			let e = html.find(".table-results,.results.text");
+			e.click(ev => { 
+						game.GURPS.onGurpslink(ev, game.GURPS.LastActor);
+					});
+/*		    tableResultHtml.find(".rollable").click(this._onClickRoll.bind(this));
+		    tableResultHtml.find(".pdflink").click(this._onClickPdf.bind(this));
+		    tableResultHtml.find(".gurpslink").click(this._onClickGurpslink.bind(this));
+		    tableResultHtml.find(".gmod").click(this._onClickGmod.bind(this));
+		    tableResultHtml.find(".glinkmod").click(this._onClickGmod.bind(this));
+		    tableResultHtml.find(".glinkmodplus").click(this._onClickGmod.bind(this));
+		    tableResultHtml.find(".glinkmodminus").click(this._onClickGmod.bind(this));
+*/			
     })
   }
+
+  async _onClickPdf(event) {
+    event.preventDefault();
+    game.GURPS.onPdf(event);
+  }
+
+  async _onClickRoll(event) {
+    event.preventDefault();
+    game.GURPS.onRoll(event, this.actor);
+  }
+
+  async _onClickGurpslink(event) {
+    event.preventDefault();
+    game.GURPS.onGurpslink(event, this.actor);
+  }
+
+  async _onClickGmod(event) {
+    let element = event.currentTarget;
+    event.preventDefault();
+    let desc = element.dataset.name;
+    game.GURPS.onGurpslink(event, this.actor, desc);
+  }
+
 
   async create(actor, diceText, damageType, overrideDiceText) {
     let formula = d6ify(diceText)

--- a/lib/parselink.js
+++ b/lib/parselink.js
@@ -87,7 +87,7 @@ export default function parselink(str, actor, htmldesc, clrdmods = false) {
       "text": gspan(str),
       "action": {
         "type": "selfcontrol",
-        "target": num,
+        "target": parseInt(num),
         "desc": desc
       }
     }

--- a/lib/parselink.js
+++ b/lib/parselink.js
@@ -129,20 +129,13 @@ export default function parselink(str, actor, htmldesc, clrdmods = false) {
     let n = a[0].trim();
     if (!!n) {
       mod = a[2];
-      if (a[1] == "*") {
-        skill = actor?.data.skills?.findInProperties(s => s.name.startsWith(n));
-      } else {
-        skill = actor?.data.skills?.findInProperties(s => s.name == n);
-      }
-      if (!!skill) {
-        return {
-          "text": gspan(str),
-          "action": {
-            "type": "skill",
-            "name": skill.name,
-            "mod": mod,
-            "desc": a[3]
-          }
+      return {
+        "text": gspan(str),
+        "action": {
+          "type": "skill",
+          "name": n + a[1],
+          "mod": mod,
+          "desc": a[3]
         }
       }
     }

--- a/lib/parselink.js
+++ b/lib/parselink.js
@@ -120,26 +120,6 @@ export default function parselink(str, actor, htmldesc, clrdmods = false) {
     }
   }
 
-  // Look for skill*+/-N test
-  parse = str.replace(/^([\w ]*)(\*?)([-+]\d+)? ?(.*)/g, "$1~$2~$3~$4");
-  let skill = null;
-  let mod = "";
-  if (parse != str) {
-    let a = parse.split("~");
-    let n = a[0].trim();
-    if (!!n) {
-      mod = a[2];
-      return {
-        "text": gspan(str),
-        "action": {
-          "type": "skill",
-          "name": n + a[1],
-          "mod": mod,
-          "desc": a[3]
-        }
-      }
-    }
-  }
 
   // for PDF link
   parse = str.replace(/^PDF: */g, "");
@@ -166,6 +146,29 @@ export default function parselink(str, actor, htmldesc, clrdmods = false) {
       }
     }
   }
+
+  // Look for S:skill*+/-N test
+	// Need to do this test last, since just about anything can count as a "skill" check
+  parse = str.replace(/^S:([\w ]*)(\*?)([-+]\d+)? ?(.*)/g, "$1~$2~$3~$4");
+  let skill = null;
+  let mod = "";
+  if (parse != str) {
+    let a = parse.split("~");
+    let n = a[0].trim();
+    if (!!n) {
+      mod = a[2];
+      return {
+        "text": gspan(str.substr(2)),
+        "action": {
+          "type": "skill",
+          "name": n + a[1],
+          "mod": mod,
+          "desc": a[3]
+        }
+      }
+    }
+  }
+
 
   return { "text": str };
 }

--- a/lib/parselink.js
+++ b/lib/parselink.js
@@ -15,7 +15,7 @@
   	
   "modifier", "attribute", "selfcontrol", "damage", "roll", "skill", "pdf"
 */
-export default function parselink(str, actor, htmldesc, clrdmods = false) {
+export default function parselink(str, actor, htmldesc, clrdmods = false, checkActor = false) {
   if (str.length < 2)
     return { "text": str };
 
@@ -147,25 +147,50 @@ export default function parselink(str, actor, htmldesc, clrdmods = false) {
     }
   }
 
-  // Look for S:skill*+/-N test
-	// Need to do this test last, since just about anything can count as a "skill" check
-  parse = str.replace(/^S:([\w ]*)(\*?)([-+]\d+)? ?(.*)/g, "$1~$2~$3~$4");
-  let skill = null;
-  let mod = "";
+  // Look for S:skill*+/-N text   (now also works for spells)
+	if (checkActor)
+	  parse = str.replace(/^([\w ]*)(\*?)([-+]\d+)? ?(.*)/g, "$1~$2~$3~$4");
+	else
+	  parse = str.replace(/^S:([\w ]*)(\*?)([-+]\d+)? ?(.*)/g, "$1~$2~$3~$4");
   if (parse != str) {
     let a = parse.split("~");
     let n = a[0].trim();
     if (!!n) {
-      mod = a[2];
-      return {
-        "text": gspan(str.substr(2)),
-        "action": {
-          "type": "skill",
-          "name": n + a[1],
-          "mod": mod,
-          "desc": a[3]
+			n = n + a[1];
+			if (!checkActor || GURPS.findSkillSpell(actor, n)) {
+	      return {
+	        "text": (gspan(n) + (!!a[3] ? " " + a[3]: "")),
+	        "action": {
+	          "type": "skill-spell",
+	          "name": n,
+	          "mod": a[2],
+	          "desc": a[3]
+					}
         }
       }
+    }
+  }
+
+	if (checkActor)
+	  parse = str.replace(/^([\w ]*)(\*?)([-+]\d+)? ?(.*)/g, "$1~$2~$3~$4");
+	else
+	  parse = str.replace(/^A:([\w ]*)(\*?)([-+]\d+)? ?(.*)/g, "$1~$2~$3~$4");
+  if (parse != str) {
+    let a = parse.split("~");
+    let n = a[0].trim();
+    if (!!n) {
+			n = n + a[1];
+			if (!checkActor || GURPS.findAttack(actor, n)) {
+	      return {
+	        "text": (gspan(n) + (!!a[3] ? " " + a[3]: "")),
+	        "action": {
+	          "type": "attack",
+	          "name": n,
+	          "mod": a[2],
+	          "desc": a[3]
+	        }
+	      }
+			}
     }
   }
 

--- a/lib/parselink.js
+++ b/lib/parselink.js
@@ -15,7 +15,7 @@
   	
   "modifier", "attribute", "selfcontrol", "damage", "roll", "skill", "pdf"
 */
-export default function parselink(str, actor, htmldesc, clrdmods = false, checkActor = false) {
+export default function parselink(str, htmldesc, clrdmods = false, knowntype) {
   if (str.length < 2)
     return { "text": str };
 
@@ -147,50 +147,66 @@ export default function parselink(str, actor, htmldesc, clrdmods = false, checkA
     }
   }
 
-  // Look for S:skill*+/-N text   (now also works for spells)
-	if (checkActor)
-	  parse = str.replace(/^([\w ]*)(\*?)([-+]\d+)? ?(.*)/g, "$1~$2~$3~$4");
-	else
-	  parse = str.replace(/^S:([\w ]*)(\*?)([-+]\d+)? ?(.*)/g, "$1~$2~$3~$4");
-  if (parse != str) {
+
+	// Simple, no-spaces, no quotes skill/spell name (with optional *)
+	parse = str.replace(/^S:([^ "+-]+\*?)([-+]\d+)? ?(.*)/g, "$1~$2~$3");
+  if (parse == str) {
+		// Use quotes to capture skill/spell name (with as many * as they want to embed)
+		parse = str.replace(/^S:"([^"]+)"([-+]\d+)? ?(.*)/g, "$1~$2~$3");
+	}
+	if (parse != str) {
     let a = parse.split("~");
-    let n = a[0].trim();
+    let n = a[0].trim();				// semi-regex pattern of skill/spell name (minus quotes)
     if (!!n) {
-			n = n + a[1];
-			if (!checkActor || GURPS.findSkillSpell(actor, n)) {
-	      return {
-	        "text": (gspan(n) + (!!a[3] ? " " + a[3]: "")),
-	        "action": {
-	          "type": "skill-spell",
-	          "name": n,
-	          "mod": a[2],
-	          "desc": a[3]
-					}
-        }
+			let spantext = n;					// What we show in the highlighted span (yellow)
+			let moddesc = "";
+			let comment = a[2];
+			if (!!a[1]) {							// If there is a +-mod, then the comment is the desc of the modifier
+					spantext += a[1] + " " + a[2];
+					moddesc = a[2];
+					comment = "";
+			}
+			let action = {
+          "type": "skill-spell",
+          "name": n,
+          "mod": a[1],
+          "desc": moddesc
+				};
+      return {
+        "text": gspan(spantext, "<b>S:</b>", btoa(JSON.stringify(action)), comment),
+        "action": action
       }
     }
   }
 
-	if (checkActor)
-	  parse = str.replace(/^([\w ]*)(\*?)([-+]\d+)? ?(.*)/g, "$1~$2~$3~$4");
-	else
-	  parse = str.replace(/^A:([\w ]*)(\*?)([-+]\d+)? ?(.*)/g, "$1~$2~$3~$4");
-  if (parse != str) {
+	// Simple, no-spaces, no quotes melee/ranged name (with optional *s)
+	parse = str.replace(/^A:([^ "+-]+\*?)([-+]\d+)? ?(.*)/g, "$1~$2~$3");
+  if (parse == str) {
+		// Use quotes to capture skill/spell name (with optional *s)
+		parse = str.replace(/^A:"([^"]+)"([-+]\d+)? ?(.*)/g, "$1~$2~$3");
+	}
+	if (parse != str) {
     let a = parse.split("~");
-    let n = a[0].trim();
+    let n = a[0].trim();				// semi-regex pattern of skill/spell name (minus quotes)
     if (!!n) {
-			n = n + a[1];
-			if (!checkActor || GURPS.findAttack(actor, n)) {
-	      return {
-	        "text": (gspan(n) + (!!a[3] ? " " + a[3]: "")),
-	        "action": {
-	          "type": "attack",
-	          "name": n,
-	          "mod": a[2],
-	          "desc": a[3]
-	        }
-	      }
+			let spantext = n;					// What we show in the highlighted span (yellow)
+			let moddesc = "";
+			let comment = a[2];
+			if (!!a[1]) {							// If there is a +-mod, then the comment is the desc of the modifier
+					spantext += a[1] + " " + a[2];
+					moddesc = a[2];
+					comment = "";
 			}
+			let action = {
+          "type": "attack",
+          "name": n,
+          "mod": a[1],
+          "desc": moddesc
+				};
+      return {
+        "text": gspan(spantext, "<b>A:</b>", btoa(JSON.stringify(action)), comment),
+        "action": action
+      }
     }
   }
 
@@ -209,6 +225,12 @@ function gmspan(str, plus, clrdmods) {
   return "<span class='glinkmod'>" + str + "</span>";
 }
 
-function gspan(str) {
-  return "<span class='gurpslink'>" + str + "</span>";
+function gspan(str, prefix, action, comment) {
+	let s = !!prefix ? prefix : "";
+  s += "<span class='gurpslink'";
+	if (!!action) s += " data-action='" + action + "'";
+	s += ">" + str.trim() + "</span>";
+	if (!!comment)
+		s += " " + comment;
+	return s;
 }

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -72,6 +72,7 @@ export class GurpsActorSheet extends ActorSheet {
     html.find(".glinkmodminus").click(this._onClickGmod.bind(this));
   }
 
+
   /* -------------------------------------------- */
 
   /** @override */
@@ -608,7 +609,7 @@ export class GurpsActorSimplifiedSheet extends GurpsActorSheet {
 		ev.preventDefault();
 		let element = ev.currentTarget;
 		let val = element.dataset.value;
-		let parsed = parselink(val, this.actor);
+		let parsed = parselink(val);
 		GURPS.performAction(parsed.action, this.actor);
 	}
 }

--- a/module/actor.js
+++ b/module/actor.js
@@ -26,7 +26,10 @@ export class GurpsActor extends Actor {
 		x = xmlTextToJson(x);
 		let r = x.root;
 		if (!r) {
-			ui.notifications.warn("No <root> object found.  Are you importing the correct GCS XML file?");
+			if (xml[0] == "{" && importname.endsWith(".gcs"))
+				ui.notifications.error("We cannot import a GCS file directly.   You must export the file using the Foundry VTT output template.");
+			else
+				ui.notifications.error("No <root> object found.  Are you importing the correct XML file?");
 			return;
 		}
 

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -866,6 +866,13 @@ function chatClickGmod(event) {
 }
 GURPS.chatClickGmod = chatClickGmod;
 
+function chatClickPdf(event) {
+  event.preventDefault();
+  game.GURPS.onPdf(event);
+}
+GURPS.chatClickPdf = chatClickPdf;
+
+
 GURPS.rangeObject = new GURPSRange()
 GURPS.initiative = new Initiative()
 GURPS.hitpoints = new HitFatPoints()
@@ -938,6 +945,15 @@ Hooks.once("init", async function () {
 		let actor = root?.data?.root?.actor;
 		if (!actor) actor = root?.actor;
 		return game.GURPS.gurpslink(str, actor, clrdmods, inclbrks);
+	});
+
+
+	/// NOTE:  To use this, you must use {{{gurpslinkbr sometext}}}.   The triple {{{}}} keeps it from interpreting the HTML
+	// Same as gurpslink, but converts \n to <br> for large text values (notes)
+	Handlebars.registerHelper('gurpslinkbr', function (str, root, clrdmods = false, inclbrks = false) {
+		let actor = root?.data?.root?.actor;
+		if (!actor) actor = root?.actor;
+		return game.GURPS.gurpslink(str, actor, clrdmods, inclbrks).replace(/\n/g, "<br>");;
 	});
 
 
@@ -1035,8 +1051,8 @@ Hooks.once("ready", async function () {
 		//console.log("PRE CHAT:");
 		//console.log(c);
 		data.content = game.GURPS.gurpslink(c, game.GURPS.LastActor?.data);
-		//console.log("AFTER:");
-		//console.log(data.content);
+		console.log("AFTER:");
+		console.log(data.content);
 	});
 	
 	Hooks.on('renderChatMessage', (app, html, msg) => {
@@ -1045,6 +1061,7 @@ Hooks.once("ready", async function () {
 	  html.find(".glinkmod").click(GURPS.chatClickGmod.bind(this));
 	  html.find(".glinkmodplus").click(GURPS.chatClickGmod.bind(this));
 	  html.find(".glinkmodminus").click(GURPS.chatClickGmod.bind(this));
+    html.find(".pdflink").click(GURPS.chatClickPdf.bind(this));
 		});
 
 });

--- a/templates/actor-sheet-gcs.html
+++ b/templates/actor-sheet-gcs.html
@@ -324,7 +324,7 @@
             {{#each data.ads}}
             <div class="desc indent0 satisfiedY">{{{gurpslink this.name}}}
                 <div class="list_note satisfiedY"></div>
-                <div class="list_note satisfiedY">{{{gurpslink this.notes}}}</div>
+                <div class="list_note satisfiedY">{{{gurpslinkbr this.notes}}}</div>
             </div>
             <div class="pts satisfiedY">{{this.points}}</div>
             <div class="ref satisfiedY pdflink">{{this.pageref}}</div>
@@ -332,7 +332,7 @@
             {{#each data.powers}}
             <div class="desc indent0 satisfiedY">{{{gurpslink this.name}}}
                 <div class="list_note satisfiedY"></div>
-                <div class="list_note satisfiedY">{{{gurpslink this.notes}}}</div>
+                <div class="list_note satisfiedY">{{{gurpslinkbr this.notes}}}</div>
             </div>
             <div class="pts satisfiedY">{{this.points}}</div>
             <div class="ref satisfiedY pdflink">{{this.pageref}}</div>
@@ -340,7 +340,7 @@
             {{#each data.disads}}
             <div class="desc indent0 satisfiedY">{{{gurpslink this.name}}}
                 <div class="list_note satisfiedY"></div>
-                <div class="list_note satisfiedY">{{{gurpslink this.notes}}}</div>
+                <div class="list_note satisfiedY">{{{gurpslinkbr this.notes}}}</div>
             </div>
             <div class="pts satisfiedY">{{this.points}}</div>
             <div class="ref satisfiedY pdflink">{{this.pageref}}</div>
@@ -348,7 +348,7 @@
             {{#each data.others}}
             <div class="desc indent0 satisfiedY">{{{gurpslink this.name}}}
                 <div class="list_note satisfiedY"></div>
-                <div class="list_note satisfiedY">{{{gurpslink this.notes}}}</div>
+                <div class="list_note satisfiedY">{{{gurpslinkbr this.notes}}}</div>
             </div>
             <div class="pts satisfiedY">{{this.points}}</div>
             <div class="ref satisfiedY pdflink">{{this.pageref}}</div>
@@ -460,7 +460,7 @@
         <div id="notes">
             <div class="desc header">Notes</div>
             {{#each data.notes}}
-            <div class="desc indent0">{{{gurpslink this.notes}}}</div>
+            <div class="desc indent0">{{{gurpslinkbr this.notes}}}</div>
             {{/each}}
         </div>
     </div>

--- a/templates/simplified.html
+++ b/templates/simplified.html
@@ -72,12 +72,12 @@
 		<label>Things That Describe Me</label>
     {{#each data.ads}}
     <div>{{{gurpslink this.name}}}
-         <div>{{{gurpslink this.notes}}}</div>
+         <div>{{{gurpslinkbr this.notes}}}</div>
     </div>
     {{/each}}
     {{#each data.disads}}
     <div>{{{gurpslink this.name}}}
-       <div>{{{gurpslink this.notes}}}</div>
+       <div>{{{gurpslinkbr this.notes}}}</div>
     </div>
     {{/each}}
 	</div>
@@ -85,7 +85,7 @@
   <div class="simple_Notes">
     <label>Notes</label>
     {{#each data.notes}}
-      <div>{{{gurpslink this.notes}}}</div>
+      <div>{{{gurpslinkbr this.notes}}}</div>
     {{/each}}
   </div>
 </div>


### PR DESCRIPTION
To be able to support more On-the-Fly formulas, I had to enforce some encoding.  We can now support skills/spells/attacks (melee/ranged) formulas.
To indicate a skill (or spell), the user must start the block with "S:", ex:  [S:Brawling]
Skills are searched first, and then spells.
This form works so long as there are no spaces.   To try to match a skill/spell with spaces, they must use:  [S:"First Aid"]
There is now an implicit "*" at the end of the string, so the user doesn't need to type the full name:  [S:"First Aid/TL3"]
Also, the user can type in as many '*' as they want, and if there are no spaces, no quotes are needed: [S:First*Aid]
A modifier (and description) can be added to the end:  [S:First*Aid+1 due to medical kit] or [S:"First Aid"+1 due to kit].
No spaces are allowed before the modifier.  So [S:Brawling +1] is parsed as [S:Brawling] and the " +1" is just displayed as text and not included in the roll.
All of the above is true for attacks.   [A:"2 Handed Axe"].    The "usage" is included in the match, so if the character has 2 attacks with a weapon:
Large Knife (Swung)  14,  1d-1 cut
Large Knife (Thrust)  14, 1d-1 imp
The OtF formula [A:"Large Knife"] will find the first usage (Swung).   [A:Large*Thr] will find the second usage.  Melee attacks are searched first, then ranged.
