### PR TITLE
Sanitize input for imported equipment values over 999

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -500,9 +500,9 @@ export class GurpsActor extends Actor {
         let j = json[key];
         let eqt = new Equipment();
         eqt.name = t(j.name);
-        eqt.count = i(j.count);
-        eqt.cost = t(j.cost);
-        eqt.weight = t(j.weight);
+        eqt.count = i(j.count).replace(',', '');
+        eqt.cost = t(j.cost).replace(',', '');
+        eqt.weight = t(j.weight).replace(',', '');
         eqt.location = t(j.location);
         let cstatus = i(j.carried);
         eqt.carried = (cstatus >= 1);


### PR DESCRIPTION
A cheesy/quick fix for sanitizing input values for the `cost` property of Equipment. This is mainly because the check performed here evaluates strings with commas as `NaN`:
https://github.com/crnormand/gurps/blob/6bb715fc98f8183b113880da16888660e8edaf33/module/actor.js#L1223

The end result of this bug was that all equipment imported that was valued at over $999 was being treated as 0.

Related issue: https://github.com/crnormand/gurps/issues/229