### PR TITLE
hide or show advanced apply damage options based on a system setting.

### DIFF
--- a/lib/applydamage.js
+++ b/lib/applydamage.js
@@ -2,6 +2,7 @@
 
 import { isNiceDiceEnabled } from '../lib/utilities.js'
 import { GURPS } from '../module/gurps.js'
+import * as settings from '../lib/miscellaneous-settings.js'
 
 
 /*   Tactical Combat */
@@ -78,6 +79,8 @@ export default class ApplyDamageDialog extends Application {
 
     this.actor = actor
     this.damageData = damageData
+    this.isSimpleDialog = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_SIMPLE_DAMAGE)
+
     this._processRandomHitLocation = this._processRandomHitLocation.bind(this)
 
     // the current value of the "Enter DR:" text field
@@ -173,7 +176,7 @@ export default class ApplyDamageDialog extends Application {
       resizable: true,
       minimizable: false,
       width: 800,
-      height: 800,
+      // height: 725,
       title: 'Apply Damage'
     });
   }
@@ -210,6 +213,16 @@ export default class ApplyDamageDialog extends Application {
 
     const digitsOnly = /^\d*$/
     const digitsAndDecimalOnly = /^\d*\.?\d*$/
+
+    let content = $('#apply-damage-dialog')[0]
+    if (this.isSimpleDialog) {
+      html.find('#apply-damage-advanced').addClass('invisible')
+      $('#apply-damage-dialog').css({ 'height': '125', 'width': '800' })
+    }
+    else {
+      html.find('#apply-damage-advanced').removeClass('invisible')
+      $('#apply-damage-dialog').css({ 'height': '725', 'width': '800' })
+    }
 
     // ==== Directly Apply ====
     // Restrict the damage text to digits only.

--- a/lib/miscellaneous-settings.js
+++ b/lib/miscellaneous-settings.js
@@ -1,7 +1,8 @@
 'use strict'
 
-const SYSTEM_NAME = 'gurps'
-const SETTING_DEFAULT_LOCATION = 'default-hitlocation'
+export const SYSTEM_NAME = 'gurps'
+export const SETTING_DEFAULT_LOCATION = 'default-hitlocation'
+export const SETTING_SIMPLE_DAMAGE = 'simple-damage'
 
 export default function () {
   Hooks.once('init', async function () {
@@ -19,5 +20,16 @@ export default function () {
       default: 'Torso',
       onChange: value => console.log(`Default hit location: ${value}`)
     })
+
+    game.settings.register(SYSTEM_NAME, SETTING_SIMPLE_DAMAGE, {
+      name: 'Use simple Apply Damage dialog:',
+      hint: 'If true, only display the "Directly Apply" option in the Apply Damage dialog',
+      scope: 'world',
+      config: true,
+      type: Boolean,
+      default: false,
+      onChange: value => console.log(`Use simply Apply Damage dialog : ${value}`)
+    })
+
   })
 }

--- a/system.json
+++ b/system.json
@@ -10,15 +10,8 @@
   "esmodules": [
     "module/gurps.js",
     "lib/SSRT/main.js",
-    "lib/ranges.js",
-    "lib/initiative.js",
-    "lib/hitpoints.js",
-    "lib/hitlocationtooltip.js",
-    "lib/utilities.js",
     "lib/parselink.js",
-    "lib/damagemessage.js",
-    "lib/moustachewax.js",
-    "lib/testdialog.js"
+    "lib/applydamage.js"
   ],
   "styles": [
     "styles/simple.css",

--- a/templates/damage/apply-damage-dialog.html
+++ b/templates/damage/apply-damage-dialog.html
@@ -15,7 +15,7 @@
       <button id='apply-secretly'>Apply (Quietly)</button>
     </div>
 
-    <div class='flex-group-center' style='margin-top: 1em;'>
+    <div id='apply-damage-advanced' class='flex-group-center' style='margin-top: 1em;'>
       <h3>Apply damage options:</h3>
 
       <div class='grid grid-3col flex-between'>


### PR DESCRIPTION
Another quick update -- use a system setting to show or hide the advanced options on the Apply Damage Dialog.