### PR TITLE
Fixed initiative and added [Parry] [Block]

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To install the latest release, use this manifest URL:
 This is what we are currently working on:
 - 0.8.3
     - Direct roll of On-the-Fly formulas.  e.g. /r [Per] or /roll [3d-2 cr]
+    - Parry & Block On-the-Fly formulas
 
 ### History
 - 0.8.2

--- a/lib/initiative.js
+++ b/lib/initiative.js
@@ -11,8 +11,8 @@ export default class Initiative {
     Hooks.once("init", () => {
       CONFIG.Combat.initiative = {
  //       formula: "(1d6 / 1000) + @attributes.DX.value / 100 + @basicspeed.value * 100",
-        formula: "(1d6 / 1000) + (@attributes.DX.value / 100) + @basicspeed.value",
-        decimals: 3
+        formula: "((@basicspeed.value*100) + (@attributes.DX.value / 100) + (1d6 / 1000)) / 100",
+        decimals: 5
       }
 
 //      console.log(CONFIG.Combat.initiative)

--- a/lib/npc-input.js
+++ b/lib/npc-input.js
@@ -186,6 +186,7 @@ export class NpcInput extends Application {
     data.touch = m.per;
     data.vision = m.per;
 		if (!!m.parry) data.parry = m.parry;
+		//if (!!m.block) data.block = m.block;			We don't show block ANYWHERE yet, so don't save it
 
     let ns = {};
     let nt = new Note(m.notes.trim());

--- a/lib/parselink.js
+++ b/lib/parselink.js
@@ -280,6 +280,22 @@ export default function parselink(str, htmldesc, clrdmods = false) {
       "action": action			
 		}
 	}
+	
+	parse = str.split(":");				// Block or Parry
+	if (["Block", "BLOCK", "Parry", "PARRY"].includes(parse[0])) {
+		let action = {
+      "orig": str,
+      "type": "block-parry",
+      "desc": parse[0],
+			"melee" : parse[1],			// optional melee name to match
+      "path" : parse[0].toLowerCase(),  
+      "blindroll" : blindroll
+		};
+		return {
+      "text": gspan(str, action, brtxt),
+      "action": action			
+		}
+	}
 
   return { "text": str };
 }

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -212,8 +212,6 @@ GURPS.PARSELINK_MAPPINGS = {
 	"Smell": "tastesmell",
 	"TOUCH": "touch",
 	"Touch": "touch",
-	"Parry": "parry",
-	"PARRY": "parry"
 }
 
 
@@ -529,7 +527,6 @@ function performAction(action, actor, event) {
 		} else
 			ui.notifications.warn("You must have a character selected");
 
-
 	if (action.type === "attack")
 		if (!!actor) {
 			let att = null;
@@ -564,6 +561,34 @@ function performAction(action, actor, event) {
 			thing = action.desc;
 		} else
 			ui.notifications.warn("You must have a character selected");
+			
+	if (action.type === "block-parry")
+		if (!!actor) {
+			thing = action.desc;
+			if (!action.melee) target = actordata.data[action.path];		// Is there a basic parry or block stored, and we didn't try to identify a melee
+			Object.values(actordata.data.melee).forEach(e => {
+				if (!target || target < 0) {
+					if (!!e[action.path]) {
+						if (!!action.melee) {
+							if (e.name.startsWith(action.melee)) {
+								target = e[action.path];
+								thing += " for " + e.name;
+							}
+						} else {
+							target = e[action.path];
+							thing += " for " + e.name;
+						}
+					}
+				}
+			});
+			target = parseInt(target);
+			if (target) 
+				formula = "3d6";
+			else
+				ui.notifications.warn("Unable to find a " + action.desc + " to roll");
+		} else
+			ui.notifications.warn("You must have a character selected");
+
 
 
 	if (!!formula) doRoll(actor, formula, targetmods, prefix, thing, target, opt);
@@ -671,7 +696,7 @@ GURPS.applyModifierDesc = applyModifierDesc;
 // formula="3d6", targetmods="[{ desc:"", mod:+-1 }]", thing="Roll vs 'thing'" or damagetype 'burn', target=skill level or -1=damage roll
 async function doRoll(actor, formula, targetmods, prefix, thing, origtarget, optionalArgs) {
 
-	if (origtarget == 0) return;	// Target == 0, so no roll.  Target == -1 for non-targetted rolls (roll, damage)
+	if (origtarget == 0 || isNaN(origtarget)) return;	// Target == 0, so no roll.  Target == -1 for non-targetted rolls (roll, damage)
 	let isTargeted = (origtarget > 0 && !!thing);		// Roll "against" something (true), or just a roll (false)
 
 	// Is Dice So Nice enabled ?


### PR DESCRIPTION
Sorry, I mucked with init a while back, and finally figured out what I did wrong.   It now shows a reasonable number that most people can parse.   Example:
    Basic Speed: 6.5,   DX: 13,   1d6: 4   =>   6.50134
    Basic Speed: 5.25,   DX: 11,   1d6: 6   =>   5.25116
    Basic Speed: 6.0,   DX: 12,   1d6: 1   =>   6.00121
We now have [Block] and [Parry] On-the-Fly formulas.   If there is a generic Parry defined (for an NPC), it uses that.   Otherwise, it iterates through the melee attacks to find the first one with a block/parry.
If you need to use a melee attack other than the first one, you can include the beginning of the name in the OtF:  Ex:
[Parry:Knife] [Block:Small Sh].       If the melee name starts with the text after the ":", it is selected.
