### PR TITLE
Fix logo aspect ratio and adapt navigation

### DIFF
--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1035,9 +1035,10 @@ Hooks.once("init", async function () {
   let src = 'systems/gurps/icons/gurps4e.png';
   if (game.i18n.lang == "pt_br")
     src = 'systems/gurps/icons/gurps4e-pt_br.png';
-  $('#logo').attr('src', src);
-  $('#logo').attr('width', '100px');
-  
+
+  const logo = document.querySelector("#logo");
+  logo.setAttribute('src', src);
+
   // Define custom Entity classes
   CONFIG.Actor.entityClass = GurpsActor;
   CONFIG.Item.entityClass = GurpsItem;

--- a/styles/css_boilerplate.css
+++ b/styles/css_boilerplate.css
@@ -1,6 +1,11 @@
 @import url("https://fonts.googleapis.com/css2?family=Martel:wght@400;800&family=Roboto:wght@300;400;500&display=swap");
 
 /* Global styles */
+#navigation {
+  top: 20px; left: 190px;
+  width: calc(100% - 510px); 
+}
+
 .window-app {
   font-family: "Roboto", sans-serif;
 }


### PR DESCRIPTION
I noticed that the GURPS logo was compressed when it was added in the last update so I made some tweaks to fix that. Nothing personal but JQuery makes me itch, so I swapped that out in gurps.js for perfectly good JS.

Here's what the update looks like:
![Screenshot_20210129_220313](https://user-images.githubusercontent.com/28788713/106348793-ce821e00-627d-11eb-9f0c-258f3fe8fca8.png)
