### PR TITLE
Improve portrait styles & markup

### DIFF
--- a/styles/css_boilerplate.css
+++ b/styles/css_boilerplate.css
@@ -5,6 +5,15 @@
   font-family: "Roboto", sans-serif;
 }
 
+
+.directory-list > .directory-item.actor {
+  align-items: center;
+}
+
+.directory-list > .directory-item.actor > .profile.actor-profile {
+  height: initial;
+}
+
 .rollable:hover,
 .rollable:focus {
   color: #000;

--- a/styles/simple.css
+++ b/styles/simple.css
@@ -689,12 +689,18 @@
   margin-bottom: 10px;
 }
 
-.gurps .profile-img {
-  flex: 0 0 100px;
+.gurps #portrait .img-display {
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  width: 112.25px;
+}
+
+.gurps #portrait .profile-img {
+  display: block;
   height: 100%;
+  opacity: 0;
   width: 100%;
-  min-width: 100px;
-  margin-right: 10px;
 }
 
 .gurps .sheet-header .header-fields {

--- a/templates/actor-sheet-gcs-editor.html
+++ b/templates/actor-sheet-gcs-editor.html
@@ -3,7 +3,9 @@
     <div id="personal">
       <div id="portrait">
         <div class="header">Portrait</div>
-        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100" />
+        <div class="img-display" style="background-image: url({{ actor.img }});">
+          <img class="profile-img" src="{{ actor.img }}" data-edit="img" title="{{actor.name}}" />
+        </div>
       </div>
       <div id="identity">
         <div class="header">Identity</div>

--- a/templates/actor-sheet-gcs.html
+++ b/templates/actor-sheet-gcs.html
@@ -3,7 +3,9 @@
     <div id="personal">
       <div id="portrait">
         <div class="header">{{localize "GURPS.portrait"}}</div>
-        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100" />
+        <div class="img-display" style="background-image: url({{ actor.img }});">
+          <img class="profile-img" src="{{ actor.img }}" data-edit="img" title="{{actor.name}}" />
+        </div>
       </div>
       <div id="identity">
         <div class="header">{{localize "GURPS.identity"}}</div>


### PR DESCRIPTION
As per: https://github.com/crnormand/gurps/issues/147 I have refactored the sheet portraits and directory-list portraits to adhere to the GCS portrait ratio of 3:4.

Instead of using a classic static image, we're using a container with a fixed width and a background-image that's set to cover the center of said container. 

What this will hopefully do is make it so that images that look good in GCS will also look good in Game Assistant. For all other portrait images, they will crop as best as they can in the middle of the image.

The directory list's portrait height is uncapped to allow non-square images to fit there. This sacrifices uniformity a little as varied image ratios will be noticeable, but at least we're not cropping to the mouth and up.

Examples:

![Screenshot_20210130_005151](https://user-images.githubusercontent.com/28788713/106352298-c682a800-6296-11eb-84fa-d0efb32fcc1d.png)

![Screenshot_20210130_005215](https://user-images.githubusercontent.com/28788713/106352301-cc788900-6296-11eb-9cdf-66701ab9dd64.png)
