### PR TITLE
0.8.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Users Guide for [GURPS 4e game aid for Foundry VTT](https://bit.ly/2JaSlQd)
 
-# Current Release Version 0.8.8
+# Current Release Version 0.8.9
 [If you like our work...](https://ko-fi.com/crnormand)
 
 <a href="https://ko-fi.com/crnormand"><img height="36" src="https://cdn.ko-fi.com/cdn/kofi2.png?v=2"></a>
@@ -18,6 +18,9 @@ To install the latest stable release, use this manifest URL:
 
 This is what we are currently working on:
 
+- 0.8.10
+
+### History
 - 0.8.9
     - Added individual die results to Roll Chat messages (e.g., "Rolled (3, 6, 1) = 10").
     - Fixed CGA export to correctly export ranged innate attacks.
@@ -28,7 +31,6 @@ This is what we are currently working on:
     - Added drag and drop menu 'before' and 'in' for all lists so you can create containers
     - Allow user created notes & equipment to survive import
 
-### History
 - 0.8.8
     - Fixed [Parry] bug (if Parry column has "No" in it)
     - Added "Send to 'Everyone'" GM option in modifier bucket

--- a/system.json
+++ b/system.json
@@ -2,14 +2,13 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT (GCS/GCA edition)",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "minimumCoreVersion": "0.7.5",
   "compatibleCoreVersion": "0.7.9",
   "templateVersion": 2,
   "author": "Chris Normand/Nose66",
   "esmodules": [
     "module/gurps.js",
-    "lib/SSRT/main.js",
     "lib/parselink.js",
     "lib/applydamage.js"
   ],
@@ -38,6 +37,6 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.8.8.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.8.9.zip",
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
    - Added individual die results to Roll Chat messages (e.g., "Rolled (3, 6, 1) = 10").
    - Fixed CGA export to correctly export ranged innate attacks.
    - Added Equipment hierarchy to GCA export
    - Support GCS v4.27, export hierarchy for Ads/Disads, Skills, Spells and Notes
    - Added Page Refs for Notes
    - Added collapsible carets for Ads/Disads, Skills, Spells, Notes & Equipment
    - Added drag and drop menu 'before' and 'in' for all lists so you can create containers
    - Allow user created notes & equipment to survive import
