### PR TITLE
sanitize input for cost values over 999

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -501,7 +501,7 @@ export class GurpsActor extends Actor {
         let eqt = new Equipment();
         eqt.name = t(j.name);
         eqt.count = i(j.count);
-        eqt.cost = t(j.cost);
+        eqt.cost = t(j.cost).replace(',', '');
         eqt.weight = t(j.weight);
         eqt.location = t(j.location);
         let cstatus = i(j.carried);

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1035,8 +1035,9 @@ Hooks.once("init", async function () {
   let src = 'systems/gurps/icons/gurps4e.png';
   if (game.i18n.lang == "pt_br")
     src = 'systems/gurps/icons/gurps4e-pt_br.png';
-  $('#logo').attr('src', src);
-  $('#logo').attr('width', '100px');
+  
+  const logo = document.querySelector("#logo");
+  logo.setAttribute('src', src);
   
   // Define custom Entity classes
   CONFIG.Actor.entityClass = GurpsActor;

--- a/styles/css_boilerplate.css
+++ b/styles/css_boilerplate.css
@@ -1,6 +1,11 @@
 @import url("https://fonts.googleapis.com/css2?family=Martel:wght@400;800&family=Roboto:wght@300;400;500&display=swap");
 
 /* Global styles */
+#navigation {
+  top: 20px; left: 190px;
+  width: calc(100% - 510px); 
+}
+
 .window-app {
   font-family: "Roboto", sans-serif;
 }


### PR DESCRIPTION
A cheesy/quick fix for sanitizing input values for the `cost` property of Equipment. This is mainly because the check performed here evaluates strings with commas as `NaN`:
https://github.com/crnormand/gurps/blob/6bb715fc98f8183b113880da16888660e8edaf33/module/actor.js#L1223

The end result of this bug was that all equipment imported that was valued at over $999 was being treated as 0.

Related issue: https://github.com/crnormand/gurps/issues/229