### PR TITLE
Feature/resource tracker refactor

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -141,6 +141,49 @@ export class GurpsActorSheet extends ActorSheet {
       this.actor.update(JSON.parse(json))
     })
 
+    html.find('.tracked-resource .header.with-editor').click(async ev => {
+      let parent = $(ev.currentTarget).closest('[data-gurps-resource]')
+      let path = parent.attr('data-gurps-resource')
+      let tracker = getProperty(this.actor.data.data, path)
+
+      let dlgHtml = await
+        renderTemplate('systems/gurps/templates/resource-editor-popup.html', tracker)
+
+      let options = {
+        width: 130,
+        popOut: true,
+        minimizable: false,
+        jQuery: true
+      }
+
+      let d = new Dialog({
+        title: 'Resource Editor',
+        content: dlgHtml,
+        buttons: {
+          one: {
+            label: "Update",
+            callback: async (html) => {
+              let name = html.find('.name input').val()
+              let current = parseInt(html.find('.current').val())
+              let minimum = parseInt(html.find('.minimum').val())
+              let maximum = parseInt(html.find('.maximum').val())
+
+              let update = {}
+              if (!!name) update[`data.${path}.name`] = name
+              if (!!current) update[`data.${path}.value`] = current
+              if (!!minimum) update[`data.${path}.min`] = minimum
+              if (!!maximum) update[`data.${path}.max`] = maximum
+
+              this.actor.update(update)
+            }
+          }
+        },
+        default: "one",
+      },
+        options);
+      d.render(true);
+    })
+
     // START CONDITIONAL INJURY
 
     const formatCIEmpty = val => val === null ? "" : val;

--- a/module/injury/domain/ConditionalInjury.js
+++ b/module/injury/domain/ConditionalInjury.js
@@ -151,13 +151,13 @@ export const conditionalEffectsTable = [
     },
     {
         severity: 4,
-        grossEffects: "Instantly Fatal Wound",
+        grossEffects: "Instantly Fatal",
         shock: -4,
         pain: "Agony",
     },
     {
         severity: 5,
-        grossEffects: "Instantly Fatal Wound",
+        grossEffects: "Instantly Fatal",
         shock: -4,
         pain: "Agony",
     },

--- a/styles/simple.css
+++ b/styles/simple.css
@@ -2595,7 +2595,7 @@ ul#result-effects li {
 
 .resource-editor>*,
 .tracked-resource>* {
-  margin: 0 0.25rem 0.25rem 0.25rem;
+  margin: 0 0.15rem 0.15rem 0.15rem;
 }
 
 .resource-editor .header,
@@ -2653,7 +2653,7 @@ ul#result-effects li {
 }
 
 .tracked-resource .spinner .reset {
-  margin-left: 0.25rem;
+  margin-left: 0.15rem;
 }
 
 .tracked-resource .condition-block {
@@ -2700,7 +2700,7 @@ ul#result-effects li {
 }
 
 .resource-editor button i {
-  margin-right: 0.25rem;
+  margin-right: 0.15rem;
 }
 
 .resource-editor button {
@@ -2727,5 +2727,22 @@ ul#result-effects li {
 }
 
 .tracked-resource .fieldblock3 {
-  grid-template-columns: 0fr 0fr 1fr;
+  grid-template-columns: 0fr 1fr 1fr;
+}
+
+.gentle-flex {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1ch;
+}
+
+.condition-block .fieldblock3 {
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.tracked-resource .name {
+  text-align: center !important;
 }

--- a/styles/simple.css
+++ b/styles/simple.css
@@ -1671,7 +1671,6 @@ body {
 #combat-hit .field,
 .tracked-resource .field {
   text-align: end;
-  border: none;
   margin-left: 2px;
   margin-right: 2px;
 }
@@ -1682,15 +1681,21 @@ body {
   border-bottom: 1px solid lightgrey;
 }
 
-.gurps #combat-sheet .condition-block {
+
+#editorsheet .tracked-resource .tooltip .field {
+  border: none !important;
+}
+
+
+/* .gurps #combat-sheet .condition-block {
   font-size: 80%;
   grid-template-columns: 0fr 1fr 0fr;
   grid-template-areas:
     "basic-value basic-label reset"
     "condition   condition   condition";
-}
+} */
 
-.gurps .condition-block .basic-value {
+/* .gurps .condition-block .basic-value {
   grid-area: basic-value;
 }
 
@@ -1701,7 +1706,7 @@ body {
   padding-right: .2em;
   white-space: nowrap;
   align-self: center;
-}
+} */
 
 .conditional-injury .condition-block .basic-value .label {
   text-align: right;
@@ -2538,10 +2543,9 @@ ul#result-effects li {
 
 #trackers {
   grid-area: trackers;
-  align-content: right;
   display: grid;
   grid-template-columns: 1fr;
-  grid-template-rows: auto;
+  grid-template-rows: 0fr auto 0fr;
   grid-gap: .05in;
 }
 
@@ -2595,7 +2599,7 @@ ul#result-effects li {
 
 .resource-editor>*,
 .tracked-resource>* {
-  margin: 0 0.15rem 0.15rem 0.15rem;
+  margin: 0 0.25rem 0.25rem 0.25rem;
 }
 
 .resource-editor .header,
@@ -2652,6 +2656,10 @@ ul#result-effects li {
   border-right: none;
 }
 
+.tracked-resource .tooltip-wrapper {
+  margin-bottom: 0.15rem;
+}
+
 .tracked-resource .spinner .reset {
   margin-left: 0.15rem;
 }
@@ -2662,9 +2670,17 @@ ul#result-effects li {
   justify-content: stretch;
 }
 
+#combat-trackers .tracked-resource .condition-block {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: stretch;
+  align-items: baseline;
+}
+
 .tracked-resource .condition-block .max {
   font-size: 80%;
   text-align: end;
+  margin-left: 0.15rem;
 }
 
 .tracked-resource .condition-block .condition {
@@ -2745,4 +2761,12 @@ ul#result-effects li {
 
 .tracked-resource .name {
   text-align: center !important;
+}
+
+#combat-sheet .tracked-resource .spinner button {
+  padding: 0 2px 2px 2px;
+}
+
+#combat-sheet .fieldblock .field {
+  text-align: right;
 }

--- a/styles/simple.css
+++ b/styles/simple.css
@@ -331,7 +331,7 @@
   padding: 8px;
   color: #fff;
   background-color: #555;
-  z-index: 102; 
+  z-index: 102;
 }
 
 .gurpstippable:hover::after {
@@ -1074,89 +1074,6 @@ body {
   grid-area: attributes;
 }
 
-#trackers {
-  grid-area: trackers;
-  align-content: right;
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: 0fr 0fr;
-  grid-gap: .05in;
-}
-
-#trackers > * {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-gap: .05in;
-}
-
-#trackers > *:first-child {
-  grid-template: "combat-hit combat-fat"
-}
-
-#trackers > *:last-child {
-  grid-template-rows: 0fr 0fr 0fr;
-  grid-gap: 0;
-}
-
-#resources {
-  grid-template-rows: 0fr 0fr;
-  /* border: 1px solid black; */
-}
-
-#editorsheet #resources {
-  font-size: 80%;
-}
-
-#editorsheet #resources .tracked-resource .fieldblock3 *:first-child {
-  grid-column: 1 / span 3;
-}
-
-#editorsheet #resources .tracked-resource .fieldblock3 .name {
-  text-align: start;
-}
-
-#resources > * {
-  border-bottom: 1px solid black;
-  border-right: 1px solid black;
-}
-
-#resources > *:first-child {
-  border-bottom: 1px solid white;
-}
-
-#resources > *:nth-child(even) {
-  border-left: 1px solid black;
-}
-
-/* .tracked-resource .header {
-  background-color: dimgrey;
-} */
-
-#resources .tracked-resource:nth-child(even) .header {
-  border-right: 1px solid white;
-}
-
-#resources .tracked-resource:nth-child(odd) .header {
-  border-left: none;
-}
-
-.tracked-resource .fieldblock {
-  font-size: unset;
-}
-
-.tracked-resource .fieldblock .field {
-  border: none;
-}
-
-.tracked-resource ::placeholder {
-  color: grey;
-}
-
-.tracked-resource {
-  grid-gap: .05in;
-  display: grid;
-  grid-template-rows: 0fr 1fr;
-}
 
 #hitpoints {
   grid-area: hitpoints;
@@ -1705,8 +1622,6 @@ body {
   /* border: 1px solid black; */
 }
 
-#combat-hit,
-#combat-fat,
 #combat-attrs,
 #combat-weapons,
 #combat-location {
@@ -1755,6 +1670,7 @@ body {
   border-bottom: 1px solid lightgrey;
 }
 
+/* 
 .gurps .condition-block {
   display: grid;
   grid-template-columns: 1fr 0fr;
@@ -1773,7 +1689,7 @@ body {
   padding-right: .2em;
   white-space: nowrap;
   align-self: center;
-}
+} */
 
 .gurps #combat-sheet .condition-block {
   font-size: 80%;
@@ -1803,31 +1719,6 @@ body {
   font-size: 80%;
 }
 
-.gurps .condition-block .condition {
-  grid-area: condition;
-  grid-gap: 2px;
-  align-content: center;
-  text-align: center;
-  padding-left: .2em;
-  padding-right: .2em;
-}
-
-.gurps .condition-block .normal {
-  background-color: lightgreen;
-}
-
-.gurps .condiition-block .reset {
-  grid-area: reset;
-}
-
-.gurps .condition-block .reset  {
-  line-height: unset;
-  font-size: smaller;
-  margin: unset;
-  padding: unset;
-  padding-left: 4px;
-  padding-right: 2px;
-}
 
 #hitpoints .selected {
   background-color: #ffcdd2;
@@ -1840,7 +1731,7 @@ body {
 
 .gurps .condition-block .collapse,
 .resource-spinner .depleted {
-    background-color: #ffcdd2;
+  background-color: #ffcdd2;
 }
 
 .gurps .condition-block .check {
@@ -2183,7 +2074,7 @@ body {
   margin-bottom: 0.5em;
 }
 
-.gurps-group h4 + aside {
+.gurps-group h4+aside {
   margin-top: -0.5em;
 }
 
@@ -2396,22 +2287,22 @@ ul#result-effects li {
 }
 
 .offscreen-only {
-  position:absolute;
-  left:-10000px;
-  top:auto;
-  width:1px;
-  height:1px;
-  overflow:hidden;
-  }
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
 
-  /* remove the top margin and indent */
+/* remove the top margin and indent */
 .gurps-group .continuation {
   margin-top: 0;
   margin-left: 2em;
 }
 
 
-  /* EXAMPLE ON HOW TO CREATE A COLLAPSIBLE PANEL IN HTML/CSS ONLY
+/* EXAMPLE ON HOW TO CREATE A COLLAPSIBLE PANEL IN HTML/CSS ONLY
     <div class='collapsible-wrapper'>
         <input id='collapsible' class='toggle offscreen-only' type='checkbox' checked>
         <label for='collapsible' class='label-toggle'>Show the math</label>
@@ -2434,7 +2325,7 @@ ul#result-effects li {
   transition: all .25s ease-in-out;
 }
 
-.toggle:checked + .label-toggle + .collapsible-content {
+.toggle:checked+.label-toggle+.collapsible-content {
   max-height: 130vh;
 }
 
@@ -2453,7 +2344,7 @@ ul#result-effects li {
   text-transform: uppercase;
 }
 
-.gurps-chat-message  .label-toggle:hover {
+.gurps-chat-message .label-toggle:hover {
   background-color: rgb(0, 0, 0, 0.7);
 }
 
@@ -2464,7 +2355,7 @@ ul#result-effects li {
   float: right;
 }
 
-.gurps-chat-message .toggle:checked + .label-toggle:after {
+.gurps-chat-message .toggle:checked+.label-toggle:after {
   font: normal normal normal 12px/1 FontAwesome;
   content: '\f077';
   color: lightgray;
@@ -2498,11 +2389,11 @@ ul#result-effects li {
   padding-top: 2px;
 }
 
-.gurps-group .options-drawer .toggle:checked + .label-toggle + .collapsible-content {
+.gurps-group .options-drawer .toggle:checked+.label-toggle+.collapsible-content {
   max-height: 130vh;
   padding-bottom: 2px;
   margin-bottom: 5px;
-  box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.3) inset, 
+  box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.3) inset,
     0px 1px 3px rgba(0, 0, 0, 0.3) inset, 0px 1px 3px rgba(0, 0, 0, 0.3) inset;
 }
 
@@ -2510,7 +2401,7 @@ ul#result-effects li {
   text-transform: uppercase;
 }
 
-.gurps-app button.with-icon > i > span{
+.gurps-app button.with-icon>i>span {
   font-family: 'Font Awesome 5 Free', Roboto, sans-serif;
   font-weight: 400;
 }
@@ -2519,22 +2410,22 @@ ul#result-effects li {
   font-family: Roboto, sans-serif;
 }
 
-.gurps-app .fa, 
-.gurps-app .fab, 
-.gurps-app .fad, 
-.gurps-app .fal, 
-.gurps-app .far, 
+.gurps-app .fa,
+.gurps-app .fab,
+.gurps-app .fad,
+.gurps-app .fal,
+.gurps-app .far,
 .gurps-app .fas {
   font-family: 'Font Awesome 5 Free' !important;
-} 
+}
 
 .gurps-app #blunt-trauma-field {
   margin-left: 6px;
 }
 
 .gurps .ranged_options {
-	display: flex;
-	flex-wrap: no-wrap;
+  display: flex;
+  flex-wrap: no-wrap;
 }
 
 .dragging {
@@ -2543,54 +2434,8 @@ ul#result-effects li {
   border-radius: 3px;
 }
 
-.tracked-resource.inactive .header {
-  color: whitesmoke;
-  background-color: grey;
-}
 
-.resource-spinner {
-  display: flex;
-  flex-flow: row nowrap;
-}
 
-.resource-spinner button {
-  line-height: unset;
-  margin: 0;
-  padding: 2px;
-  height: 26px;
-  flex: 0;
-  border: 1px solid grey;
-  font-family: "Font Awesome 5 Free", Roboto, sans-serif;
-}
-
-.tracked-resource.inactive .condition-block > *,
-.tracked-resource.inactive .resource-spinner input,
-.tracked-resource.inactive .resource-spinner button {
-  color: grey;
-}
-
-.resource-spinner .inactive button {
-  color: grey;
-}
-
-.resource-spinner button:first-child{
-  border-radius: 3px 0px 0px 3px; 
-  border: 1px solid grey; 
-  border-right-width: 0;
-}
-
-.resource-spinner button:last-child {
-  border-radius: 0px 3px 3px 0px; 
-  border: 1px solid grey; 
-  border-left-width: 0;  
-  padding-left: 4px;
-  padding-right: 0;
-}
-
-.resource-spinner input {
-  flex: 3; 
-  border-radius: 0; 
-}
 
 #combat-sheet .resource-spinner button {
   height: 21px;
@@ -2609,9 +2454,10 @@ ul#result-effects li {
 .tooltip {
   position: relative;
   display: inline-block;
-  border-bottom: 1px dotted darkgrey; /* If you want dots under the hoverable text */
-  text-transform: uppercase;
-  color: darkgrey
+  border-bottom: 1px dotted darkgrey;
+  /* If you want dots under the hoverable text */
+  /* text-transform: uppercase; */
+  /* color: darkgrey */
 }
 
 /* Tooltip text */
@@ -2655,12 +2501,6 @@ ul#result-effects li {
   opacity: 1;
 }
 
-.tooltip-wrapper {
-  margin: auto;
-  text-transform: uppercase;
-  font-size: smaller;
-}
-
 .fieldblock3 .tooltip-wrapper {
   grid-column: 1 / span 2;
 }
@@ -2684,7 +2524,7 @@ ul#result-effects li {
 
 .field textarea {
   font-family: inherit;
-  font-size: 80%; 
+  font-size: 80%;
   border-radius: 0;
   border: 1px solid lightgrey;
   padding: 3px;
@@ -2700,4 +2540,202 @@ ul#result-effects li {
 .label.textarea {
   align-self: start;
   margin-top: 6px;
+}
+
+
+/* Resource Trackers and Editors */
+
+#trackers {
+  grid-area: trackers;
+  align-content: right;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto;
+  grid-gap: .05in;
+}
+
+#trackers>* {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: .05in;
+}
+
+#trackers>*:first-child {
+  grid-template: "combat-hit combat-fat"
+}
+
+#trackers>*:last-child {
+  grid-template-rows: 0fr 1fr 1fr;
+  grid-gap: 0;
+}
+
+#resources {
+  grid-template-rows: 0fr 0fr;
+}
+
+#resources .tracked-resource .header:hover {
+  outline: none;
+  box-shadow: 0 0 5px red;
+}
+
+#resources>*:first-child {
+  border-bottom: 1px solid white;
+}
+
+.tracked-resource:nth-child(even) .header {
+  border-right: 1px solid white;
+}
+
+.tracked-resource:nth-child(odd) .header {
+  border-left: none;
+}
+
+.resource-editor,
+.tracked-resource {
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: space-between;
+  border-left: 1px solid black;
+  border-bottom: 1px solid black;
+}
+
+.tracked-resource:nth-child(odd) {
+  border-right: 1px solid black;
+}
+
+.resource-editor>*,
+.tracked-resource>* {
+  margin: 0 0.25rem 0.25rem 0.25rem;
+}
+
+.resource-editor .header,
+.tracked-resource .header {
+  color: white;
+  background-color: black;
+  text-align: center;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  border-bottom: 1px solid black;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.tracked-resource .header .edit {
+  float: right;
+  margin-right: 0.25em;
+}
+
+.resource-editor .name,
+.tracked-resource .spinner {
+  display: flex;
+  flex-flow: row nowrap;
+  line-height: unset;
+}
+
+.tracked-resource button i {
+  font-size: 67%;
+  margin: 0;
+}
+
+.resource-editor input,
+.tracked-resource .spinner input {
+  height: 1.2rem;
+  min-width: 2rem;
+  border: 1px solid grey;
+  border-radius: 0;
+  font-size: inherit;
+  text-align: center;
+
+}
+
+.tracked-resource .spinner .increment {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left: none;
+}
+
+.tracked-resource .spinner .decrement {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: none;
+}
+
+.tracked-resource .spinner .reset {
+  margin-left: 0.25rem;
+}
+
+.tracked-resource .condition-block {
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: stretch;
+}
+
+.tracked-resource .condition-block .max {
+  font-size: 80%;
+  text-align: end;
+}
+
+.tracked-resource .condition-block .condition {
+  text-align: center;
+  width: 100%;
+  border-bottom: 1px grey dotted;
+}
+
+.tracked-resource .condition.normal {
+  background-color: rgba(144, 238, 144, 0.6);
+}
+
+.tracked-resource .condition.below {
+  background-color: rgba(240, 128, 128, 0.6);
+}
+
+.tracked-resource .condition.above {
+  background-color: rgba(238, 130, 238, 0.6);
+}
+
+.tracked-resource ::placeholder {
+  color: grey;
+}
+
+.resource-editor .inputs {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto;
+  grid-gap: 0.15rem;
+}
+
+.resource-editor .inputs .label {
+  font-size: 80%;
+}
+
+.resource-editor button i {
+  margin-right: 0.25rem;
+}
+
+.resource-editor button {
+  font-size: inherit;
+  padding: 0 0.15rem;
+}
+
+.tracked-resource .spinner button {
+  line-height: unset;
+  margin: 0;
+  height: 1.2rem;
+  flex: 0;
+  border: 1px solid grey;
+  font-family: "Font Awesome 5 Free", Roboto, sans-serif;
+}
+
+.tracked-resource.inactive .condition-block>* {
+  color: grey;
+}
+
+.tracked-resource.inactive .header {
+  color: whitesmoke;
+  background-color: grey;
+}
+
+.tracked-resource .fieldblock3 {
+  grid-template-columns: 0fr 0fr 1fr;
 }

--- a/styles/simple.css
+++ b/styles/simple.css
@@ -1619,7 +1619,6 @@ body {
   display: flex;
   flex-flow: column nowrap;
   justify-content: space-between;
-  /* border: 1px solid black; */
 }
 
 #combat-attrs,
@@ -1636,6 +1635,19 @@ body {
 #combat-attrs,
 #combat-location {
   border: 1px solid black;
+}
+
+.header.major-heading {
+  border-bottom: 1px solid white;
+}
+
+.header.minor-heading {
+  background-color: grey !important;
+  border: none !important;
+}
+
+.no-border {
+  border: none !important;
 }
 
 #combat-encumber {
@@ -1670,27 +1682,6 @@ body {
   border-bottom: 1px solid lightgrey;
 }
 
-/* 
-.gurps .condition-block {
-  display: grid;
-  grid-template-columns: 1fr 0fr;
-  grid-template-areas:
-    "basic-value reset"
-    "condition   condition";
-  grid-template-rows: 0fr 0fr;
-  align-items: end;
-  padding-bottom: .15em;
-  grid-gap: 3px;
-}
-
-.gurps .condition-block {
-  text-align: start;
-  padding-left: .2em;
-  padding-right: .2em;
-  white-space: nowrap;
-  align-self: center;
-} */
-
 .gurps #combat-sheet .condition-block {
   font-size: 80%;
   grid-template-columns: 0fr 1fr 0fr;
@@ -1701,9 +1692,6 @@ body {
 
 .gurps .condition-block .basic-value {
   grid-area: basic-value;
-  margin-right: .2em;
-  padding-left: .2em;
-  padding-right: .2em;
 }
 
 .gurps .condition-block .basic-label {
@@ -1715,10 +1703,13 @@ body {
   align-self: center;
 }
 
+.conditional-injury .condition-block .basic-value .label {
+  text-align: right;
+}
+
 .gurps #combat-sheet .condition-block .basic-label {
   font-size: 80%;
 }
-
 
 #hitpoints .selected {
   background-color: #ffcdd2;
@@ -2454,7 +2445,7 @@ ul#result-effects li {
 .tooltip {
   position: relative;
   display: inline-block;
-  border-bottom: 1px dotted darkgrey;
+  border-bottom: 1px dotted grey;
   /* If you want dots under the hoverable text */
   /* text-transform: uppercase; */
   /* color: darkgrey */
@@ -2594,7 +2585,6 @@ ul#result-effects li {
 .tracked-resource {
   display: flex;
   flex-flow: column nowrap;
-  justify-content: space-between;
   border-left: 1px solid black;
   border-bottom: 1px solid black;
 }
@@ -2631,6 +2621,7 @@ ul#result-effects li {
   display: flex;
   flex-flow: row nowrap;
   line-height: unset;
+  align-items: center;
 }
 
 .tracked-resource button i {
@@ -2679,7 +2670,6 @@ ul#result-effects li {
 .tracked-resource .condition-block .condition {
   text-align: center;
   width: 100%;
-  border-bottom: 1px grey dotted;
 }
 
 .tracked-resource .condition.normal {

--- a/templates/actor-sheet-gcs-editor.html
+++ b/templates/actor-sheet-gcs-editor.html
@@ -347,8 +347,8 @@
               </div>
               <div class="label">Basic</div>
             </div>
-            <div class='tooltip-wrapper'>
-              <div class="tooltip gentle-flex">Thresholds
+            <div class='tooltip-wrapper gentle-flex'>
+              <div class="tooltip">Thresholds
                 <span class="tooltiptext">
                   <div class="fieldblock">
                     {{#hpBreakpoints data.HP}}

--- a/templates/actor-sheet-gcs-editor.html
+++ b/templates/actor-sheet-gcs-editor.html
@@ -285,86 +285,84 @@
       <div id='trackers'>
         <div>
           {{#if useCI}}
-            <div id='combat-hit'>
-              <div class='header'>Injury</div>
-              <div class="fieldblock3">
-                <div class="points"></div>
-                <div class="field"><input class="gcs-input" name="data.conditionalinjury.injury.severity" type="text" value="{{data.conditionalinjury.injury.severity}}"
-                    data-dtype="Number" />
-                </div>
-                <div class="label">Severity</div>
-
-                <div class="points"></div>
-                <div class="field"><input class="gcs-input" name="data.conditionalinjury.injury.daystoheal" type="text" value="{{data.conditionalinjury.injury.daystoheal}}"
-                    data-dtype="Number" />
-                </div>
-                <div class="label">Days</div>
-
-                <div class="points">
-                  <input name="data.conditionalinjury.RT.points" class="gcs-input-sm2" type="text" value="{{data.conditionalinjury.RT.points}}">
-                </div>
-                <div class="field"><input class="gcs-input" name="data.conditionalinjury.RT.value" type="text" value="{{data.conditionalinjury.RT.value}}"
-                    data-dtype="Number" />
-                </div>
-                <div class="label">RT</div>
-
-                <div class="points">
-                  <input name="{{data.HP.points}}" class="gcs-input-sm2" type="text" value="{{data.HP.points}}">
-                </div>
-                <div class="field">
-                  <input class="gcs-input" name="data.HP.max" type="text" value="{{data.HP.max}}" data-dtype="Number" />
-                </div>
-                <div class="label">HP</div>
-
+          <div id='combat-hit' class='tracked-resource'>
+            <div class='header'>Injury</div>
+            <div class="fieldblock3">
+              <div class="points"></div>
+              <div class="field"><input class="gcs-input" name="data.conditionalinjury.injury.severity" type="text"
+                  value="{{data.conditionalinjury.injury.severity}}" data-dtype="Number" />
               </div>
-              <div class='tooltip-wrapper'>
-                <div class="tooltip">Severities
-                  <span class="tooltiptext">
-                    <div class="fieldblock">
-                      {{#ciSeveritiesTooltip}}
-                      <div class="field condensed noedit">{{severity}}</div>
-                      <div class="label">{{label}}</div>
-                      {{/ciSeveritiesTooltip}}
-                    </div>
-                  </span>
-                </div>
+              <div class="label">Severity</div>
+
+              <div class="points"></div>
+              <div class="field"><input class="gcs-input" name="data.conditionalinjury.injury.daystoheal" type="text"
+                  value="{{data.conditionalinjury.injury.daystoheal}}" data-dtype="Number" />
               </div>
-            </div> <!-- combat-hit -->
+              <div class="label">Days</div>
+
+              <div class="points">
+                <input name="data.conditionalinjury.RT.points" class="gcs-input-sm2" type="text"
+                  value="{{data.conditionalinjury.RT.points}}">
+              </div>
+              <div class="field"><input class="gcs-input" name="data.conditionalinjury.RT.value" type="text"
+                  value="{{data.conditionalinjury.RT.value}}" data-dtype="Number" />
+              </div>
+              <div class="label">RT</div>
+
+              <div class="points">
+                <input name="{{data.HP.points}}" class="gcs-input-sm2" type="text" value="{{data.HP.points}}">
+              </div>
+              <div class="field">
+                <input class="gcs-input" name="data.HP.max" type="text" value="{{data.HP.max}}" data-dtype="Number" />
+              </div>
+              <div class="label">HP</div>
+            </div>
+            <div class='tooltip-wrapper gentle-flex'>
+              <div class="tooltip">Severities
+                <span class="tooltiptext">
+                  <div class="fieldblock">
+                    {{#ciSeveritiesTooltip}}
+                    <div class="field condensed noedit">{{severity}}</div>
+                    <div class="label">{{label}}</div>
+                    {{/ciSeveritiesTooltip}}
+                  </div>
+                </span>
+              </div>
+            </div>
+          </div> <!-- combat-hit -->
           {{else}}
-            <div id='combat-hit' data-gurps-resource='HP'>
-              <div class='header'>Hit Points</div>
-              <div class="fieldblock3">
-                <div class="points"></div>
-                <div class="field"><input class="gcs-input" name="data.HP.value" type="text" value="{{data.HP.value}}"
-                                          data-dtype="Number" /></div>
-                <div class="label">Current</div>
+          <div id='combat-hit' class='tracked-resource' data-gurps-resource='HP'>
+            <div class='header'>Hit Points</div>
+            <div class="fieldblock3">
+              <div class="points"></div>
+              <div class="field"><input class="gcs-input" name="data.HP.value" type="text" value="{{data.HP.value}}"
+                  data-dtype="Number" /></div>
+              <div class="label">Current</div>
 
-                <div class="points">
-                  <input name="{{data.HP.points}}" class="gcs-input-sm2" type="text" value="{{data.HP.points}}">
-                </div>
-
-                <div class="field">
-                  <input class="gcs-input" name="data.HP.max" type="text" value="{{data.HP.max}}" data-dtype="Number" />
-                </div>
-                <div class="label">Basic</div>
-
+              <div class="points">
+                <input name="{{data.HP.points}}" class="gcs-input-sm2" type="text" value="{{data.HP.points}}">
               </div>
-              <div class='tooltip-wrapper'>
-                <div class="tooltip">Thresholds
-                  <span class="tooltiptext">
-                    <div class="fieldblock">
-                      {{#hpBreakpoints data.HP}}
-                      <div class="field condensed noedit">{{breakpoint}}</div>
-                      <div class="label {{style}}">{{label}}</div>
-                      {{/hpBreakpoints}}
-                    </div>
-                  </span>
-                </div>
+              <div class="field">
+                <input class="gcs-input" name="data.HP.max" type="text" value="{{data.HP.max}}" data-dtype="Number" />
               </div>
-            </div> <!-- combat-hit -->
+              <div class="label">Basic</div>
+            </div>
+            <div class='tooltip-wrapper'>
+              <div class="tooltip gentle-flex">Thresholds
+                <span class="tooltiptext">
+                  <div class="fieldblock">
+                    {{#hpBreakpoints data.HP}}
+                    <div class="field condensed noedit">{{breakpoint}}</div>
+                    <div class="label {{style}}">{{label}}</div>
+                    {{/hpBreakpoints}}
+                  </div>
+                </span>
+              </div>
+            </div>
+          </div> <!-- combat-hit -->
           {{/if}}
 
-          <div id='combat-fat' data-gurps-resource='FP'>
+          <div id='combat-fat' class='tracked-resource' data-gurps-resource='FP'>
             <div class='header'>Fatigue</div>
             <div class="fieldblock3">
               <div class="points"></div>
@@ -381,8 +379,7 @@
               </div>
               <div class="label">Basic</div>
             </div>
-
-            <div class='tooltip-wrapper'>
+            <div class='tooltip-wrapper gentle-flex'>
               <div class="tooltip">Thresholds
                 <span class="tooltiptext">
                   <div class="fieldblock">
@@ -404,11 +401,12 @@
           {{#each data.additionalresources.tracker}}
           <div class='tracked-resource' data-gurps-resource='additionalresources.tracker.{{@index}}'>
             <div class='header'>Resource {{@index}}</div>
+            <div class='field name'>
+              <input name="data.additionalresources.tracker.{{@index}}.name" class="gcs-input" type="text"
+                value="{{name}}" placeholder="Resource Name">
+            </div>
             <div class="fieldblock3" style='padding-bottom: 0.05in; '>
-              <div class='field name' style='margin-bottom: 0.05in;'>
-                <input name="data.additionalresources.tracker.{{@index}}.name" class="gcs-input" type="text"
-                  value="{{name}}" placeholder="Resource Name">
-              </div>
+
 
               <div class="points"></div>
               <div class="field"><input class="gcs-input" name="data.additionalresources.tracker.{{@index}}.value"

--- a/templates/actor-sheet-gcs-editor.html
+++ b/templates/actor-sheet-gcs-editor.html
@@ -406,8 +406,6 @@
                 value="{{name}}" placeholder="Resource Name">
             </div>
             <div class="fieldblock3" style='padding-bottom: 0.05in; '>
-
-
               <div class="points"></div>
               <div class="field"><input class="gcs-input" name="data.additionalresources.tracker.{{@index}}.value"
                   type="text" value="{{value}}" data-dtype="Number" /></div>
@@ -418,10 +416,7 @@
                   type="text" value="{{min}}" data-dtype="Number" /></div>
               <div class="label">Minimum</div>
 
-              <div class="points">
-                <input name="data.additionalresources.tracker.{{@index}}.points" class="gcs-input-sm2" type="text"
-                  value="{{points}}">
-              </div>
+              <div class="points"></div>
               <div class="field">
                 <input class="gcs-input" name="data.additionalresources.tracker.{{@index}}.max" type="text"
                   value="{{max}}" data-dtype="Number" />

--- a/templates/actor-sheet-gcs.html
+++ b/templates/actor-sheet-gcs.html
@@ -226,63 +226,66 @@
       <div id="trackers">
         <div>
           {{#if useCI}}
-            <div id='combat-hit'>
-              <div class='header'>Injury</div>
-              <div class="tracked-resource">
-                <div class="header">Severity</div>
-                <div class='field'>
-                  <div class='resource-spinner'>
-                    <button data-operation='ci-severity-dec'><i class="fas fa-caret-left"></i></button>
-                    <input class="gcs-attr-input" name="data.conditionalinjury.injury.severity" type="text" value="{{data.conditionalinjury.injury.severity}}"
-                           placeholder="" data-dtype="String" data-operation="ci-severity-set" />
-                    <button data-operation='ci-severity-inc'><i class="fas fa-caret-right"></i></button>
-                  </div>
-                </div>
-                <div class="header">Days to Heal</div>
-                <div class='field'>
-                  <div class='resource-spinner'>
-                    <button data-operation='ci-days-dec'><i class="fas fa-caret-left"></i></button>
-                    <input class="gcs-attr-input" name="data.conditionalinjury.injury.daystoheal" type="text" value="{{data.conditionalinjury.injury.daystoheal}}"
-                           placeholder="" data-dtype="Number" data-operation="ci-days-set" />
-                    <button data-operation='ci-days-inc'><i class="fas fa-caret-right"></i></button>
-                  </div>
-                </div>
-              </div>
-              <div class='tooltip-wrapper'>
-                <div class="tooltip">Severities
-                  <span class="tooltiptext">
-                      <div class="fieldblock">
-                        {{#ciSeveritiesTooltip}}
-                        <div class="field condensed noedit">{{severity}}</div>
-                        <div class="label">{{label}}</div>
-                        {{/ciSeveritiesTooltip}}
-                      </div>
-                    </span>
-                </div>
-              </div>
-              <div class='condition-block'>
-                <div class='basic-value fieldblock3'>
-                  <div class="points">[{{data.conditionalinjury.RT.points}}]</div>
-                  <div class='field'>{{data.conditionalinjury.RT.value}}</div>
-                  <div class='field'>RT</div>
-                </div>
-                <div class='condition {{ciCurrentGrossEffects data.conditionalinjury.injury.severity "style"}}'>{{ciCurrentGrossEffects data.conditionalinjury.injury.severity "label"}}</div>
-                <button class='reset' data-operation='ci-reset'><i class="fas fa-undo"></i></button>
-              </div>
-            </div>
-          {{else}}
-            <div id='combat-hit' data-gurps-resource='HP'>
-              <div class='header'>Hit Points</div>
+          <div id='combat-hit'>
+            <div class='header'>Injury</div>
+            <div class="tracked-resource">
+              <div class="header">Severity</div>
               <div class='field'>
                 <div class='resource-spinner'>
-                  <button data-operation='resource-dec'><i class="fas fa-caret-left"></i></button>
-                  <input class="gcs-attr-input" name="data.HP.value" type="text" value="{{data.HP.value}}"
-                         placeholder="{{data.HP.max}}" data-dtype="Number" />
-                  <button data-operation='resource-inc'><i class="fas fa-caret-right"></i></button>
+                  <button data-operation='ci-severity-dec'><i class="fas fa-caret-left"></i></button>
+                  <input class="gcs-attr-input" name="data.conditionalinjury.injury.severity" type="text"
+                    value="{{data.conditionalinjury.injury.severity}}" placeholder="" data-dtype="String"
+                    data-operation="ci-severity-set" />
+                  <button data-operation='ci-severity-inc'><i class="fas fa-caret-right"></i></button>
                 </div>
               </div>
+              <div class="header">Days to Heal</div>
+              <div class='field'>
+                <div class='resource-spinner'>
+                  <button data-operation='ci-days-dec'><i class="fas fa-caret-left"></i></button>
+                  <input class="gcs-attr-input" name="data.conditionalinjury.injury.daystoheal" type="text"
+                    value="{{data.conditionalinjury.injury.daystoheal}}" placeholder="" data-dtype="Number"
+                    data-operation="ci-days-set" />
+                  <button data-operation='ci-days-inc'><i class="fas fa-caret-right"></i></button>
+                </div>
+              </div>
+            </div>
+            <div class='tooltip-wrapper'>
+              <div class="tooltip">Severities
+                <span class="tooltiptext">
+                  <div class="fieldblock">
+                    {{#ciSeveritiesTooltip}}
+                    <div class="field condensed noedit">{{severity}}</div>
+                    <div class="label">{{label}}</div>
+                    {{/ciSeveritiesTooltip}}
+                  </div>
+                </span>
+              </div>
+            </div>
+            <div class='condition-block'>
+              <div class='basic-value fieldblock3'>
+                <div class="points">[{{data.conditionalinjury.RT.points}}]</div>
+                <div class='field'>{{data.conditionalinjury.RT.value}}</div>
+                <div class='field'>RT</div>
+              </div>
+              <div class='condition {{ciCurrentGrossEffects data.conditionalinjury.injury.severity "style"}}'>
+                {{ciCurrentGrossEffects data.conditionalinjury.injury.severity "label"}}</div>
+              <button class='reset' data-operation='ci-reset'><i class="fas fa-undo"></i></button>
+            </div>
+          </div>
+          {{else}}
+          <div id='combat-hit' class='tracked-resource' data-gurps-resource='HP'>
+            <div class='header'>Hit Points</div>
+            <div class='spinner'>
+              <button class='decrement' data-operation='resource-dec'><i class="fas fa-minus"></i></button>
+              <input class="gcs-attr-input" name="data.HP.value" type="text" value="{{data.HP.value}}"
+                placeholder="{{data.HP.max}}" data-dtype="Number" />
+              <button class='increment' data-operation='resource-inc'><i class="fas fa-plus"></i></button>
+              <button class='reset' data-operation='resource-reset'><i class="fas fa-undo"></i></button>
+            </div>
+            <div class='condition-block'>
               <div class='tooltip-wrapper'>
-                <div class="tooltip">Thresholds
+                <div class='tooltip condition {{fpCondition data.HP "style"}}'>{{hpCondition data.HP 'label'}}
                   <span class="tooltiptext">
                     <div class="fieldblock">
                       {{#hpBreakpoints data.HP}}
@@ -293,52 +296,48 @@
                   </span>
                 </div>
               </div>
-              <div class='condition-block'>
-                <div class='basic-value fieldblock3'>
-                  <div class="points">[{{data.HP.points}}]</div>
-                  <div class='field'>{{data.HP.max}}</div>
-                  <div class='label'>Basic</div>
-                </div>
-                <div class='condition {{hpCondition data.HP "style"}}'>{{hpCondition data.HP "label"}}</div>
-                <button class='reset' data-operation='resource-reset'><i class="fas fa-undo"></i></button>
+              <div class='basic-value fieldblock3'>
+                <div class="points">[{{data.HP.points}}]</div>
+                <div class='field'>{{data.HP.max}}</div>
+                <div class='label'>Basic</div>
               </div>
             </div>
+          </div>
           {{/if}}
-         <!-- end of combat-hit -->
+          <!-- end of combat-hit -->
 
-          <div id='combat-fat' data-gurps-resource='FP'>
+          <div id='combat-fat' class='tracked-resource' data-gurps-resource='FP'>
             <div class='header'>Fatigue</div>
-            <div class='field'>
-              <div class='resource-spinner'>
-                <button data-operation='resource-dec'><i class="fas fa-caret-left"></i></button>
-                <input class="gcs-attr-input" name="data.FP.value" type="text" value="{{data.FP.value}}"
-                  placeholder="{{data.FP.max}}" data-dtype="Number" />
-                <button data-operation='resource-inc'><i class="fas fa-caret-right"></i></button>
-              </div>
-            </div>
-            <div class='tooltip-wrapper'>
-              <div class="tooltip">Thresholds
-                <span class="tooltiptext">
-                  <div class="fieldblock">
-                    {{#fpBreakpoints data.FP}}
-                    <div class="field condensed noedit">{{breakpoint}}</div>
-                    <div class="label {{style}}">{{label}}</div>
-                    {{/fpBreakpoints}}
-                  </div>
-                </span>
-              </div>
+            <div class='spinner'>
+              <button class='decrement' data-operation='resource-dec'><i class="fas fa-minus"></i></button>
+              <input class="gcs-attr-input" name="data.FP.value" type="text" value="{{data.FP.value}}"
+                placeholder="{{data.FP.max}}" data-dtype="Number" />
+              <button class='increment' data-operation='resource-inc'><i class="fas fa-plus"></i></button>
+              <button class='reset' data-operation='resource-reset'><i class="fas fa-undo"></i></button>
             </div>
             <div class='condition-block'>
+              <div class='tooltip-wrapper'>
+                <div class='tooltip condition {{fpCondition data.FP "style"}}'>{{fpCondition data.FP 'label'}}
+                  <span class="tooltiptext">
+                    <div class="fieldblock">
+                      {{#fpBreakpoints data.FP}}
+                      <div class="field condensed noedit">{{breakpoint}}</div>
+                      <div class="label {{style}}">{{label}}</div>
+                      {{/fpBreakpoints}}
+                    </div>
+                  </span>
+                </div>
+              </div>
               <div class='basic-value fieldblock3'>
                 <div class="points">[{{data.FP.points}}]</div>
                 <div class='field'>{{data.FP.max}}</div>
                 <div class='label'>Basic</div>
               </div>
-              <div class='condition {{fpCondition data.FP "style"}}'>{{fpCondition data.FP 'label'}}</div>
-              <button class='reset' data-operation='resource-reset'><i class="fas fa-undo"></i></button>
             </div>
           </div> <!-- combat-fat -->
         </div>
+
+        <div></div>
 
         <div id='resources'>
           <div class="header" style="grid-column: 1 / span 2;">Resource Trackers</div>
@@ -346,26 +345,21 @@
           {{#each data.additionalresources.tracker}}
           <div class='tracked-resource {{#unless name}}inactive{{/unless}}'
             data-gurps-resource='additionalresources.tracker.{{@index}}'>
-            <div class='header'>{{#if name}}{{name}}{{else}}Resource
-              {{@index}}{{/if}}</div>
-            <div class='field'>
-              <div class='resource-spinner'>
-                <button data-operation='resource-dec'><i class="fas fa-caret-left"></i></button>
-                <input class="gcs-attr-input {{#if max}}
-                {{#unless (gt value min)}}depleted{{/unless}}
-                {{/if}}" name="data.additionalresources.tracker.{{@index}}.value" type="text" value="{{value}}"
-                  placeholder="0" data-dtype="Number" />
-                <button data-operation='resource-inc'><i class="fas fa-caret-right"></i></button>
-              </div>
+            <div class='header'>
+              {{#if name}}{{name}}{{else}}Resource {{@index}}{{/if}}<span class='edit'><i
+                  class='fas fa-pencil-alt'></i></span>
+            </div>
+            <div class='spinner'>
+              <button class='decrement' data-operation='resource-dec'><i class="fas fa-minus"></i></button>
+              <input class="gcs-attr-input" name="data.additionalresources.tracker.{{@index}}.value" type="text"
+                value="{{value}}" placeholder="0" data-dtype="Number" />
+              <button class='increment' data-operation='resource-inc'><i class="fas fa-plus"></i></button>
+              <button class='reset' data-operation='resource-reset'><i class="fas fa-undo"></i></button>
             </div>
             <div class='condition-block'>
-              <div class='basic-value fieldblock3'>
-                <div class='points'>[{{points}}]</div>
-                <div class='field'>{{max}}</div>
-                <div class='label'>Max</div>
-              </div>
-              <div class='condition'></div>
-              <button class='reset' data-operation='resource-reset'><i class="fas fa-undo"></i></button>
+              <div class='condition {{#if (gt value max)}}above{{else}}{{#if (lt value min)}}below{{/if}}{{/if}}'>{{#if
+                (gt value max)}}Over{{else}}{{#if (lt value min)}}Below{{else}}Normal{{/if}}{{/if}}</div>
+              <div class='max'>[{{min}}/{{max}}]</div>
             </div>
           </div> <!-- end of resource -->
           {{/each}}

--- a/templates/actor-sheet-gcs.html
+++ b/templates/actor-sheet-gcs.html
@@ -226,51 +226,49 @@
       <div id="trackers">
         <div>
           {{#if useCI}}
-          <div id='combat-hit'>
-            <div class='header'>Injury</div>
-            <div class="tracked-resource">
-              <div class="header">Severity</div>
-              <div class='field'>
-                <div class='resource-spinner'>
-                  <button data-operation='ci-severity-dec'><i class="fas fa-caret-left"></i></button>
-                  <input class="gcs-attr-input" name="data.conditionalinjury.injury.severity" type="text"
-                    value="{{data.conditionalinjury.injury.severity}}" placeholder="" data-dtype="String"
-                    data-operation="ci-severity-set" />
-                  <button data-operation='ci-severity-inc'><i class="fas fa-caret-right"></i></button>
-                </div>
+          <div id='combat-hit' class='conditional-injury'>
+            <div class='header major-heading'>Injury</div>
+            <div class="tracked-resource no-border">
+              <div class="header minor-heading">Severity</div>
+              <div class='spinner'>
+                <button class='decrement' data-operation='ci-severity-dec'><i class="fas fa-minus"></i></button>
+                <input class="gcs-attr-input" name="data.conditionalinjury.injury.severity" type="text"
+                  value="{{data.conditionalinjury.injury.severity}}" data-dtype="String"
+                  data-operation="ci-severity-set" />
+                <button class='increment' data-operation='ci-severity-inc'><i class="fas fa-plus"></i></button>
+                <button class='reset' data-operation='ci-reset'><i class="fas fa-undo"></i></button>
               </div>
-              <div class="header">Days to Heal</div>
-              <div class='field'>
-                <div class='resource-spinner'>
-                  <button data-operation='ci-days-dec'><i class="fas fa-caret-left"></i></button>
-                  <input class="gcs-attr-input" name="data.conditionalinjury.injury.daystoheal" type="text"
-                    value="{{data.conditionalinjury.injury.daystoheal}}" placeholder="" data-dtype="Number"
-                    data-operation="ci-days-set" />
-                  <button data-operation='ci-days-inc'><i class="fas fa-caret-right"></i></button>
-                </div>
+              <div class="header minor-heading">Time to Heal</div>
+              <div class='spinner'>
+                <button class='decrement' data-operation='ci-days-dec'><i class="fas fa-minus"></i></button>
+                <input class="gcs-attr-input" name="data.conditionalinjury.injury.daystoheal" type="text"
+                  value="{{data.conditionalinjury.injury.daystoheal}}" placeholder="" data-dtype="Number"
+                  data-operation="ci-days-set" />
+                <button class='increment' data-operation='ci-days-inc'><i class="fas fa-plus"></i></button>
+                <div style='font-size: 85%;'>&nbsp;Days</div>
               </div>
-            </div>
-            <div class='tooltip-wrapper'>
-              <div class="tooltip">Severities
-                <span class="tooltiptext">
-                  <div class="fieldblock">
-                    {{#ciSeveritiesTooltip}}
-                    <div class="field condensed noedit">{{severity}}</div>
-                    <div class="label">{{label}}</div>
-                    {{/ciSeveritiesTooltip}}
+
+              <div class='condition-block'>
+                <div class='tooltip-wrapper'>
+                  <div
+                    class='tooltip condition {{ciCurrentGrossEffects data.conditionalinjury.injury.severity "style"}}'>
+                    {{ciCurrentGrossEffects data.conditionalinjury.injury.severity "label"}}
+                    <span class="tooltiptext">
+                      <div class="fieldblock">
+                        {{#ciSeveritiesTooltip}}
+                        <div class="field condensed noedit">{{severity}}</div>
+                        <div class="label">{{label}}</div>
+                        {{/ciSeveritiesTooltip}}
+                      </div>
+                    </span>
                   </div>
-                </span>
+                </div>
+                <div class='basic-value fieldblock3'>
+                  <div class="points">[{{data.conditionalinjury.RT.points}}]</div>
+                  <div class='field'>{{data.conditionalinjury.RT.value}}&nbsp;RT</div>
+                  <div class='label'>{{data.HP.max}}&nbsp;HP</div>
+                </div>
               </div>
-            </div>
-            <div class='condition-block'>
-              <div class='basic-value fieldblock3'>
-                <div class="points">[{{data.conditionalinjury.RT.points}}]</div>
-                <div class='field'>{{data.conditionalinjury.RT.value}}</div>
-                <div class='field'>RT</div>
-              </div>
-              <div class='condition {{ciCurrentGrossEffects data.conditionalinjury.injury.severity "style"}}'>
-                {{ciCurrentGrossEffects data.conditionalinjury.injury.severity "label"}}</div>
-              <button class='reset' data-operation='ci-reset'><i class="fas fa-undo"></i></button>
             </div>
           </div>
           {{else}}
@@ -357,7 +355,8 @@
               <button class='reset' data-operation='resource-reset'><i class="fas fa-undo"></i></button>
             </div>
             <div class='condition-block'>
-              <div class='condition {{#if (gt value max)}}above{{else}}{{#if (lt value min)}}below{{/if}}{{/if}}'>{{#if
+              <div class='condition {{#if (gt value max)}}above{{else}}{{#if (lt value min)}}below{{/if}}{{/if}}'>
+                {{#if
                 (gt value max)}}Over{{else}}{{#if (lt value min)}}Below{{else}}Normal{{/if}}{{/if}}</div>
               <div class='max'>[{{min}}/{{max}}]</div>
             </div>

--- a/templates/actor-sheet-gcs.html
+++ b/templates/actor-sheet-gcs.html
@@ -227,6 +227,7 @@
         <div>
           {{#if useCI}}
           <div id='combat-hit' class='conditional-injury'>
+            {{#with data.conditionalinjury}}
             <div class='header major-heading'>Injury</div>
             <div class="tracked-resource no-border">
               <div class="header minor-heading">Severity</div>
@@ -241,18 +242,15 @@
               <div class="header minor-heading">Time to Heal</div>
               <div class='spinner'>
                 <button class='decrement' data-operation='ci-days-dec'><i class="fas fa-minus"></i></button>
-                <input class="gcs-attr-input" name="data.conditionalinjury.injury.daystoheal" type="text"
-                  value="{{data.conditionalinjury.injury.daystoheal}}" placeholder="" data-dtype="Number"
-                  data-operation="ci-days-set" />
+                <input class="gcs-attr-input" name="injury.daystoheal" type="text" value="{{injury.daystoheal}}"
+                  placeholder="" data-dtype="Number" data-operation="ci-days-set" />
                 <button class='increment' data-operation='ci-days-inc'><i class="fas fa-plus"></i></button>
                 <div style='font-size: 85%;'>&nbsp;Days</div>
               </div>
-
               <div class='condition-block'>
                 <div class='tooltip-wrapper'>
-                  <div
-                    class='tooltip condition {{ciCurrentGrossEffects data.conditionalinjury.injury.severity "style"}}'>
-                    {{ciCurrentGrossEffects data.conditionalinjury.injury.severity "label"}}
+                  <div class='tooltip condition {{ciCurrentGrossEffects injury.severity "style"}}'>
+                    {{ciCurrentGrossEffects injury.severity "label"}}
                     <span class="tooltiptext">
                       <div class="fieldblock">
                         {{#ciSeveritiesTooltip}}
@@ -264,12 +262,13 @@
                   </div>
                 </div>
                 <div class='basic-value fieldblock3'>
-                  <div class="points">[{{data.conditionalinjury.RT.points}}]</div>
-                  <div class='field'>{{data.conditionalinjury.RT.value}}&nbsp;RT</div>
-                  <div class='label'>{{data.HP.max}}&nbsp;HP</div>
+                  <div class="points">[{{#if RT.points}}{{RT.points}}{{else}}{{../data.HP.points}}{{/if}}]</div>
+                  <div class='field'>{{RT.value}}&nbsp;RT</div>
+                  <div class='label'>{{../data.HP.max}}&nbsp;HP</div>
                 </div>
               </div>
             </div>
+            {{/with}}
           </div>
           {{else}}
           <div id='combat-hit' class='tracked-resource' data-gurps-resource='HP'>
@@ -358,7 +357,7 @@
               <div class='condition {{#if (gt value max)}}above{{else}}{{#if (lt value min)}}below{{/if}}{{/if}}'>
                 {{#if
                 (gt value max)}}Over{{else}}{{#if (lt value min)}}Below{{else}}Normal{{/if}}{{/if}}</div>
-              <div class='max'>[{{min}}/{{max}}]</div>
+              <div class='max'>({{min}}/{{max}})</div>
             </div>
           </div> <!-- end of resource -->
           {{/each}}

--- a/templates/actor-sheet-gcs.html
+++ b/templates/actor-sheet-gcs.html
@@ -342,7 +342,7 @@
           {{#each data.additionalresources.tracker}}
           <div class='tracked-resource {{#unless name}}inactive{{/unless}}'
             data-gurps-resource='additionalresources.tracker.{{@index}}'>
-            <div class='header'>
+            <div class='header with-editor'>
               {{#if name}}{{name}}{{else}}Resource {{@index}}{{/if}}<span class='edit'><i
                   class='fas fa-pencil-alt'></i></span>
             </div>

--- a/templates/combat-sheet.html
+++ b/templates/combat-sheet.html
@@ -2,53 +2,40 @@
   <div id='responsive' class="gurpsactorsheet">
     <div id='combat-sheet'>
 
-      <!-- <div id='combat-identity'>
-        <div class='header'>Identity</div>
-        <div class='fieldblock'>
-          <div class='label'>Name:</div>
-          <div class='field'>{{actor.name}}</div>
-          <div class="label">Title:</div>
-          <div class="field">{{data.traits.title}}</div>
-          <div class='label'>Player:</div>
-          <div class='field'>{{data.traits.player}}</div>
-        </div>
-      </div> -->
-      <!-- end of identity-->
-
       <div id='combat-hitfat'>
-        <div id='combat-hit' data-gurps-resource='HP'>
+        <div id='combat-hit' class='tracked-resource' data-gurps-resource='HP'>
           <div class='header'>Hit Points</div>
-          <div class='field'>
-            <div class='resource-spinner'>
-              <button data-operation='resource-dec'><i class="fas fa-caret-left"></i></button>
-              <input class="gcs-attr-input" name="data.HP.value" type="text" value="{{data.HP.value}}"
-                placeholder="{{data.HP.max}}" data-dtype="Number" />
-              <button data-operation='resource-inc'><i class="fas fa-caret-right"></i></button>
-            </div>
+          <div class='spinner'>
+            <button class='decrement' data-operation='resource-dec'><i class="fas fa-minus"></i></button>
+            <input class="gcs-attr-input" name="data.HP.value" type="text" value="{{data.HP.value}}"
+              placeholder="{{data.HP.max}}" data-dtype="Number" />
+            <button class='increment' data-operation='resource-inc'><i class="fas fa-plus"></i></button>
+            <button class='reset' data-operation='resource-reset'><i class="fas fa-undo"></i></button>
           </div>
           <div class='condition-block'>
-            <div class='basic-value'>{{data.HP.max}}</div>
-            <div class='basic-label'>Basic</div>
+            <div class='basic-value fieldblock'>
+              <div class='field'>{{data.HP.max}}</div>
+              <div class='label'>Basic</div>
+            </div>
             <div class='condition {{hpCondition data.HP "style"}}'>{{hpCondition data.HP "label"}}</div>
-            <button class='reset' data-operation='resource-reset'><i class="fas fa-undo"></i></button>
           </div>
         </div> <!-- end of combat-hit -->
 
-        <div id='combat-fat' data-gurps-resource='FP'>
+        <div id='combat-fat' class='tracked-resource' data-gurps-resource='FP'>
           <div class='header'>Fatigue</div>
-          <div class='field'>
-            <div class='resource-spinner'>
-              <button data-operation='resource-dec'><i class="fas fa-caret-left"></i></button>
-              <input class="gcs-attr-input" name="data.FP.value" type="text" value="{{data.FP.value}}"
-                placeholder="{{data.FP.max}}" data-dtype="Number" />
-              <button data-operation='resource-inc'><i class="fas fa-caret-right"></i></button>
-            </div>
+          <div class='spinner'>
+            <button class='decrement' data-operation='resource-dec'><i class="fas fa-minus"></i></button>
+            <input class="gcs-attr-input" name="data.FP.value" type="text" value="{{data.FP.value}}"
+              placeholder="{{data.FP.max}}" data-dtype="Number" />
+            <button class='increment' data-operation='resource-inc'><i class="fas fa-plus"></i></button>
+            <button class='reset' data-operation='resource-reset'><i class="fas fa-undo"></i></button>
           </div>
           <div class='condition-block'>
-            <div class='basic-value'>{{data.FP.max}}</div>
-            <div class='basic-label'>Basic</div>
+            <div class='basic-value fieldblock'>
+              <div class='field'>{{data.FP.max}}</div>
+              <div class='label'>Basic</div>
+            </div>
             <div class='condition {{fpCondition data.FP "style"}}'>{{fpCondition data.FP 'label'}}</div>
-            <button class='reset' data-operation='resource-reset'><i class="fas fa-undo"></i></button>
           </div>
         </div> <!-- combat-fat -->
       </div>
@@ -59,22 +46,20 @@
         <div class='tracked-resource {{#unless name}}inactive{{/unless}}'
           data-gurps-resource='additionalresources.tracker.{{@index}}'>
           <div class='header'>{{#if name}}{{name}}{{else}}Resource {{@index}}{{/if}}</div>
-          <div class='field'>
-            <div class='resource-spinner'>
-              <button data-operation='resource-dec'><i class="fas fa-caret-left"></i></button>
-
-              <input class="gcs-attr-input {{#if max}}
+          <div class='spinner'>
+            <button class='decrement' data-operation='resource-dec'><i class="fas fa-minus"></i></button>
+            <input class="gcs-attr-input {{#if max}}
               {{#unless (gt value min)}}depleted{{/unless}}
               {{/if}}" name="data.additionalresources.tracker.{{@index}}.value" type="text" value="{{value}}"
-                placeholder="0" data-dtype="Number" />
-              <button data-operation='resource-inc'><i class="fas fa-caret-right"></i></button>
-            </div>
+              placeholder="0" data-dtype="Number" />
+            <button class='increment' data-operation='resource-inc'><i class="fas fa-plus"></i></button>
+            <button class='reset' data-operation='resource-reset'><i class="fas fa-undo"></i></button>
           </div>
           <div class='condition-block'>
-            <div class='basic-value'>{{max}}</div>
-            <div class='basic-label'>Max</div>
-            <div class='condition'></div>
-            <button class='reset' data-operation='resource-reset'><i class="fas fa-undo"></i></button>
+            <div class='condition {{#if (gt value max)}}above{{else}}{{#if (lt value min)}}below{{/if}}{{/if}}'>
+              {{#if
+              (gt value max)}}Over{{else}}{{#if (lt value min)}}Below{{else}}Normal{{/if}}{{/if}}</div>
+            <div class='max'>({{min}}/{{max}})</div>
           </div>
         </div> <!-- end of resource -->
         {{/each}}

--- a/templates/resource-editor-popup.html
+++ b/templates/resource-editor-popup.html
@@ -1,0 +1,13 @@
+<div class='resource-editor' style='border: none;'>
+  <div class='name'>
+    <input class="gcs-input" type="text" value="{{name}}" placeholder="Resource Name">
+  </div>
+  <div class='inputs'>
+    <input class="current gcs-input" type="text" value="{{value}}" data-dtype="Number" />
+    <div class="label">Current</div>
+    <input class="minimum gcs-input" type="text" value="{{min}}" data-dtype="Number" />
+    <div class="label">Minimum</div>
+    <input class="maximum gcs-input" type="text" value="{{max}}" data-dtype="Number" />
+    <div class="label">Maximum</div>
+  </div>
+</div>


### PR DESCRIPTION
- Rework the look of the resource trackers and HP/FP trackers to make them more compact. 
- Remove the cp entry fields on resource tracker editors.
- Display the current resource tracker thresholds. Right now, that is only "Below" (value is below the minimum), "Over" (value is over the maximum), or "Normal". Below and Over are highlighted in color. (Should I make "Normal" green, just like the FP/HP tracker?)
- User can directly edit the trackers in Full view without going to the editor: the header of the resource tracker has a pencil icon, and glows when hovering over it. Clicking will bring up a popup editor for that tracker.