### PR TITLE
Rewrite and unify damage parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This is what we are currently working on:
     - Added Mook Generator defaults editor
     - GCA export/import now handles parents for Ads/Disads/Spells and Skills
     - Rewrite of damage parser, more uniform handling of multipliers/divisors, etc.  support for const damage [1 cut]
+    - Don't tell anyone, but we now support any sided dice for non-targeted, non-derived damage rolls [3d4], [2d20 cut]
 
 ### History
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This is what we are currently working on:
     - Fixed actors not having the new calculated values (currentdodge, currentmove, equippedparry, equippedblock)
     - Added Mook Generator defaults editor
     - GCA export/import now handles parents for Ads/Disads/Spells and Skills
+    - Support for const damage [1 cut]
 
 ### History
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This is what we are currently working on:
     - Fixed actors not having the new calculated values (currentdodge, currentmove, equippedparry, equippedblock)
     - Added Mook Generator defaults editor
     - GCA export/import now handles parents for Ads/Disads/Spells and Skills
-    - Support for const damage [1 cut]
+    - Rewrite of damage parser, more uniform handling of multipliers/divisors, etc.  support for const damage [1 cut]
 
 ### History
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -229,6 +229,7 @@
 	"GURPS.forTurns" : "for {turns} turns",
 	"GURPS.suffersA" : "suffers a",
 	"GURPS.for" : "for ",
+  "GURPS.highest" : "Highest",
 	"GURPS.of" : "of ",
 	"GURPS.effectsDoubles" : "doubles",
 	"GURPS.effectsNotApplicableDefenses" : "Does not apply to Active Defenses or other defensive reactions. See ",

--- a/lang/pt_br.json
+++ b/lang/pt_br.json
@@ -229,6 +229,7 @@
   "GURPS.forTurns" : "por {turns} turnos",
   "GURPS.suffersA" : "recebe um ",
   "GURPS.for" : "devido a ",
+  "GURPS.highest" : "Highest",
   "GURPS.of" : "de ",
   "GURPS.effectsDoubles" : "dobra",
   "GURPS.effectsNotApplicableDefenses" : "Não se aplica a Defesas Ativas ou outras reações defensivas. Consulte ",

--- a/lib/parselink.js
+++ b/lib/parselink.js
@@ -2,6 +2,8 @@
 
 import { GURPS } from "../module/gurps.js";
 import { woundModifiers } from '../module/damage/damage-tables.js'
+import { d6ify } from './utilities.js'
+
 
 /* Here is where we do all the work to try to parse the text inbetween [ ].
  Supported formats:
@@ -21,7 +23,7 @@ import { woundModifiers } from '../module/damage/damage-tables.js'
   "modifier", "attribute", "selfcontrol", "damage", "roll", "skill", "pdf"
 */
 
-export const DAMAGE_REGEX = /^(\d+)(d)?6?([-+]\d+)?([xX\*]\d+)? ?(\([.\d]+\))?(!)? ?([^\*]*)(\*[Cc]osts? \d+[Ff][Pp])?$/  
+export const DAMAGE_REGEX = /^(\d+)(d\d*)?([-+]\d+)?([xX\*]\d+)? ?(\([.\d]+\))?(!)? ?([^\*]*)(\*[Cc]osts? \d+[Ff][Pp])?$/  
 export const DMG_INDEX_DICE = 1
 export const DMG_INDEX_D = 2
 export const DMG_INDEX_ADDS = 3
@@ -40,7 +42,7 @@ export function parseForDamage(str) {
   // Straight roll, no damage type. 4d, 2d-1, etc.   Allows "!" suffix to indicate minimum of 1.
   let a = str.match(DAMAGE_REGEX)
   if (!!a) {
-    const D = a[DMG_INDEX_D] || ""  // Can now support non-variable damage '2 cut' or '2x3(1) imp'
+    let D = a[DMG_INDEX_D] || ""  // Can now support non-variable damage '2 cut' or '2x3(1) imp'
     const damageType = !!a[DMG_INDEX_TYPE] ? a[DMG_INDEX_TYPE].trim() : ""
     const woundingModifier = woundModifiers[damageType.toLowerCase()]
     const adds = a[DMG_INDEX_ADDS] || ""
@@ -50,10 +52,12 @@ export function parseForDamage(str) {
     const bang = a[DMG_INDEX_BANG] || ""
     
     if (!woundingModifier) {  // Not one of the recognized damage types. Ignore Armor divisor, but allow multiplier.
+      let dice = (D === 'd') ? d6ify(D) : D
       let action = {
         orig: str,
         type: 'roll',
-        formula: a[DMG_INDEX_DICE] + D + adds + multiplier + bang,
+        displayformula: a[DMG_INDEX_DICE] + D + adds + multiplier + bang,
+        rollformula: a[DMG_INDEX_DICE] + dice + adds + multiplier + bang,
         desc: damageType, // Action description
         costs: a[DMG_INDEX_COST]
       }

--- a/lib/parselink.js
+++ b/lib/parselink.js
@@ -1,6 +1,7 @@
 'use strict'
 
 import { GURPS } from "../module/gurps.js";
+import { woundModifiers } from '../module/damage/damage-tables.js'
 
 /* Here is where we do all the work to try to parse the text inbetween [ ].
  Supported formats:
@@ -83,9 +84,9 @@ export default function parselink(str, htmldesc, clrdmods = false) {
     }
     let def = a[3]
     if (!!def) {
-      def = parselink(def.substr(1))
+      def = parselink(def.substr(1).trim())
       if (def.action?.type == 'skill-spell' || def.action?.type == 'attribute') 
-        spantext += " |" + def.action.spanttext;
+        spantext += " | " + def.action.spanttext;
       else def = {}
     }
     let action = {
@@ -150,11 +151,99 @@ export default function parselink(str, htmldesc, clrdmods = false) {
 
   // Straight roll 4d, 2d-1, etc. Is "damage" if it includes a damage type.  Allows "!" suffix to indicate minimum of 1.
   // Supports:  2d+1x3(5), 4dX2(0.5), etc
-  // Now all processing is delegated to DamageChat; 
-  // this handles both straight die formulas (3d-2) and basic damage formulas (sw+1).
-  let parsedText = GURPS.damageChat.parseLink(str)
-  if (parsedText != str) {
-    return GURPS.damageChat.createAction(str, parsedText)
+  // Straight roll, no damage type. 4d, 2d-1, etc.   Allows "!" suffix to indicate minimum of 1.
+  a = str.match(/^(\d+)(d)?6?([-+]\d+)?([xX\*]\d+)? ?(\([.\d]+\))?(!)? ?([^\*]*)(\*[Cc]osts? \d+[Ff][Pp])?$/)
+  if (!!a) {
+    const INDEX_DICE = 1
+    const INDEX_D = 2
+    const INDEX_ADDS = 3
+    const INDEX_MULTIPLIER = 4
+    const INDEX_DIVISOR = 5
+    const INDEX_BANG = 6
+    const INDEX_TYPE = 7
+    const INDEX_COST = 8
+    
+    const D = a[INDEX_D] || ""  // Can now support non-variable damage '2 cut' or '2x3(1) imp'
+    const damageType = !!a[INDEX_TYPE] ? a[INDEX_TYPE].trim() : ""
+    const woundingModifier = woundModifiers[damageType.toLowerCase()]
+    const adds = a[INDEX_ADDS] || ""
+    let multiplier = a[INDEX_MULTIPLIER] || ""
+    if (!!multiplier && 'Xx'.includes(multiplier[0])) multiplier = '*' + multiplier.substr(1) // Must convert to '*' for Foundry.
+    const divisor = a[INDEX_DIVISOR] || ""
+    const bang = a[INDEX_BANG] || ""
+    
+    if (!woundingModifier) {  // Not one of the recognized damage types. Ignore Armor divisor, but allow multiplier.
+      let action = {
+        orig: str,
+        type: 'roll',
+        formula: a[INDEX_DICE] + D + adds + multiplier + bang,
+        desc: damageType, // Action description
+        costs: a[INDEX_COST]
+      }
+      return {
+        text: gspan(str, action),
+        action: action,
+      }
+    } else {    // Damage roll 1d+2 cut.  
+      let action = {
+        orig: str,
+        type: 'damage',
+        formula: a[INDEX_DICE] + D + adds + multiplier + divisor + bang,
+        damagetype: damageType,
+        costs: a[INDEX_COST]
+      }
+      return {
+        text: gspan(str, action),
+        action: action,
+      }
+    }
+  }
+  
+  a = str.match(/^(SW|Sw|sw|THR|Thr|thr)([-+]\d+)?([xX\*]\d+)? ?(\([.\d]+\))?(!)? ?([^\*]*)(\*[Cc]osts? \d+[Ff][Pp])?$/)
+  if (!!a) {
+    const INDEX_BASICDAMAGE = 1
+    const INDEX_ADDS = 2
+    const INDEX_MULTIPLIER = 3
+    const INDEX_DIVISOR = 4
+    const INDEX_BANG = 5
+    const INDEX_TYPE = 6
+    const INDEX_COST = 7
+    const basic = a[INDEX_BASICDAMAGE].toLowerCase()
+    const damageType = !!a[INDEX_TYPE] ? a[INDEX_TYPE].trim().toLowerCase() : ""
+    const woundingModifier = woundModifiers[damageType]
+    const adds = a[INDEX_ADDS] || ""
+    let multiplier = a[INDEX_MULTIPLIER] || ""
+    if (!!multiplier && 'Xx'.includes(multiplier[0])) multiplier = '*' + multiplier.substr(1) // Must convert to '*' for Foundry.
+    const divisor = a[INDEX_DIVISOR] || ""
+    const bang = a[INDEX_BANG] || ""
+
+    if (!!woundingModifier) {
+      let action = {
+        orig: str,
+        type: 'deriveddamage',
+        derivedformula: basic,
+        formula: adds + multiplier + bang,
+        damagetype: damageType,
+        costs: a[INDEX_COST]
+      }
+      return {
+        text: gspan(str, action),
+        action: action,
+      }
+    } else {
+      let action = {
+        orig: str,
+        type: 'derivedroll',
+        derivedformula: basic,
+        formula: adds + multiplier + divisor + bang,
+        desc: damageType,
+        costs: a[INDEX_COST]
+      }
+      return {
+        text: gspan(str, action),
+        action: action,
+      }
+    }
   }
 
   // for PDF link
@@ -189,9 +278,9 @@ export default function parselink(str, htmldesc, clrdmods = false) {
       }
       let def = a[3]
       if (!!def) {
-        def = parselink(def.substr(1))
+        def = parselink(def.substr(1).trim())
         if (def.action?.type == 'skill-spell' || def.action?.type == 'attribute') 
-          spantext += " |" + def.action.spanttext;
+          spantext += " | " + def.action.spanttext;
         else def = {}
       }
       let prefix = brtxt + "<b>S:</b>"

--- a/lib/parselink.js
+++ b/lib/parselink.js
@@ -31,8 +31,91 @@ export const DMG_INDEX_BANG = 6
 export const DMG_INDEX_TYPE = 7
 export const DMG_INDEX_COST = 8
 
-export const DERIVED_DAMAGE_REGEX = /^(SW|Sw|sw|THR|Thr|thr)()([-+]\d+)?([xX\*]\d+)? ?(\([.\d]+\))?(!)? ?([^\*]*)(\*[Cc]osts? \d+[Ff][Pp])?$/ // have fake 2 element so indexes match
+export const DERIVED_DAMAGE_REGEX = /^(SW|Sw|sw|THR|Thr|thr)()([-+]\d+)?([xX\*]\d+)? ?(\([.\d]+\))?(!)? ?([^\*]*)(\*[Cc]osts? \d+[Ff][Pp])?$/ // have fake 2nd element so indexes match
 export const DMG_INDEX_BASICDAMAGE = 1
+
+export function parseForDamage(str) {
+  // Straight roll 4d, 2d-1, etc. Is "damage" if it includes a damage type.  Allows "!" suffix to indicate minimum of 1.
+  // Supports:  2d+1x3(5), 4dX2(0.5), etc
+  // Straight roll, no damage type. 4d, 2d-1, etc.   Allows "!" suffix to indicate minimum of 1.
+  let a = str.match(DAMAGE_REGEX)
+  if (!!a) {
+    const D = a[DMG_INDEX_D] || ""  // Can now support non-variable damage '2 cut' or '2x3(1) imp'
+    const damageType = !!a[DMG_INDEX_TYPE] ? a[DMG_INDEX_TYPE].trim() : ""
+    const woundingModifier = woundModifiers[damageType.toLowerCase()]
+    const adds = a[DMG_INDEX_ADDS] || ""
+    let multiplier = a[DMG_INDEX_MULTIPLIER] || ""
+    if (!!multiplier && 'Xx'.includes(multiplier[0])) multiplier = '*' + multiplier.substr(1) // Must convert to '*' for Foundry.
+    const divisor = a[DMG_INDEX_DIVISOR] || ""
+    const bang = a[DMG_INDEX_BANG] || ""
+    
+    if (!woundingModifier) {  // Not one of the recognized damage types. Ignore Armor divisor, but allow multiplier.
+      let action = {
+        orig: str,
+        type: 'roll',
+        formula: a[DMG_INDEX_DICE] + D + adds + multiplier + bang,
+        desc: damageType, // Action description
+        costs: a[DMG_INDEX_COST]
+      }
+      return {
+        text: gspan(str, action),
+        action: action,
+      }
+    } else {    // Damage roll 1d+2 cut.  
+      let action = {
+        orig: str,
+        type: 'damage',
+        formula: a[DMG_INDEX_DICE] + D + adds + multiplier + divisor + bang,
+        damagetype: damageType,
+        costs: a[DMG_INDEX_COST]
+      }
+      return {
+        text: gspan(str, action),
+        action: action,
+      }
+    }
+  }
+  
+  a = str.match(DERIVED_DAMAGE_REGEX)     // SW+1
+  if (!!a) {
+    const basic = a[DMG_INDEX_BASICDAMAGE]
+    const damageType = !!a[DMG_INDEX_TYPE] ? a[DMG_INDEX_TYPE].trim() : ""
+    const woundingModifier = woundModifiers[damageType.toLowerCase()]
+    const adds = a[DMG_INDEX_ADDS] || ""
+    let multiplier = a[DMG_INDEX_MULTIPLIER] || ""
+    if (!!multiplier && 'Xx'.includes(multiplier[0])) multiplier = '*' + multiplier.substr(1) // Must convert to '*' for Foundry.
+    const divisor = a[DMG_INDEX_DIVISOR] || ""
+    const bang = a[DMG_INDEX_BANG] || ""
+    if (!woundingModifier) { // Not one of the recognized damage types. Ignore Armor divisor, but allow multiplier.
+      let action = {
+        orig: str,
+        type: 'derivedroll',
+        derivedformula: basic,
+        formula: adds + multiplier + bang,
+        desc: damageType,
+        costs: a[DMG_INDEX_COST]
+      }
+      return {
+        text: gspan(str, action),
+        action: action,
+      }
+    } else {
+      let action = {
+        orig: str,
+        type: 'deriveddamage',
+        derivedformula: basic,
+        formula: adds + multiplier + divisor + bang,
+        damagetype: damageType,
+        costs: a[DMG_INDEX_COST]
+      }
+      return {
+        text: gspan(str, action),
+        action: action,
+      }
+    }
+  }
+  return null
+}
 
 export function parselink(str, htmldesc, clrdmods = false) {
   if (str.length < 2)
@@ -162,86 +245,9 @@ export function parselink(str, htmldesc, clrdmods = false) {
       "action": action
     }
   }
-
-  // Straight roll 4d, 2d-1, etc. Is "damage" if it includes a damage type.  Allows "!" suffix to indicate minimum of 1.
-  // Supports:  2d+1x3(5), 4dX2(0.5), etc
-  // Straight roll, no damage type. 4d, 2d-1, etc.   Allows "!" suffix to indicate minimum of 1.
-  a = str.match(DAMAGE_REGEX)
-  if (!!a) {
-    const D = a[DMG_INDEX_D] || ""  // Can now support non-variable damage '2 cut' or '2x3(1) imp'
-    const damageType = !!a[DMG_INDEX_TYPE] ? a[DMG_INDEX_TYPE].trim() : ""
-    const woundingModifier = woundModifiers[damageType.toLowerCase()]
-    const adds = a[DMG_INDEX_ADDS] || ""
-    let multiplier = a[DMG_INDEX_MULTIPLIER] || ""
-    if (!!multiplier && 'Xx'.includes(multiplier[0])) multiplier = '*' + multiplier.substr(1) // Must convert to '*' for Foundry.
-    const divisor = a[DMG_INDEX_DIVISOR] || ""
-    const bang = a[DMG_INDEX_BANG] || ""
-    
-    if (!woundingModifier) {  // Not one of the recognized damage types. Ignore Armor divisor, but allow multiplier.
-      let action = {
-        orig: str,
-        type: 'roll',
-        formula: a[DMG_INDEX_DICE] + D + adds + multiplier + bang,
-        desc: damageType, // Action description
-        costs: a[DMG_INDEX_COST]
-      }
-      return {
-        text: gspan(str, action),
-        action: action,
-      }
-    } else {    // Damage roll 1d+2 cut.  
-      let action = {
-        orig: str,
-        type: 'damage',
-        formula: a[DMG_INDEX_DICE] + D + adds + multiplier + divisor + bang,
-        damagetype: damageType,
-        costs: a[DMG_INDEX_COST]
-      }
-      return {
-        text: gspan(str, action),
-        action: action,
-      }
-    }
-  }
   
-  a = str.match(DERIVED_DAMAGE_REGEX)     // SW+1
-  if (!!a) {
-    const basic = a[DMG_INDEX_BASICDAMAGE]
-    const damageType = !!a[DMG_INDEX_TYPE] ? a[DMG_INDEX_TYPE].trim() : ""
-    const woundingModifier = woundModifiers[damageType.toLowerCase()]
-    const adds = a[DMG_INDEX_ADDS] || ""
-    let multiplier = a[DMG_INDEX_MULTIPLIER] || ""
-    if (!!multiplier && 'Xx'.includes(multiplier[0])) multiplier = '*' + multiplier.substr(1) // Must convert to '*' for Foundry.
-    const divisor = a[DMG_INDEX_DIVISOR] || ""
-    const bang = a[DMG_INDEX_BANG] || ""
-    if (!woundingModifier) { // Not one of the recognized damage types. Ignore Armor divisor, but allow multiplier.
-      let action = {
-        orig: str,
-        type: 'derivedroll',
-        derivedformula: basic,
-        formula: adds + multiplier + bang,
-        desc: damageType,
-        costs: a[DMG_INDEX_COST]
-      }
-      return {
-        text: gspan(str, action),
-        action: action,
-      }
-    } else {
-      let action = {
-        orig: str,
-        type: 'deriveddamage',
-        derivedformula: basic,
-        formula: adds + multiplier + divisor + bang,
-        damagetype: damageType,
-        costs: a[DMG_INDEX_COST]
-      }
-      return {
-        text: gspan(str, action),
-        action: action,
-      }
-    }
-  }
+  a = parseForDamage(str)
+  if (!!a) return a
 
   // for PDF link
   parse = str.replace(/^PDF: */g, "");

--- a/lib/parselink.js
+++ b/lib/parselink.js
@@ -20,7 +20,21 @@ import { woundModifiers } from '../module/damage/damage-tables.js'
   	
   "modifier", "attribute", "selfcontrol", "damage", "roll", "skill", "pdf"
 */
-export default function parselink(str, htmldesc, clrdmods = false) {
+
+export const DAMAGE_REGEX = /^(\d+)(d)?6?([-+]\d+)?([xX\*]\d+)? ?(\([.\d]+\))?(!)? ?([^\*]*)(\*[Cc]osts? \d+[Ff][Pp])?$/  
+export const DMG_INDEX_DICE = 1
+export const DMG_INDEX_D = 2
+export const DMG_INDEX_ADDS = 3
+export const DMG_INDEX_MULTIPLIER = 4
+export const DMG_INDEX_DIVISOR = 5
+export const DMG_INDEX_BANG = 6
+export const DMG_INDEX_TYPE = 7
+export const DMG_INDEX_COST = 8
+
+export const DERIVED_DAMAGE_REGEX = /^(SW|Sw|sw|THR|Thr|thr)()([-+]\d+)?([xX\*]\d+)? ?(\([.\d]+\))?(!)? ?([^\*]*)(\*[Cc]osts? \d+[Ff][Pp])?$/ // have fake 2 element so indexes match
+export const DMG_INDEX_BASICDAMAGE = 1
+
+export function parselink(str, htmldesc, clrdmods = false) {
   if (str.length < 2)
     return { "text": str };
 
@@ -152,33 +166,24 @@ export default function parselink(str, htmldesc, clrdmods = false) {
   // Straight roll 4d, 2d-1, etc. Is "damage" if it includes a damage type.  Allows "!" suffix to indicate minimum of 1.
   // Supports:  2d+1x3(5), 4dX2(0.5), etc
   // Straight roll, no damage type. 4d, 2d-1, etc.   Allows "!" suffix to indicate minimum of 1.
-  a = str.match(/^(\d+)(d)?6?([-+]\d+)?([xX\*]\d+)? ?(\([.\d]+\))?(!)? ?([^\*]*)(\*[Cc]osts? \d+[Ff][Pp])?$/)
+  a = str.match(DAMAGE_REGEX)
   if (!!a) {
-    const INDEX_DICE = 1
-    const INDEX_D = 2
-    const INDEX_ADDS = 3
-    const INDEX_MULTIPLIER = 4
-    const INDEX_DIVISOR = 5
-    const INDEX_BANG = 6
-    const INDEX_TYPE = 7
-    const INDEX_COST = 8
-    
-    const D = a[INDEX_D] || ""  // Can now support non-variable damage '2 cut' or '2x3(1) imp'
-    const damageType = !!a[INDEX_TYPE] ? a[INDEX_TYPE].trim() : ""
+    const D = a[DMG_INDEX_D] || ""  // Can now support non-variable damage '2 cut' or '2x3(1) imp'
+    const damageType = !!a[DMG_INDEX_TYPE] ? a[DMG_INDEX_TYPE].trim() : ""
     const woundingModifier = woundModifiers[damageType.toLowerCase()]
-    const adds = a[INDEX_ADDS] || ""
-    let multiplier = a[INDEX_MULTIPLIER] || ""
+    const adds = a[DMG_INDEX_ADDS] || ""
+    let multiplier = a[DMG_INDEX_MULTIPLIER] || ""
     if (!!multiplier && 'Xx'.includes(multiplier[0])) multiplier = '*' + multiplier.substr(1) // Must convert to '*' for Foundry.
-    const divisor = a[INDEX_DIVISOR] || ""
-    const bang = a[INDEX_BANG] || ""
+    const divisor = a[DMG_INDEX_DIVISOR] || ""
+    const bang = a[DMG_INDEX_BANG] || ""
     
     if (!woundingModifier) {  // Not one of the recognized damage types. Ignore Armor divisor, but allow multiplier.
       let action = {
         orig: str,
         type: 'roll',
-        formula: a[INDEX_DICE] + D + adds + multiplier + bang,
+        formula: a[DMG_INDEX_DICE] + D + adds + multiplier + bang,
         desc: damageType, // Action description
-        costs: a[INDEX_COST]
+        costs: a[DMG_INDEX_COST]
       }
       return {
         text: gspan(str, action),
@@ -188,9 +193,9 @@ export default function parselink(str, htmldesc, clrdmods = false) {
       let action = {
         orig: str,
         type: 'damage',
-        formula: a[INDEX_DICE] + D + adds + multiplier + divisor + bang,
+        formula: a[DMG_INDEX_DICE] + D + adds + multiplier + divisor + bang,
         damagetype: damageType,
-        costs: a[INDEX_COST]
+        costs: a[DMG_INDEX_COST]
       }
       return {
         text: gspan(str, action),
@@ -199,32 +204,24 @@ export default function parselink(str, htmldesc, clrdmods = false) {
     }
   }
   
-  a = str.match(/^(SW|Sw|sw|THR|Thr|thr)([-+]\d+)?([xX\*]\d+)? ?(\([.\d]+\))?(!)? ?([^\*]*)(\*[Cc]osts? \d+[Ff][Pp])?$/)
+  a = str.match(DERIVED_DAMAGE_REGEX)     // SW+1
   if (!!a) {
-    const INDEX_BASICDAMAGE = 1
-    const INDEX_ADDS = 2
-    const INDEX_MULTIPLIER = 3
-    const INDEX_DIVISOR = 4
-    const INDEX_BANG = 5
-    const INDEX_TYPE = 6
-    const INDEX_COST = 7
-    const basic = a[INDEX_BASICDAMAGE].toLowerCase()
-    const damageType = !!a[INDEX_TYPE] ? a[INDEX_TYPE].trim().toLowerCase() : ""
-    const woundingModifier = woundModifiers[damageType]
-    const adds = a[INDEX_ADDS] || ""
-    let multiplier = a[INDEX_MULTIPLIER] || ""
+    const basic = a[DMG_INDEX_BASICDAMAGE]
+    const damageType = !!a[DMG_INDEX_TYPE] ? a[DMG_INDEX_TYPE].trim() : ""
+    const woundingModifier = woundModifiers[damageType.toLowerCase()]
+    const adds = a[DMG_INDEX_ADDS] || ""
+    let multiplier = a[DMG_INDEX_MULTIPLIER] || ""
     if (!!multiplier && 'Xx'.includes(multiplier[0])) multiplier = '*' + multiplier.substr(1) // Must convert to '*' for Foundry.
-    const divisor = a[INDEX_DIVISOR] || ""
-    const bang = a[INDEX_BANG] || ""
-
-    if (!!woundingModifier) {
+    const divisor = a[DMG_INDEX_DIVISOR] || ""
+    const bang = a[DMG_INDEX_BANG] || ""
+    if (!woundingModifier) { // Not one of the recognized damage types. Ignore Armor divisor, but allow multiplier.
       let action = {
         orig: str,
-        type: 'deriveddamage',
+        type: 'derivedroll',
         derivedformula: basic,
         formula: adds + multiplier + bang,
-        damagetype: damageType,
-        costs: a[INDEX_COST]
+        desc: damageType,
+        costs: a[DMG_INDEX_COST]
       }
       return {
         text: gspan(str, action),
@@ -233,11 +230,11 @@ export default function parselink(str, htmldesc, clrdmods = false) {
     } else {
       let action = {
         orig: str,
-        type: 'derivedroll',
+        type: 'deriveddamage',
         derivedformula: basic,
         formula: adds + multiplier + divisor + bang,
-        desc: damageType,
-        costs: a[INDEX_COST]
+        damagetype: damageType,
+        costs: a[DMG_INDEX_COST]
       }
       return {
         text: gspan(str, action),

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -2,7 +2,7 @@ import { GURPS } from './gurps.js'
 import { isNiceDiceEnabled } from '../lib/utilities.js'
 import { Melee, Reaction, Ranged, Advantage, Skill, Spell, Equipment, Note } from './actor.js'
 import { HitLocation } from '../module/hitlocation/hitlocation.js'
-import parselink from '../lib/parselink.js'
+import { parselink } from '../lib/parselink.js'
 import * as CI from './injury/domain/ConditionalInjury.js'
 import * as settings from '../lib/miscellaneous-settings.js'
 

--- a/module/chat.js
+++ b/module/chat.js
@@ -1,5 +1,5 @@
 'use strict'
-import parselink from '../lib/parselink.js'
+import { parselink } from '../lib/parselink.js'
 import { NpcInput } from '../lib/npc-input.js'
 
 /**

--- a/module/damage/applydamage.js
+++ b/module/damage/applydamage.js
@@ -282,13 +282,14 @@ export default class ApplyDamageDialog extends Application {
     }
 
     if (object.type === 'knockback') {
+      let dxCheck = object.modifier === 0 ? 'DX' : `DX-${object.modifier}`
+      let acroCheck = object.modifier === 0 ? 'S:Acrobatics' : `S:Acrobatics-${object.modifier}`
+      let judoCheck = object.modifier === 0 ? 'S:Judo' : `S:Judo-${object.modifier}`
       message = await this._renderTemplate('chat-knockback.html',
         {
           name: this.actor.data.name,
           yards: object.amount,
-          dxCheck: object.modifier === 0 ? 'DX' : `DX-${object.modifier}`,
-          acroCheck: object.modifier === 0 ? 'S:Acrobatics' : `S:Acrobatics-${object.modifier}`,
-          judoCheck: object.modifier === 0 ? 'S:Judo' : `S:Judo-${object.modifier}`
+          combinedCheck: `${dxCheck}|${acroCheck}|${judoCheck}`
         })
     }
 

--- a/module/damage/damagechat.js
+++ b/module/damage/damagechat.js
@@ -11,7 +11,7 @@ import { d6ify, isNiceDiceEnabled, generateUniqueId } from '../../lib/utilities.
  * specific actor. This object takes care of binding the dragstart and dragend events to that div.
  */
 export default class DamageChat {
-  static fullRegex = /^(?<roll>\d+(?<D>d)?(?<adds1>[+-]\d+)?(?<adds2>[+-]\d+)?)(?:[×xX\*](?<mult>\d+))?(?: ?\((?<divisor>\d+(?:\.\d+)?)\))?/
+  static fullRegex = /^(?<roll>\d+(?<D>d\d*)?(?<adds1>[+-]\d+)?(?<adds2>[+-]\d+)?)(?:[×xX\*](?<mult>\d+))?(?: ?\((?<divisor>\d+(?:\.\d+)?)\))?/
 
   constructor(GURPS) {
     this.setup()
@@ -134,8 +134,8 @@ export default class DamageChat {
     let formula = diceText
     let verb = ''
     if (!!result.groups.D) {
-      formula = d6ify(diceText)
       verb = 'Rolling '
+      if (result.groups.D === 'd') formula = d6ify(diceText)  // GURPS dice (assume 6)
     }
     let displayText = overrideDiceText || diceText      // overrideDiceText used when actual formula isn't 'pretty' SW+2 vs 1d6+1+2
     let min = 1

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -587,8 +587,8 @@ async function performAction(action, actor, event, targets) {
   }
 
   if (action.type === 'roll') {
-    prefix = 'Rolling ' + action.formula + ' ' + action.desc
-    formula = d6ify(action.formula)
+    prefix = 'Rolling ' + action.displayformula + ' ' + action.desc
+    formula = action.rollformula
     if (!!action.costs) targetmods.push(GURPS.ModifierBucket.makeModifier(0, action.costs))
   }
 

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -610,7 +610,7 @@ async function performAction(action, actor, event, targets) {
         formula,
         action.damagetype,
         event,
-        action.derivedformula + action.formula,
+        action.derivedformula.toUpperCase() + action.formula,
         targets
       )
       return true

--- a/module/modifiers.js
+++ b/module/modifiers.js
@@ -1,5 +1,5 @@
 import { displayMod, makeSelect, horiz } from '../lib/utilities.js'
-import parselink from '../lib/parselink.js'
+import { parselink } from '../lib/parselink.js'
 import * as Settings from '../lib/miscellaneous-settings.js'
 import * as HitLocations from '../module/hitlocation/hitlocation.js'
 

--- a/templates/apply-damage/chat-knockback.html
+++ b/templates/apply-damage/chat-knockback.html
@@ -3,9 +3,7 @@
   {{pluralize 'yard' yards}}.<br />
   <span style='font-size:small;'>{{localize "GURPS.roll"}} <i>{{localize "GURPS.highest"}}</i> {{localize "GURPS.of"}}:
     <ul>
-      <li>[{{dxCheck}} {{localize "GURPS.toAvoidFalling"}}]</li>
-      <li>[{{acroCheck}} {{localize "GURPS.toAvoidFalling"}}]</li>
-      <li>[{{judoCheck}} {{localize "GURPS.toAvoidFalling"}}]</li>
+      <li>[{{combinedCheck}}]<br>{{localize "GURPS.toAvoidFalling"}}</li>
     </ul>
     <hr />
     <ul>

--- a/templates/damage-message-wrapper.html
+++ b/templates/damage-message-wrapper.html
@@ -1,5 +1,5 @@
 <div>
-  <div class='prefix'>Rolling {{dice}} {{damageTypeText}} damage.</div>
+  <div class='prefix'>{{verb}}{{dice}} {{damageTypeText}} damage.</div>
   <div class='roll-message'>
     {{#if modifiers}}
       <hr />
@@ -17,7 +17,7 @@
         <div class='roll-message'>
           <div class='collapsible-wrapper'>
             <input id='collapsible-{{id}}' class='toggle offscreen-only' type='checkbox'>
-            <label for='collapsible-{{id}}' class='roll-result label-toggle'>
+            <label for='collapsible-{{id}}' class='roll-result {{#if hasExplanation}}label-toggle{{/if}}'>
               <span>{{#if target}}&nbsp;{{target}}:{{/if}}
                   <i class='fa fa-dice'></i><i class='fa fa-long-arrow-alt-right'></i>
                   <span class='roll-value'>{{damage}}</span>


### PR DESCRIPTION
Support non-dice damage [3 cut].   Can support all other modifiers.   This is a legal (if stupid) roll formula:  '5-2x3(2) cut', and it displays:  
5-2 = 3.
Total = 3 x 3 = 9
If there are no dice rolled, and there are no other modifying factors to the damage "roll", the drag-able section does not contain a collapsible section (since there is nothing to display).
Don't tell anyone... we now support any sided dice for non-targeted (e.g attribute, skill), non-derived damage (e.g. SW+1) rolls.    Examples: [3d4], [2d10 cut], [2d100-30x3(0.5) imp]
We only show the dice sides if they are part of the damage formula (e.g. '3d6').   If they are not included, we assume 6 sided dice, and we display the roll in 'GURPS' format (e.g '3d')