### PR TITLE
Bunch-o-stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### Users Guide for [GURPS 4e game aid for Foundry VTT](https://docs.google.com/document/d/1NMBPt9KhA9aGG1_kZxyk8ncuOKhz9Z6o7vPS8JcjdWc/edit?usp=sharing)
+### Users Guide for [GURPS 4e game aid for Foundry VTT](https://bit.ly/2JaSlQd)
 
 
 # Current Release Version 0.8.0
@@ -20,6 +20,7 @@ This is what we are currently working on:
     - Users Guide link in Foundry.   Type "/help" or "!help" in chat
     - Current Encumbrance can be set on main/combat sheet
     - Fixed Full/Combat sheet toggle
+    - Warn on FG import
 		
 
 ### History

--- a/lib/parselink.js
+++ b/lib/parselink.js
@@ -39,20 +39,28 @@ export default function parselink(str, htmldesc, clrdmods = false, knowntype) {
     }
   }
 
+	let blindroll = false;
+	if (str[0] === "!") {
+		blindroll = true;
+		str = str.substr(1);
+	}
+
   // Attributes "ST+2 desc, Per"
   let parse = str.replace(/^(\w+)([+-]\d+)?(.*)$/g, "$1~$2~$3")
   let a = parse.split("~");
   let path = GURPS.attributepaths[a[0]];
   if (!!path) {
-    return {
-      "text": gspan(str),
-      "action": {
+		let action = {
         "type": "attribute",
         "attribute": a[0],
         "path": path,
         "desc": a[2].trim(),		// Action description, not modifier desc
-        "mod": a[1]
-      }
+        "mod": a[1],
+				"blindroll" : blindroll
+      };
+    return {
+      "text": gspan(str, action),
+      "action": action
     }
   }
 
@@ -93,18 +101,21 @@ export default function parselink(str, htmldesc, clrdmods = false, knowntype) {
     }
   }
 
-  // Straight roll, no damage type. 4d, 2d-1, etc.   Allows "!" suffix to indicate minimum of 1.
-  parse = str.replace(/^(\d+)d([-+]\d+)?( \(\d+\) )?(!)? ?(.*)$/g, "$1~$2~$3~$4~$5")
+  // Straight roll 4d, 2d-1, etc.   Is "damage" if it includes a damage type.  Allows "!" suffix to indicate minimum of 1.
+  // Supports:  2d+1x3(5), 4dX2 (0.5), etc
+  parse = str.replace(/^(\d+)d([-+]\d+)?([xX\*]\d+)?( ?\([.\d]+\))?(!)? ?(.*)$/g, "$1~$2~$3~$4~$5~$6")
   if (parse != str) {
     let a = parse.split("~");
-    let d = a[4].trim();
+    let d = a[5].trim();
     let m = GURPS.woundModifiers[d];
-    if (!m) {		// Not one of the recognized damage types
+    if (!m) {		// Not one of the recognized damage types.   Ignore Armor divisor, but allow multiplier.  must convert to '*' for Foundry
+			let mult = a[2];
+			if (!!mult && "Xx".includes(mult[0])) mult = "*" + mult.substr(1);
       return {
         "text": gspan(str),
         "action": {
           "type": "roll",
-          "formula": a[0] + "d" + a[1] + a[2] + a[3],				// a[2] and a[3] should never happen together
+          "formula": a[0] + "d" + a[1] + mult + a[4],				
           "desc": d			// Action description
         }
       }
@@ -113,7 +124,7 @@ export default function parselink(str, htmldesc, clrdmods = false, knowntype) {
         "text": gspan(str),
         "action": {
           "type": "damage",
-          "formula": a[0] + "d" + a[1] + a[2] + a[3],				// a[2] and a[3] should never happen together
+          "formula": a[0] + "d" + a[1] + a[2] + a[3] +a[4],				
           "damagetype": d
         }
       }
@@ -179,10 +190,11 @@ export default function parselink(str, htmldesc, clrdmods = false, knowntype) {
           "type": "skill-spell",
           "name": n,
           "mod": a[1],
-          "desc": moddesc
-				};
+          "desc": moddesc,
+					"blindroll" : blindroll
+			};
       return {
-        "text": gspan(spantext, "<b>S:</b>", action, comment),
+        "text": gspan(spantext, action, "<b>S:</b>", comment),
         "action": action
       }
     }
@@ -210,10 +222,11 @@ export default function parselink(str, htmldesc, clrdmods = false, knowntype) {
           "type": "attack",
           "name": n,
           "mod": a[1],
-          "desc": moddesc
+          "desc": moddesc,
+					"blindroll" : blindroll
 				};
       return {
-        "text": gspan(spantext, "<b>A:</b>", action, comment),
+        "text": gspan(spantext, action, "<b>A:</b>", comment),
         "action": action
       }
     }
@@ -224,8 +237,9 @@ export default function parselink(str, htmldesc, clrdmods = false, knowntype) {
       "type": "dodge"
 		};
 		return {
-      "text": gspan(str, "", action),
-      "action": action			
+      "text": gspan(str, action),
+      "action": action,
+			"blindroll" : blindroll			
 		}
 	}
 
@@ -243,7 +257,7 @@ function gmspan(str, plus, clrdmods) {
   return "<span class='glinkmod'>" + str + "</span>";
 }
 
-function gspan(str, prefix, action, comment) {
+function gspan(str, action, prefix, comment) {
 	let s = !!prefix ? prefix : "";
   s += "<span class='gurpslink'";
 	if (!!action) s += " data-action='" + btoa(JSON.stringify(action)) + "'";

--- a/module/actor.js
+++ b/module/actor.js
@@ -43,6 +43,11 @@ export class GurpsActor extends Actor {
 		let ra = r["@attributes"];
 		const isFoundryGCS = (!!ra && ra.release == "Foundry" && ra.version == "1");
 		const isFoundryGCA = (!!ra && ra.release == "Foundry" && ra.version == "GCA");
+		if (!(isFoundryGCS || isFoundryGCA)) {
+			ui.notifications.error("We no longer support the Fantasy Ground import.   Please check the Users Guide (see Chat log).");
+			ChatMessage.create({ content: "<a href='" + GURPS.USER_GUIDE_URL + "'>GURPS 4e Game Aid USERS GUIDE</a>", user: game.user._id, type: CONST.CHAT_MESSAGE_TYPES.OTHER });
+			return;			
+		}
 
 		// The character object starts here
 		let c = r.character;

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -323,6 +323,8 @@ GURPS.SJGProductMappings = {
 	"VOR": "http://www.warehouse23.com/products/vorkosigan-saga-sourcebook-and-roleplaying-game"
 }
 
+GURPS.USER_GUIDE_URL = "https://bit.ly/2JaSlQd";
+
 
 // This is an ugly hack to clean up the "formatted text" output from GCS FG XML.
 // First we have to remove non-printing characters, and then we want to replace 
@@ -503,7 +505,7 @@ function performAction(action, actor) {
 		} else
 			ui.notifications.warn("You must have a character selected");
 
-	if (!!formula) doRoll(actor, formula, targetmods, prefix, thing, target, opt);
+	if (!!formula) doRoll(actor, formula, targetmods, prefix, thing, target, opt, action.blindroll);
 }
 GURPS.performAction = performAction;
 
@@ -604,7 +606,7 @@ GURPS.applyModifierDesc = applyModifierDesc;
 	unfortunately, it has a lot fo hard coded junk in it.
 	*/
 // formula="3d6", targetmods="[{ desc:"", mod:+-1 }]", thing="Roll vs 'thing'" or damagetype 'burn', target=skill level or -1=damage roll
-async function doRoll(actor, formula, targetmods, prefix, thing, origtarget, optlabel = "") {
+async function doRoll(actor, formula, targetmods, prefix, thing, origtarget, optlabel = "", blindroll = false) {
 
 	if (origtarget == 0) return;	// Target == 0, so no roll.  Target == -1 for non-targetted rolls (roll, damage)
 	let isTargeted = (origtarget > 0 && !!thing);		// Roll "against" something (true), or just a roll (false)
@@ -695,6 +697,11 @@ async function doRoll(actor, formula, targetmods, prefix, thing, origtarget, opt
 		type: CONST.CHAT_MESSAGE_TYPES.OOC,
 		roll: roll
 	};
+	if (blindroll) {
+		messageData.whisper = ChatMessage.getWhisperRecipients("GM");
+		messageData.blind = true;
+		messageData.flavor = prefix + thing + " (" + origtarget + ")" + optlabel + modscontent;
+	}
 
 	if (niceDice) {
 		game.dice3d.showForRoll(roll).then((displayed) => {
@@ -1085,7 +1092,7 @@ Hooks.once("init", async function () {
 	
 	Hooks.on('chatMessage', (log, content, data) => {
     if (content === "/help" || content === "!help") {
-        ChatMessage.create({ content: "<a href='https://bit.ly/2JaSlQd'>GURPS 4e Game Aid USERS GUIDE</a>", user: game.user._id, type: CONST.CHAT_MESSAGE_TYPES.OTHER });
+        ChatMessage.create({ content: "<a href='" + GURPS.USER_GUIDE_URL + "'>GURPS 4e Game Aid USERS GUIDE</a>", user: game.user._id, type: CONST.CHAT_MESSAGE_TYPES.OTHER });
         return false;
     }
 });


### PR DESCRIPTION
Started support for blindroll sematics.   So GM can ask everyone for a Perception roll and they can't see it.
Updated parselinks to handle 4d+1X4 (0…5) damage.  Optional space allowed in front of armor divisor (but not multiplier).
If formula is NOT a damage roll, pass to Foundry without armor divisor, and convert "X" and "x" to "*".  4d+1*4
Warn user if they try to import using a Fantasy Grounds export (and yes, someone installed 0.8.0, didn't read the docs and DMed me on Discord as to why it didn't work).     So now it shows an error, and then puts the URL in the chat log.