### PR TITLE
implemented wounding modifiers by hit location

### DIFF
--- a/lib/applydamage.js
+++ b/lib/applydamage.js
@@ -30,42 +30,48 @@ let tacticalOptions = [
   {
     id: 'blunttrauma',
     apply: true,
-    label: 'Apply blunt trauma',
+    label: 'Blunt Trauma',
     ref: 'B379'
   },
   {
     id: 'armordivisor',
     apply: true,
-    label: 'Apply armor divisor',
+    label: 'Armor Divisor',
     ref: 'B378'
   },
   {
-    id: 'range12D',
-    apply: false,
-    label: 'Ranged, Half Damage (1/2D)',
-    ref: 'B378'
+    id: 'perlocationmodifier',
+    apply: true,
+    label: 'Hit Location Wounding Modifiers',
+    ref: 'B398'
   }
 ]
 
 let otherSituations = [
   {
-    id: 'unliving',
+    id: 'range12D',
     apply: false,
-    label: 'Unliving',
-    ref: 'B380'
+    label: 'Ranged, Half Damage (1/2D)',
+    ref: 'B378'
   },
-  {
-    id: 'homogenous',
-    apply: false,
-    label: 'Homogenous',
-    ref: 'B380'
-  },
-  {
-    id: 'diffuse',
-    apply: false,
-    label: 'Diffuse',
-    ref: 'B380'
-  },
+  // {
+  //   id: 'unliving',
+  //   apply: false,
+  //   label: 'Unliving',
+  //   ref: 'B380'
+  // },
+  // {
+  //   id: 'homogenous',
+  //   apply: false,
+  //   label: 'Homogenous',
+  //   ref: 'B380'
+  // },
+  // {
+  //   id: 'diffuse',
+  //   apply: false,
+  //   label: 'Diffuse',
+  //   ref: 'B380'
+  // },
 ]
 
 
@@ -100,13 +106,13 @@ export default class ApplyDamageDialog extends Application {
     this.onClickPdf = this.onClickPdf.bind(this)
     this.updateUI = this.updateUI.bind(this)
 
-    this.isSimpleDialog = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_SIMPLE_DAMAGE)
-    this.isBluntTrauma = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_BLUNT_TRAUMA)
-
     // NOTE: my convention is to use underscore instance variables when
     // the rest of the code in the object should not access those variables
     // directly. Instead, use the provided accessors.
 
+    this.isSimpleDialog = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_SIMPLE_DAMAGE)
+    this.isBluntTrauma = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_BLUNT_TRAUMA)
+    this.isLocationModifiers = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_LOCATION_MODIFIERS)
     this._isApplyDivisor = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_APPLY_DIVISOR)
 
     // current Basic damage value
@@ -135,6 +141,9 @@ export default class ApplyDamageDialog extends Application {
 
     // the currently selected wound modifier (multiplier)
     this.selectedMod = 1
+
+    // if true, wound modifier is adjusted for hit location
+    this.isAdjustedForHitLocation = false
 
     // the current value of the 'Enter Modifier:' field
     this.userEnteredMod = 1
@@ -311,6 +320,48 @@ export default class ApplyDamageDialog extends Application {
   getCurrentWoundingModifier(type) {
     if (type === 'none') return 1
     if (type === 'User Entered') return this.userEnteredMod
+
+    if (this.isLocationModifiers) {
+      this.isAdjustedForHitLocation = true
+      switch (this.location) {
+        case 'Vitals':
+          if (['imp', 'pi-', 'pi', 'pi+', 'pi++'].includes(this.damageType))
+            return 3;
+          // TODO if (this.isTightBeamAttack() && this.damageType === 'burn') 
+          //   return 2;
+          break;
+
+        case 'Skull':
+        case 'Eye':
+          if (this.damageType !== 'tox')
+            return 4;
+          break;
+
+        case 'Face':
+          if (this.damageType === 'cor')
+            return 1.5;
+          break;
+
+        case 'Neck':
+          if (['cr', 'cor'].includes(this.damageType))
+            return 1.5;
+          if (this.damageType === 'cut')
+            return 2;
+          break;
+
+        case 'Right Arm':
+        case 'Left Arm':
+        case 'Right Leg':
+        case 'Left Leg':
+        case 'Hand':
+        case 'Foot':
+          if (['imp', 'pi+', 'pi++'].includes(this.damageType))
+            return 1;
+          break;
+
+      }
+    }
+    this.isAdjustedForHitLocation = false
     return GURPS.woundModifiers[type].multiplier
   }
 
@@ -401,7 +452,12 @@ export default class ApplyDamageDialog extends Application {
       self.updateUI(html)
     })
 
-    html.find('#tactical-range12D').click(function (ev) {
+    html.find('#tactical-perlocationmodifier').click(function (ev) {
+      self.isLocationModifiers = $(this).is(':checked')
+      self.updateUI(html)
+    })
+
+    html.find('#specials-range12D').click(function (ev) {
       self.isHalfDamage = $(this).is(':checked')
       self.updateUI(html)
     })
@@ -482,10 +538,18 @@ export default class ApplyDamageDialog extends Application {
     html.find('#tactical-armordivisor').prop('checked', this.isApplyDivisor)
     html.find('#tactical-blunttrauma').prop('checked', this.isBluntTrauma)
 
+    let adjust = this.isAdjustedForHitLocation ? '*' : ''
+    html.find('[name="adjusted"]').text(adjust)
+
     if (this.additionalMods > 0)
       html.find('[name="result-type-add"]').removeClass('invisible')
     else
       html.find('[name="result-type-add"]').addClass('invisible')
+
+    if (this.isAdjustedForHitLocation)
+      html.find('#modifier-footnote-wrapper').removeClass('invisible')
+    else
+      html.find('#modifier-footnote-wrapper').addClass('invisible')
 
     // Always remove (clear) the results of half-damage; if necessary they 
     // will be re-added with potentiatlly new values
@@ -514,43 +578,47 @@ export default class ApplyDamageDialog extends Application {
     if (this.isBluntTrauma) {
       // add the Flexible Armor checkbox/textfield combo
       let insertPoint = html.find('#result-extrastuff')
-      let classText = !!this.bluntTrauma ? 'user-entered' : ''
-
-      insertPoint.append(
-        $(`<input id='flexible-armor' name='flexible-armor' type='checkbox' value='flexible-armor'>`),
-        $(`<label name='flexible-armor' for='flexible-armor'>Flexible Armor, Blunt Trauma:</label>`),
-        $(`<div id='blunt-trauma-field' name='flexible-armor' class='with-button'><input id='blunt-trauma' class='${classText}' value='${this.effectiveBluntTrauma}' type='number' ${this.isFlexibleArmor ? '' : 'disabled'}><button name='clear'><span class='fas fa-times-circle'></button></div>`)
-      )
-
-      let self = this
-
-      html.find('#blunt-trauma-field button').click(function () {
-        self.bluntTrauma = null
-        self.updateUI(html)
-      })
-
-      // configure the textfield
-      let textInput = html.find('#blunt-trauma')
-      // restrict entry to digits only
-      textInput.inputFilter(value => digitsOnly.test(value))
-      // on change, update blunt trauma
-      textInput.on('change', function () {
-        let currentValue = $(this).val()
-        self.bluntTrauma = (currentValue === '' || currentValue === self.calculatedBluntTrauma)
-          ? null
-          : parseFloat(currentValue)
-        self.updateUI(html)
-      })
-      textInput.click(ev => ev.preventDefault())
-
-      // configure checkbox
-      let checkbox = html.find('#flexible-armor')
-      checkbox.prop('checked', this.isFlexibleArmor)
-      checkbox.click(function (ev) {
-        self.isFlexibleArmor = $(this).is(':checked')
-        self.updateUI(html)
-      })
+      this.insertBluntTrauma(html, insertPoint)
     }
+  }
+
+  insertBluntTrauma(html, insertPoint) {
+    let classText = !!this.bluntTrauma ? 'user-entered' : ''
+
+    insertPoint.append(
+      $(`<input id='flexible-armor' name='flexible-armor' type='checkbox' value='flexible-armor'>`),
+      $(`<label name='flexible-armor' for='flexible-armor'>Flexible Armor, Blunt Trauma:</label>`),
+      $(`<div id='blunt-trauma-field' name='flexible-armor' class='with-button'><input id='blunt-trauma' class='${classText}' value='${this.effectiveBluntTrauma}' type='number' ${this.isFlexibleArmor ? '' : 'disabled'}><button name='clear'><span class='fas fa-times-circle'></button></div>`)
+    )
+
+    let self = this
+
+    html.find('#blunt-trauma-field button').click(function () {
+      self.bluntTrauma = null
+      self.updateUI(html)
+    })
+
+    // configure the textfield
+    let textInput = html.find('#blunt-trauma')
+    // restrict entry to digits only
+    textInput.inputFilter(value => digitsOnly.test(value))
+    // on change, update blunt trauma
+    textInput.on('change', function () {
+      let currentValue = $(this).val()
+      self.bluntTrauma = (currentValue === '' || currentValue === self.calculatedBluntTrauma)
+        ? null
+        : parseFloat(currentValue)
+      self.updateUI(html)
+    })
+    textInput.click(ev => ev.preventDefault())
+
+    // configure checkbox
+    let checkbox = html.find('#flexible-armor')
+    checkbox.prop('checked', this.isFlexibleArmor)
+    checkbox.click(function (ev) {
+      self.isFlexibleArmor = $(this).is(':checked')
+      self.updateUI(html)
+    })
   }
 
   insertArmorDivisor(html, element) {

--- a/lib/miscellaneous-settings.js
+++ b/lib/miscellaneous-settings.js
@@ -5,6 +5,7 @@ export const SETTING_DEFAULT_LOCATION = 'default-hitlocation'
 export const SETTING_SIMPLE_DAMAGE = 'combat-simple-damage'
 export const SETTING_APPLY_DIVISOR = 'combat-apply-divisor'
 export const SETTING_BLUNT_TRAUMA = 'combat-blunt-trauma'
+export const SETTING_LOCATION_MODIFIERS = 'combat-location-modifiers'
 
 export default function () {
   Hooks.once('init', async function () {
@@ -51,6 +52,16 @@ export default function () {
       type: Boolean,
       default: true,
       onChange: value => console.log(`Apply Blunt Trauma : ${value}`)
+    })
+
+    game.settings.register(SYSTEM_NAME, SETTING_LOCATION_MODIFIERS, {
+      name: 'Use Hit Location Wounding Modifiers:',
+      hint: 'If true, modify Wounding Modifiers based on Hit Location.',
+      scope: 'world',
+      config: true,
+      type: Boolean,
+      default: true,
+      onChange: value => console.log(`Apply Location Modifiers : ${value}`)
     })
   })
 }

--- a/lib/moustachewax.js
+++ b/lib/moustachewax.js
@@ -53,5 +53,15 @@ export default function () {
   Handlebars.registerHelper('isOdd', function (value) {
     return value % 2 !== 0
   })
+
+  /*
+   * if value is equal to compareTo, return _default; otherwise return the
+   * format string replacing '*' with value.
+   */
+  Handlebars.registerHelper('printIfNe', function (value, compareTo, format, _default = '') {
+    if (value === compareTo) return _default
+    let result = format.replace('*', value)
+    return result
+  })
 }
 

--- a/styles/simple.css
+++ b/styles/simple.css
@@ -2355,6 +2355,7 @@ body {
 /* Apply Damage Dialog: Results Table panel */
 .gurps-group .results-table {
   justify-self: stretch;
+  width: 100%;
   grid-template-columns: min-content min-content 1fr;
   min-height: 130px;
 }

--- a/templates/damage/apply-damage-dialog.html
+++ b/templates/damage/apply-damage-dialog.html
@@ -1,6 +1,7 @@
 <div class='gurps-app {{classes}}' {{debug}}>
   <div classes='flexcol flex-between'>
-    <h2>Apply {{basicDamage}} points of ({{armorDivisor}}) {{damageType}} damage to {{actor.data.name}}</h2>
+    <h2>Apply {{basicDamage}} points of {{printIfNe armorDivisor 0 '(*)' ' '}}{{damageType}} damage to
+      {{actor.data.name}}</h2>
     <div class='flexrow flex-group-center flex-between'>
       <h3>DIRECTLY APPLY:</h3>
       <input type='number' id='damage' name='damage' value='{{basicDamage}}'>
@@ -83,7 +84,7 @@
           <h4>Other Situations</h4>
           <div class='gurps-3col gurps-checkbox-col'>
             {{#each otherSituations}}
-            <div><input disabled id='specials-{{this.id}}' type='checkbox' name='specials' value='{{this.id}}'></input>
+            <div><input id='specials-{{this.id}}' type='checkbox' name='specials' value='{{this.id}}'></input>
             </div>
             <div><label for='specials-{{this.id}}'>{{this.label}}</label></div>
             <div class='pdflink'>{{this.ref}}</div>
@@ -116,6 +117,7 @@
         </div>
       </div>
     </div>
+
     <div>
       <div class='gurps-group'>
         <h4>Results</h4>
@@ -143,7 +145,8 @@
             <div><span>(×<span name='result-modifier'>{{selectedMod}}</span> <span
                   name='result-type'>{{damageType}}</span><span name='result-type-add'> + <span
                     name='result-addmods'>{{additionalMods}}</span>
-                </span>)
+                </span>)<span id='modifier-footnote-wrapper'>* <span id="modifier-footnote"
+                    class="pdflink">B398</span></span>
               </span>
             </div>
 


### PR DESCRIPTION
I did this in the same way as the special armor divisor rule (where a fractional divisor is applied to a location with DR 0 - treat the DR as 1 and then apply the divisor). In that case I added an '*' to the result table and a reference to the rule.

In this case I did the same thing -- if the hit location changes the divisor, it adds a '*' to the result table and a reference.

What I really want to do is to, if the setting is turned on and the hit location is one that applies a non-default modifier, is to actually change the modifier in the table of radio buttons for Wounding Modifiers. Maybe later.