### PR TITLE
Added support for /qty

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This is what we are currently working on:
   - Allow OtF skill check to use a different attribute than the default. (E.g., make a Per-based Traps skill check at -2 for difficulty: "[S:Traps -2 difficulty (Based:Per)]".)
   - Allow conditional text for Attribute and Skill checks [!Per ?"You sense something is there", "You hear nothing!"]
   - Bug fix for old chat messages.  Can now be clicked on
+  - Added /hp /fp /qty /trackerN chat commands
 
 ## History
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -208,12 +208,13 @@ export function convertRollStringToArrayOfInt(text) {
   return results
 }
 
-export function recurselist(list, fn) {
-  if (!!list) Object.values(list).forEach(o => {
-    fn(o);
-    recurselist(o.contains, fn);
-    recurselist(o.collapsed, fn);
-  });
+export function recurselist(list, fn, parentkey = '') {
+  if (!!list) 
+    for (const [key, value] of Object.entries(list)) {
+      fn(value, parentkey + key);
+      recurselist(value.contains, fn, parentkey + key + '.contains.');
+      recurselist(value.collapsed, fn,  parentkey + key + '.collapsed.');
+    }
 }
 
 export function getAllActorsInActiveScene() {

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -909,7 +909,7 @@ function gurpslink(str, clrdmods = true) {
       output += action.text
       if (!action.action) output += ']'
       str = str.substr(i + 1)
-      i = 0
+      i = -1
       found = -1
     }
   }

--- a/module/modifiers.js
+++ b/module/modifiers.js
@@ -579,10 +579,10 @@ const SizeModifiers = [
 let HitlocationModifiers = ['Hit Locations (if miss by 1, then *)']
 
 // Using back quote to allow \n in the string.  Will make it easier to edit later (instead of array of strings)
-const MeleeMods = `[+4 to hit (Determined Attack)]
+const MeleeMods = `[+4 to hit (Determined Attack)] [PDF:B365]
 [+4 to hit (Telegraphic Attack)]
-[-2 to hit (Deceptive Attack)]
-[-4 to hit (Charge Attack) *Max:9]
+[-2 to hit (Deceptive Attack)] [PDF:B369]
+[-4 to hit (Charge Attack) *Max:9] [PDF:B365]
 [+2 dmg (Strong Attack)]
 ${horiz('Extra Effort')}
 [+2 dmg (Mighty Blow) *Cost 1FP]


### PR DESCRIPTION
Ok, I lied a little bit... I really had to implement the chat command "/qty <formula> <equipment name>".   It was so close to what I already had... it was a no-brainer (mostly).

So now, a user can create an OtF formula to keep track of their ammo (if they aren't using a resource tracker), for example:
`[/qty -1 *919mm]`
Into the note for the weapon:

![image](https://user-images.githubusercontent.com/8931036/109717027-89e6ec80-7b73-11eb-80c7-b600ffc48f6d.png)

It finds the first equipment that matches the name pattern (including '*').    
