### PR TITLE
Implemented damage multipliers and armore divisors

### DIFF
--- a/lib/damagemessage.js
+++ b/lib/damagemessage.js
@@ -23,6 +23,19 @@ export default class DamageChat {
   }
 
   async create(actor, diceText, damageType, overrideDiceText) {
+    // Handle multipliers on the damage dice:
+    // The diceText will be of the form, "<dice>d<adds>x<multiplier>".
+    // Be very permissive and accept 'x', 'X', '*', and '×' (multiplication symbol).
+    let multiplier = 1;
+    let regex = /^\S+([x×\*X]\d+)$/
+
+    if (diceText.match(regex)) {
+      let result = regex.exec(diceText)
+      console.log(result[1])
+      multiplier = parseInt(result[1].slice(1))
+      diceText = diceText.replace(result[1], '') // remove multipler from diceText
+    }
+
     let formula = d6ify(diceText)
 
     let targetmods = await GURPS.ModifierBucket.applyMods([])		// append any global mods
@@ -41,6 +54,17 @@ export default class DamageChat {
     let min = 1
     let b378 = false
 
+    // damageType may have an armor divisor on it -- check for that and parse out.
+    // armor divisors are decimal numbers in parentheses: (2), (5), (0.2), (0.5)
+    let divisor = 0
+    let divisorRegex = /^(\((\d+(?:.\d+)?)\)) \S+$/
+    if (damageType.match(divisorRegex)) {
+      let result = divisorRegex.exec(damageType)
+      console.log(result[1])
+      divisor = parseFloat(result[2])
+      damageType = damageType.replace(result[1], '').trim()
+    }
+
     if (damageType === 'cr') min = 0
 
     if (formula.slice(-1) === '!') {
@@ -56,10 +80,16 @@ export default class DamageChat {
       if (damageType !== 'cr') b378 = true
     }
 
+    rtotal = rtotal * multiplier
+
+    if (multiplier > 1) diceText = `${diceText}×${multiplier}`
+    if (divisor > 0) diceText = `${diceText} (${divisor})`
+
     let contentData = {
-      dice: overrideDiceText || diceText,		// overrideDicxeText used when actual formula isn't "pretty" SW+2 vs 1d6+1+2
+      dice: overrideDiceText || diceText,		// overrideDiceText used when actual formula isn't "pretty" SW+2 vs 1d6+1+2
       damage: rtotal,
       damageType: damageType,
+      divisor: divisor,
       modifiers: targetmods.map(it => `${it.mod} ${it.desc.replace(/^dmg/, 'damage')}`),
       isB378: b378,
       attacker: actor._id


### PR DESCRIPTION
Now accepts damage rolls with multipliers. Multiplier symbol can be 'x', 'X', '*', or '×'. Examples: '3dx5', '2d-1*3', '5dX3', '3d+1×2'.

Also accepts armor divisors in damage rolls: '3d (2) cut', '2d-1 (0.5) pi--', or '4dx4 (5) imp'.