### PR TITLE
0.8.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Users Guide for [GURPS 4e game aid for Foundry VTT](https://bit.ly/2JaSlQd)
 
-# Current Release Version 0.8.10
+# Current Release Version 0.8.11
 [If you like our work...](https://ko-fi.com/crnormand)
 
 <a href="https://ko-fi.com/crnormand"><img height="36" src="https://cdn.ko-fi.com/cdn/kofi2.png?v=2"></a>
@@ -14,10 +14,13 @@ Join us on Discord: [GURPS Foundry-VTT Discord](https://discord.gg/7qzzgJDT)
 
 ## The 'main' branch is being actively developed... and it may break things.   
 ### If you are looking for the latest stable release, use the manifest URL above.
-[Current GCA Export version: GCA-2 1/29/2021 / Current GCS Export version: GCS-3 1/31/2021](https://drive.google.com/file/d/1vbDb9WtYQiZI78Pwa_TlEvYpJnR_S67B/view?usp=sharing)
+[Current GCA Export version: GCA-3 2/04/2021 / Current GCS Export version: GCS-3 1/31/2021](https://drive.google.com/file/d/1vbDb9WtYQiZI78Pwa_TlEvYpJnR_S67B/view?usp=sharing)
 
 This is what we are currently working on:
 
+- 0.8.12
+
+### History
 - 0.8.11
     - Fixed the z-index of the modifier bucket (it no longer displays on top of everything!)
     - Ongoing internationalization effort by @Gus
@@ -31,8 +34,9 @@ This is what we are currently working on:
     - Copy to chat input (GM Send).   Can't do clipboard
     - Chat command /:<macro name> - call macro
     - OtF formula [/<chat command>] execute chat command as a button
+    - Fixed GCA export, ranged attacks in the melee list and sanitize pagerefs
+    - Enhanced the import error warnings
  
-### History
 - 0.8.10 - 1/30/2021
     - @Tratz equipment bug fix, portrait fix and logo fix!
     - Bug fix for OtF formulas in Skills/Spells in containers

--- a/exportutils/export to Foundry VTT.gce
+++ b/exportutils/export to Foundry VTT.gce
@@ -7,7 +7,7 @@
 'By Brian Ronnle, enhanced for Foundry VTT by Chris Normand/Nose66
 'Based on the original export filter by Graham Brand (Spyke)
 '
-Const LastUpdated = 20210126
+Const LastUpdated = 20210204
 ' Last Updated: Nov 25, 2020
 ' v1
 '
@@ -41,7 +41,7 @@ Sub Main()
 
     ' begin the xml file
     Paragraph = "<?xml version=""1.0"" encoding=""iso-8859-1""?>"
-    Paragraph = "<root release=""Foundry"" version=""GCA-2"">"
+    Paragraph = "<root release=""Foundry"" version=""GCA-3"">"
     Paragraph = "<character>"
 
     ' in Fantasy Grounds the <name> field must be at the top level
@@ -1017,6 +1017,10 @@ Sub PrintHandWeapons()
         If Char.Items(i).TagItem("charreach") <> "" Then
             okay = True
         End If
+	  'that don't have a range
+        If Char.Items(i).DamageModeTagItemCount("charrangemax") > 0 Then
+            okay = False
+        End If
 
         'exclude hidden items
         If Char.Items(CurItem).TagItem("hide") <> "" Then
@@ -1322,9 +1326,9 @@ Sub PrintEquipment()
                 Paragraph = "<cost type=""string"">" & StrToDbl(Char.Items(i).tagitem("cost")) / qty & "</cost>"
                 Paragraph = "<weight type=""number"">" & StrToDbl(Char.Items(i).tagitem("weight")) / qty & "</weight>"
                 Paragraph = "<location type=""string"">" & Char.Items(i).tagitem("location") & "</location>"
-                Paragraph = "<notes type=""formattedtext"">" & Char.Items(i).tagitem("description") & "</notes>"
+                Paragraph = "<notes type=""formattedtext"">" & UpdateEscapeChars(Char.Items(i).tagitem("description")) & "</notes>"
                 Paragraph = "<carried type=""number"">2</carried>"
-                Paragraph = "<pageref type=""string"">" & Char.Items(i).tagitem("page") & "</pageref>"
+                Paragraph = "<pageref type=""string"">" & UpdateEscapeChars(Char.Items(i).tagitem("page")) & "</pageref>"
                 Paragraph = "<parentuuid>" & Char.Items(i).ParentKey & "</parentuuid>"
                 Paragraph = "<uuid>k" & Char.Items(i).idkey & "</uuid>"
                 Paragraph = "</id-" & tag_index & ">"

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT (GCS/GCA edition)",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "minimumCoreVersion": "0.7.5",
   "compatibleCoreVersion": "0.7.9",
   "templateVersion": 2,
@@ -35,6 +35,6 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.8.10.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.8.11.zip",
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
    - Fixed the z-index of the modifier bucket (it no longer displays on top of everything!)
    - Ongoing internationalization effort by @Gus
    - Fixed GCS export to reinstate Self Control Rolls, ex: [CR: 12 Bad Temper] (GCS-3)
    - Added chat command: /everyone <commands> 
    - revamped the chat message handler (it actually works now)
    - Added currentdodge, currentmove, equippedparry and equippedblock attributes (for use with modules like Token Tooltip Alt)
    - Added GM Send function to Journal entries
    - Enhance OtF for damage to allow "*Costs ?FP" [4d-4 burn *Costs 4FP]
    - "Best of" skill or attribute OtF [S:Skillname|DX-2], actually infinite, can be used to try other skills [S:Skill1|S:Skill2|ST|S:Skill3|IQ-4 default]
    - Copy to chat input (GM Send).   Can't do clipboard
    - Chat command /:<macro name> - call macro
    - OtF formula [/<chat command>] execute chat command as a button
    - Fixed GCA export, ranged attacks in the melee list and sanitize pagerefs
    - Enhanced the import error warnings
