### PR TITLE
Feature/nonhuman hitlocation

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -73,5 +73,8 @@
 		"GURPS.STATUSModerate": "Moderate Pain",
 		"GURPS.STATUSSevere": "Severe Pain",
 		"GURPS.STATUSTerrible": "Terrible Pain",
-		"GURPS.STATUSRetching": "Retching"
+		"GURPS.STATUSRetching": "Retching",
+
+		"GURPS.BODYPLANhumanoid": "Humanoid",
+		"GURPS.BODYPLANquadruped": "Quadruped"
 }

--- a/lib/moustachewax.js
+++ b/lib/moustachewax.js
@@ -133,15 +133,31 @@ export default function () {
   });
 
   // Only necessary because of the FG import
-  Handlebars.registerHelper('hitlocationroll', function (loc, roll) {
-    if (!roll)
-      roll = GURPS.hitlocationRolls[loc]?.roll;
+  Handlebars.registerHelper('hitlocationroll', function (loc, roll, data) {
+    if (!roll) {
+      // get hitlocation table name
+      let tableName = data?.additionalresources?.bodyplan;
+      if (!tableName)
+        tableName = 'humanoid';
+      let table = GURPS.hitlocationDictionary[tableName];
+      if (!table)
+        table = GURPS.hitlocationDictionary['humanoid']
+      roll = table[loc]?.roll;
+    }
     return roll;
   });
 
-  Handlebars.registerHelper('hitlocationpenalty', function (loc, penalty) {
-    if (!penalty)
-      penalty = GURPS.hitlocationRolls[loc]?.penalty;
+  Handlebars.registerHelper('hitlocationpenalty', function (loc, penalty, data) {
+    if (!penalty) {
+      // get hitlocation table name
+      let tableName = data?.additionalresources?.bodyplan
+      if (!tableName)
+        tableName = 'humanoid'
+      let table = GURPS.hitlocationDictionary[tableName]
+      if (!table)
+        table = GURPS.hitlocationDictionary['humanoid']
+      penalty = table[loc]?.penalty;
+    }
     return penalty;
   });
 

--- a/module/actor.js
+++ b/module/actor.js
@@ -740,20 +740,36 @@ export class GurpsActor extends Actor {
 	//  	rollText: string value of the roll from the hitlocations table (examples: '5', '6-9', '-')
 	//  	roll: array of int of the values that match rollText (examples: [5], [6,7,8,9], [])
 	// 	}
-	// TODO update for non-humanoid hit locations
 	get hitLocationsWithDR() {
 		let myhitlocations = []
+		let table = this._hitLocationRolls
 		for (const [key, value] of Object.entries(this.data.data.hitlocations)) {
 			myhitlocations.push({
 				where: value.where,
 				dr: parseInt(value.dr),
 				roll: this._convertRollStringToArrayOfInt(
-					GURPS.hitlocationRolls[value.where].roll
+					table[value.where].roll
 				),
-				rollText: GURPS.hitlocationRolls[value.where].roll
+				rollText: table[value.where].roll
 			})
 		}
 		return myhitlocations
+	}
+
+	/**
+	 * @returns the appropriate hitlocation table based on the actor's bodyplan
+	 */
+	get _hitLocationRolls() {
+		let tableName = this.data.data.additionalresources?.bodyplan
+
+		if (!tableName)
+			tableName = 'humanoid'
+
+		let table = GURPS.hitlocationDictionary[tableName]
+		if (!table)
+			table = GURPS.hitlocationDictionary['humanoid']
+
+		return table
 	}
 
 	// Take a string like "", "-", "3", "4-5" and convert it into an array of int.

--- a/module/actor.js
+++ b/module/actor.js
@@ -740,6 +740,7 @@ export class GurpsActor extends Actor {
 	//  	rollText: string value of the roll from the hitlocations table (examples: '5', '6-9', '-')
 	//  	roll: array of int of the values that match rollText (examples: [5], [6,7,8,9], [])
 	// 	}
+	// TODO update for non-humanoid hit locations
 	get hitLocationsWithDR() {
 		let myhitlocations = []
 		for (const [key, value] of Object.entries(this.data.data.hitlocations)) {
@@ -933,11 +934,11 @@ export class Equipment extends Named {
 	contains = {};
 	costsum = "";
 	weightsum = "";
-	
+
 	calc() {
 		if (!isNaN(this.count) && !isNaN(this.cost)) {
 			this.costsum = this.count * this.cost;
-		} 
+		}
 		if (!isNaN(this.count) && !isNaN(this.weight)) {
 			this.weightsum = (this.count * this.weight) + " lb";
 		}

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -89,6 +89,24 @@ GURPS.hitlocationRolls = {
 	"Chinks in Other": { penalty: -10, desc: "Halves DR" },
 };
 
+GURPS.quadrupedHitLocations = {
+	"Eye": { roll: "-", penalty: -9 },
+	"Skull": { roll: "3-4", penalty: -7 },
+	"Face": { roll: "5", penalty: -5 },
+	"Neck": { roll: "6", penalty: -5 },
+	"Foreleg": { roll: "7-8", penalty: -2 },
+	"Torso": { roll: "9-11", penalty: 0 },
+	"Groin": { roll: "12", penalty: -3 },
+	"Hindleg": { roll: "13-14", penalty: -2 },
+	"Foot": { roll: "15-16", penalty: -4 },
+	"Tail": { roll: "17-18", penalty: -3 },
+	"Vitals": { roll: "-", penalty: -3 }
+};
+
+GURPS.hitlocationDictionary = {
+	"humanoid": GURPS.hitlocationRolls,
+	"quadruped": GURPS.quadrupedHitLocations
+}
 
 GURPS.woundModifiers = {
 	"burn": { multiplier: 1, label: 'Burning' },

--- a/module/modifiers.js
+++ b/module/modifiers.js
@@ -5,19 +5,23 @@ import * as settings from '../lib/miscellaneous-settings.js'
 // Install Custom Roll to support global modifier access (@gmod & @gmodc)
 export class GurpsRoll extends Roll {
 	_prepareData(data) {
-    let d = super._prepareData(data);
-    if (!d.hasOwnProperty('gmodc'))
-	    Object.defineProperty(d, 'gmodc', { get: () => {
-	      let m = GURPS.ModifierBucket.currentSum();
-	      GURPS.ModifierBucket.clear();
-	      return m }});
-    d.gmod = GURPS.ModifierBucket.currentSum();
+		let d = super._prepareData(data);
+		if (!d.hasOwnProperty('gmodc'))
+			Object.defineProperty(d, 'gmodc', {
+				get: () => {
+					let m = GURPS.ModifierBucket.currentSum();
+					GURPS.ModifierBucket.clear();
+					return m;
+				}
+			});
+		d.gmod = GURPS.ModifierBucket.currentSum();
 		return d;
-  }
+	}
 }
 CONFIG.Dice.rolls[0] = GurpsRoll;
 
 
+// TODO how to handle non-humanoid hit locations?
 export class ModifierBucket extends Application {
 	constructor(options = {}) {
 		super(options)
@@ -88,7 +92,7 @@ export class ModifierBucket extends Application {
 			let ranged = [];
 			let defense = [];
 			let gen = [];
-			
+
 			let effects = game.GURPS.LastActor.effects.filter(e => !e.data.disabled);
 			for (let e of effects) {
 				let type = e.data.flags.core.statusId;
@@ -291,12 +295,12 @@ ${OtherMods}`;
 	// Public method. Used by GURPS to create a temporary modifer for an action.
 	makeModifier(mod, reason) {
 		let m = displayMod(mod);
-		return { 
-      "mod": m, 
-      "modint": parseInt(m),
-      "desc": reason, 
-      "plus": (m[0] == "+") 
-    };
+		return {
+			"mod": m,
+			"modint": parseInt(m),
+			"desc": reason,
+			"plus": (m[0] == "+")
+		};
 	}
 
 	sum() {
@@ -324,7 +328,7 @@ ${OtherMods}`;
 		if (!!oldmod) {
 			let m = oldmod.modint + parseInt(mod);
 			oldmod.mod = displayMod(m);
-      oldmod.modint = m;
+			oldmod.modint = m;
 		} else {
 			stack.modifierList.push(this.makeModifier(mod, reason));
 		}

--- a/styles/npc-input.css
+++ b/styles/npc-input.css
@@ -56,7 +56,7 @@
   height: 100% !important;
   display: grid;
   grid-template-columns: 245px 1fr 50%;
-  grid-template-rows: 40px 125px auto auto auto;
+  grid-template-rows: auto 125px auto auto auto;
   gap: 5px 5px;
   grid-template-areas:
     "top top top"
@@ -82,7 +82,7 @@
 .npc-input-top {
   display: grid;
   grid-template-columns: 40px 2fr 40px 2fr;
-  grid-template-rows: 1fr 1fr;
+  grid-template-rows: 0fr 1fr;
   gap: 5px 5px;
   grid-template-areas:
     "nm nm-val title title-val"

--- a/styles/simple.css
+++ b/styles/simple.css
@@ -881,6 +881,7 @@
     "header header header"
     "block1 block2 block3";
   grid-template-rows: 0fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
   border: 1px solid black;
 }
 
@@ -1203,7 +1204,7 @@ body {
 #notes {
   display: grid;
   border: 1px solid black;
-  align-content: stretch;
+  align-content: start;
 }
 
 #reactions,
@@ -2636,4 +2637,37 @@ ul#result-effects li {
 
 .tooltip .fieldblock .field {
   border: none !important;
+}
+
+.field select {
+  height: min-content;
+  background-color: transparent;
+  border: none;
+  padding: 0 1em 0 0;
+  margin: 0;
+  width: 100%;
+  font-family: inherit;
+  font-size: 90%;
+  cursor: inherit;
+  line-height: inherit;
+}
+
+.field textarea {
+  font-family: inherit;
+  font-size: 80%; 
+  border-radius: 0;
+  border: 1px solid lightgrey;
+  padding: 3px;
+  resize: none;
+  /* background-color: transparent; */
+  margin-top: 3px;
+}
+
+.field textarea:read-only {
+  background-color: transparent;
+}
+
+.label.textarea {
+  align-self: start;
+  margin-top: 6px;
 }

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT (GCS/GCA edition)",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "minimumCoreVersion": "0.7.5",
   "compatibleCoreVersion": "0.7.9",
   "templateVersion": 2,

--- a/template.json
+++ b/template.json
@@ -216,6 +216,7 @@
 			},
 			"reactions": {},
 			"additionalresources": {
+				"bodyplan": "humanoid",
 				"tracker": {
 					"0": {
 						"name": "",

--- a/templates/actor-sheet-gcs-editor.html
+++ b/templates/actor-sheet-gcs-editor.html
@@ -60,7 +60,17 @@
           <div class="label">TL:</div>
           <div class="field"><input name="data.traits.techlevel" class="gcs-input" type="text"
               value="{{data.traits.techlevel}}" /></div>
+          <div class="label">Body Plan:</div>
+          <div class="field">
+            <select id='body-plan' name="data.additionalresources.bodyplan">
+              <option value='humanoid' {{#if (eq data.additionalresources.bodyplan 'humanoid' )}}selected{{/if}}>
+                {{localize 'GURPS.BODYPLANhumanoid'}}</option>
+              <option value='quadruped' {{#if (eq data.additionalresources.bodyplan 'quadruped' )}}selected{{/if}}>
+                {{localize 'GURPS.BODYPLANquadruped'}}</option>
+            </select>
+          </div>
         </div>
+
         <div class="fieldblock">
           {{#if data.traits.eyes}}
           <div class="label">Hair:</div>
@@ -76,15 +86,14 @@
           <div class="field"><input name="data.traits.hand" class="gcs-input" type="text"
               value="{{data.traits.hand}}" /></div>
           {{else}}
+
           <div class="label">&nbsp;</div>
-          <div class="field"></div>
+          <div class="label textarea">Appearance:</div>
+
           <div class="label"></div>
-          <div class="label">Appearance:</div>
-          <div class="label"></div>
-          <div class="field"><input name="data.traits.appearance" class="gcs-input" type="text"
-              value="{{data.traits.appearance}}" /></div>
-          <div class="label">&nbsp;</div>
-          <div class="field"></div>
+          <div class="field" style="border: none;">
+            <textarea name="data.traits.appearance" rows="5">{{data.traits.appearance}}</textarea>
+          </div>
           {{/if}}
         </div>
       </div>
@@ -258,11 +267,11 @@
         <div class="dr header">DR</div>
 
         {{#each data.hitlocations as | this key |}}
-        <div class="roll">{{hitlocationroll this.where this.roll}}</div>
+        <div class="roll">{{hitlocationroll this.where this.roll ../data}}</div>
         <div class="where {{gurpstippable}}" data-tooltip="Eqt on {{this.where}}: {{this.equipment}}">
           {{this.where}}
         </div>
-        <div class="penalty">{{hitlocationpenalty this.where this.penalty}}</div>
+        <div class="penalty">{{hitlocationpenalty this.where this.penalty ../data}}</div>
         <div class="dr"><input class="gcs-input" type="text" name="data.hitlocations.{{key}}.dr" value="{{this.dr}}" />
         </div>
         {{/each}}

--- a/templates/actor-sheet-gcs.html
+++ b/templates/actor-sheet-gcs.html
@@ -38,6 +38,8 @@
           <div class="field">{{data.traits.birthday}}</div>
           <div class="label">Religion:</div>
           <div class="field">{{data.traits.religion}}</div>
+          <div class="label">&nbsp;</div>
+          <div class="field"></div>
         </div>
         <div class="fieldblock">
           <div class="label">Height:</div>
@@ -48,6 +50,9 @@
           <div class="field">{{data.traits.sizemod}}</div>
           <div class="label">TL:</div>
           <div class="field">{{data.traits.techlevel}}</div>
+          <div class="label">Body Plan:</div>
+          <div class="field">{{localize (concat 'GURPS.BODYPLAN'
+            data.additionalresources.bodyplan)}}</div>
         </div>
         <div class="fieldblock">
           {{#if data.traits.eyes}}
@@ -60,15 +65,12 @@
           <div class="label">Hand:</div>
           <div class="field">{{data.traits.hand}}</div>
           {{else}}
-          <div class="label">&nbsp;</div>
-          <div class="label">&nbsp;</div>
-          <div class="label">Appearance:</div>
-          <div class="label">&nbsp;</div>
-          <div class="label">&nbsp;</div>
-          <div class="label">&nbsp;</div>
-          <div class="field">{{data.traits.appearance}}</div>
-          <div class="label">&nbsp;</div>
-          <div class="label">&nbsp;</div>
+          <div class="label textarea">Appearance:</div>
+          <div class="label"></div>
+
+          <div class="field" style="border: none; grid-column: 1 / span 2;">
+            <textarea readonly rows="4">{{data.traits.appearance}}</textarea>
+          </div>
           {{/if}}
         </div>
       </div>
@@ -209,12 +211,12 @@
         <div class="dr header">DR</div>
 
         {{#each data.hitlocations}}
-        <div class="roll">{{hitlocationroll this.where this.roll}}</div>
+        <div class="roll">{{hitlocationroll this.where this.roll ../data}}</div>
         <div class="where {{gurpstippable}}" data-tooltip="Eqt on {{this.where}}: {{this.equipment}}">
           {{this.where}}
         </div>
         <div class="penalty {{#if (ne this.penalty '0')}}gmod{{/if}}" data-name="to hit {{this.where}}">
-          {{hitlocationpenalty this.where this.penalty}}</div>
+          {{hitlocationpenalty this.where this.penalty ../data}}</div>
         <div class="dr {{gurpstippable}}" data-tooltip="Eqt on {{this.where}}: {{this.equipment}}">{{this.dr}}
         </div>
         {{/each}}

--- a/templates/combat-sheet.html
+++ b/templates/combat-sheet.html
@@ -180,14 +180,15 @@
       </div>
 
       <div id='combat-location'>
-        <div class="header">Hit Location</div>
+        <div class="header">Hit Location ({{localize (concat 'GURPS.BODYPLAN' data.additionalresources.bodyplan)}})
+        </div>
         <div class="roll header">Roll</div>
         <div class="where header">Where</div>
         <div class="penalty header">Penalty</div>
         <div class="dr header">DR</div>
 
         {{#each data.hitlocations}}
-        <div class="roll">{{hitlocationroll this.where this.roll}}</div>
+        <div class="roll">{{hitlocationroll this.where this.roll ../data}}</div>
         <div class="where">{{this.where}}</div>
         <div class="penalty {{#if (ne this.penalty '0')}}gmod{{/if}}" data-name="to hit {{this.where}}">
           {{hitlocationpenalty this.where this.penalty}}


### PR DESCRIPTION
Updated the design to support the ability to have alternate hit locations. This works if the character is imported from GCS with the alternate hit locations defined. User has to go into the editor and set the "body plan" of non-humanoid characters using a drop-down.

- implement Quadruped as the currently only example
- includes updates to the ADD to support alternate hit locations
- Other updates:
 - Add <textarea> to support adding long, free-form descriptions in both Editor, (GCS) Full View.
 - Adjust the format of the NPC sheet to show the full description.
 - Incorporate LegendSmith's fix for the last item in the skill/advantage/etc list.