### PR TITLE
Lots-o-bug fixes

### DIFF
--- a/lib/hitpoints.js
+++ b/lib/hitpoints.js
@@ -7,7 +7,7 @@ const hpConditions = {
     style: 'normal'
   },
   REELING: {
-    breakpoint: (HP) => (HP.max / 3),
+    breakpoint: (HP) => (HP.max / 3) -1,  // less than 1/3
     label: 'Reeling',
     style: 'reeling'
   },
@@ -55,7 +55,7 @@ const fpConditions = {
     style: 'normal'
   },
   REELING: {
-    breakpoint: (FP) => (FP.max / 3),
+    breakpoint: (FP) => (FP.max / 3) -1,
     label: 'Tired',
     style: 'tired'
   },

--- a/lib/npc-input.js
+++ b/lib/npc-input.js
@@ -223,6 +223,7 @@ export class NpcInput extends FormApplication {
     e.level = 0
     e.current = true
     e.key = 'enc0'
+    e.weight = 0
     e.move = parseInt(m.move)
     e.dodge = parseInt(m.dodge)
     game.GURPS.put(es, e)

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -1125,16 +1125,16 @@ export class GurpsActorSheet extends ActorSheet {
       for (let enckey in encs) {
         let enc = encs[enckey]
         let t = 'data.encumbrance.' + enckey + '.current'
-        if (enc.current) {
-          await this.actor.update({ [t]: false })
-        }
         if (key === enckey) {
           await this.actor.update({
             [t]: true,
             'data.currentmove': parseInt(enc.move),
             'data.currentdodge': parseInt(enc.dodge),
           })
+        } else if (enc.current) {
+          await this.actor.update({ [t]: false })
         }
+
       }
     } else {
       ui.notifications.warn(
@@ -1384,7 +1384,8 @@ export class GurpsActorNpcSheet extends GurpsActorSheet {
 
   getData() {
     const data = super.getData()
-    data.dodge = this.actor.getCurrentDodge()
+    data.currentdodge = this.actor.data.data.currentdodge
+    data.currentmove = this.actor.data.data.currentmove
     data.defense = this.actor.getTorsoDr()
     let p = this.actor.getEquippedParry()
     //    let b = this.actor.getEquippedBlock();      // Don't have a good way to display block yet

--- a/module/actor.js
+++ b/module/actor.js
@@ -1220,7 +1220,7 @@ export class GurpsActor extends Actor {
           eqt = e
           key = k
         }
-      } else return l > 0
+      } else return pats.length == 1
     }, pkey1 )
     recurselist(list2, (e, k, d) => {
       let l = pats.length - 1
@@ -1230,7 +1230,7 @@ export class GurpsActor extends Actor {
           eqt = e
           key = k
         }
-      } else return l > 0
+      } else return pats.length == 1
     }, pkey2 )
     return [eqt, key]
   }

--- a/module/chat.js
+++ b/module/chat.js
@@ -98,6 +98,7 @@ export default function addChatHooks() {
           c += '<br>/qty &lt;formula&gt; &lt;equipment name&gt;'
           c += '<br>/uses &lt;formula&gt; &lt;equipment name&gt;'
           c += '<br>/status on|off|t|toggle &lt;status&gt;'
+          c += '<br>/ra N | Skillname-N'
           if (game.user.isGM) {
             c += '<br> --- GM only ---'
             c += '<br>/sendmb &lt;OtF&gt &lt;playername(s)&gt'
@@ -164,7 +165,7 @@ export default function addChatHooks() {
           return          
         }
         
-        m = line.match(/\/qty ([\+-=]\d+)(.*)/i)
+        m = line.match(/\/qty ?([\+-=]\d+)(.*)/i)
         if (!!m) {
           let actor = GURPS.LastActor
           if (!actor)
@@ -203,7 +204,7 @@ export default function addChatHooks() {
           return     
         }
         
-        m = line.match(/\/uses ([\+-=]\w+)?(reset)?(.*)/i)
+        m = line.match(/\/uses ?([\+-=]\w+)?(reset)?(.*)/i)
         if (!!m) {
           let actor = GURPS.LastActor
           if (!actor)
@@ -246,7 +247,7 @@ export default function addChatHooks() {
           return     
         }
 
-        m = line.match(/\/([fh]p) ([+-=]\d+)?(reset)?(.*)/i)
+        m = line.match(/\/([fh]p) ?([+-=]\d+)?(reset)?(.*)/i)
         if (!!m) {
           let actor = GURPS.LastActor
           if (!actor)
@@ -288,7 +289,7 @@ export default function addChatHooks() {
           return      
         }
  
-        m = line.match(/\/(tracker|tr|rt|resource)([0123])?(\(([^\)]+)\))? ([+-=]\d+)?(reset)?(.*)/i)
+        m = line.match(/\/(tracker|tr|rt|resource)([0123])?(\(([^\)]+)\))? ?([+-=]\d+)?(reset)?(.*)/i)
         if (!!m) {
           let actor = GURPS.LastActor
           if (!actor)
@@ -297,12 +298,18 @@ export default function addChatHooks() {
             let tracker = parseInt(m[2])
             let display = tracker
             if (!!m[3]) {
+              tracker = -1
               for (const [key, value] of Object.entries(actor.data.data.additionalresources.tracker)) {
                 if (value.name.match(m[4])) {
                   tracker = key
                   display = "(" + value.name + ")"
                 }
               } 
+              if (tracker == -1) {
+                ui.notifications.warn(`No Resource Tracker matched '${m[3]}'`)
+                handled = true
+                return      
+              }
             }
             let delta = parseInt(m[5])
             let reset = ''
@@ -335,7 +342,7 @@ export default function addChatHooks() {
         }
      
         // /everyone +1 fp or /everyone -2d-1 fp
-        m = line.match(/\/(everyone|ev) ([fh]p) ([+-]\d+d\d*)?([+-=]\d+)?(!)?/i);
+        m = line.match(/\/(everyone|ev) ([fh]p) ?([+-]\d+d\d*)?([+-=]\d+)?(!)?/i);
         if (!!m && (!!m[3] || !!m[4])) {
           if (game.user.isGM) {
             let any = false

--- a/module/chat.js
+++ b/module/chat.js
@@ -116,7 +116,7 @@ export default function addChatHooks() {
           return
         }
                 
-        m = line.match(/\/(st|status) (t|toggle|on|off|\+|-) ([^ ]+)(@self)?/i)
+        m = line.match(/\/(st|status) +(t|toggle|on|off|\+|-) +([^ ]+)(@self)?/i)
         if (!!m) {
           let pattern =  new RegExp('^' + (m[3].trim().split('*').join('.*').replace(/\(/g, '\\(').replace(/\)/g, '\\)')), 'i') // Make string into a RegEx pattern
           let any = false
@@ -165,7 +165,7 @@ export default function addChatHooks() {
           return          
         }
         
-        m = line.match(/\/qty ?([\+-=]\d+)(.*)/i)
+        m = line.match(/\/qty *([\+-=]\d+)(.*)/i)
         if (!!m) {
           let actor = GURPS.LastActor
           if (!actor)
@@ -204,7 +204,7 @@ export default function addChatHooks() {
           return     
         }
         
-        m = line.match(/\/uses ?([\+-=]\w+)?(reset)?(.*)/i)
+        m = line.match(/\/uses *([\+-=]\w+)?(reset)?(.*)/i)
         if (!!m) {
           let actor = GURPS.LastActor
           if (!actor)
@@ -247,7 +247,7 @@ export default function addChatHooks() {
           return     
         }
 
-        m = line.match(/\/([fh]p) ?([+-=]\d+)?(reset)?(.*)/i)
+        m = line.match(/\/([fh]p) *([+-=]\d+)?(reset)?(.*)/i)
         if (!!m) {
           let actor = GURPS.LastActor
           if (!actor)
@@ -289,7 +289,7 @@ export default function addChatHooks() {
           return      
         }
  
-        m = line.match(/\/(tracker|tr|rt|resource)([0123])?(\(([^\)]+)\))? ?([+-=]\d+)?(reset)?(.*)/i)
+        m = line.match(/\/(tracker|tr|rt|resource)([0123])?(\(([^\)]+)\))? *([+-=]\d+)?(reset)?(.*)/i)
         if (!!m) {
           let actor = GURPS.LastActor
           if (!actor)
@@ -342,7 +342,7 @@ export default function addChatHooks() {
         }
      
         // /everyone +1 fp or /everyone -2d-1 fp
-        m = line.match(/\/(everyone|ev) ([fh]p) ?([+-]\d+d\d*)?([+-=]\d+)?(!)?/i);
+        m = line.match(/\/(everyone|ev) ([fh]p) *([+-]\d+d\d*)?([+-=]\d+)?(!)?/i);
         if (!!m && (!!m[3] || !!m[4])) {
           if (game.user.isGM) {
             let any = false

--- a/module/chat.js
+++ b/module/chat.js
@@ -114,7 +114,7 @@ export default function addChatHooks() {
           handled = true
           return
         }
-        
+                
         m = line.match(/\/(st|status) (t|toggle|on|off|\+|-) ([^ ]+)(@self)?/i)
         if (!!m) {
           let pattern =  new RegExp('^' + (m[3].trim().split('*').join('.*').replace(/\(/g, '\\(').replace(/\)/g, '\\)')), 'i') // Make string into a RegEx pattern
@@ -425,13 +425,26 @@ export default function addChatHooks() {
             pub(line, msgs)   // Looks like an OtF, but didn't parse as one
           handled = true
           return
-       } 
+        }
+        
+        m = line.match(/([\.\/]p?ra) +(\w+-)?(\d+)/i)
+        if (!!m) {
+          let skill = m[2] || "Default="
+          let action = parselink("S:" + skill.replace('-', '=') + m[3])
+          send(msgs) // send what we have
+          GURPS.performAction(action.action, GURPS.LastActor, { shiftKey: line.substr(1).startsWith('pra')  })   // We can't await this until we rewrite Modifiers.js to use sockets to update stacks
+          handled = true
+          return
+        }
+
+         
         if (line === '/clearmb') {
           priv(line, msgs);
           GURPS.ModifierBucket.clear()
           handled = true
           return
         }
+        
         if (line.startsWith('/sendmb')) {
           if (game.user.isGM) {
             priv(line, msgs)

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1432,6 +1432,9 @@ Hooks.once('init', async function () {
 
   ui.modifierbucket = GURPS.ModifierBucket
   ui.modifierbucket.render(true)
+  
+  const v = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_CHANGELOG_VERSION) || '0.0.1'
+
 })
 
 Hooks.once('ready', async function () {

--- a/styles/simple.css
+++ b/styles/simple.css
@@ -2005,6 +2005,12 @@ body {
   text-align: start;
 }
 
+.roll-message .note {
+  text-align: end;
+  font-weight: normal;
+  text-align: start;
+}
+
 .roll-result .roll-value,
 .roll-result .roll-detail {
   font-family: 'Font Awesome 5 Free', 'Roboto', sans-serif;

--- a/templates/die-roll-chat-message.html
+++ b/templates/die-roll-chat-message.html
@@ -45,8 +45,8 @@
       {{#if (gt rofrcl 1)}}
       <div>
         <span class='fa fa-bullseye' />
-        <span class='roll-detail'>
-          &nbsp;Total possible hits due to RoF/Rcl: <span class='roll-value'>{{rofrcl}}</span>
+        <span class='note'>
+          Total possible hits due to RoF/Rcl: <span class='roll-value'>{{rofrcl}}</span> {{{gurpslink '[PDF:B373]'}}}
         </span>
       </div>
       {{/if}}

--- a/templates/npc-sheet.html
+++ b/templates/npc-sheet.html
@@ -11,7 +11,7 @@
   </div>
   <div class="npc-input-attr gurps">
     <div class="npc-input-st npc-input-label">ST:</div>
-    <div class="npc-input-st-val rollable npc-sheet-centered" data-path="attributes.ST.value" data-otf='ST'>{{data.attributes.ST.value}}</div>
+    <div class="npc-input-st-val rollable npc-sheet-centered" data-path="attributes.ST.currentvalue" data-otf='ST'>{{data.attributes.ST.currentvalue}}</div>
     <div class="npc-input-dx npc-input-label">DX:</div>
     <div class="npc-input-dx-val rollable npc-sheet-centered" data-path="attributes.DX.value" data-otf='DX'>{{data.attributes.DX.value}}</div>
     <div class="npc-input-iq npc-input-label">IQ:</div>
@@ -29,13 +29,13 @@
     <div class="npc-input-fp npc-input-label">FP:</div>
     <div class="npc-input-fp-val condition-block"><input class="npc-input-2 {{fpCondition data.FP "style"}}" name="data.FP.value" type="text" value="{{data.FP.value}}" data-dtype="Number" /></div>
     <div class="npc-input-dodge npc-input-labelr">Dodge:</div>
-    <div class="npc-input-dodge-val rollable npc-sheet-centered" data-path="dodge" data-otf='Dodge'>{{this.dodge}}</div>
+    <div class="npc-input-dodge-val rollable npc-sheet-centered" data-path="dodge" data-otf='Dodge'>{{data.currentdodge}}</div>
     <div class="npc-input-parry npc-input-labelr">Parry:</div>
     <div class="npc-input-parry-val rollable npc-sheet-centered" data-path="parry" data-otf='Parry'>{{this.parryblock}}</div>
     <div class="npc-input-spd npc-input-labelr">Speed:</div>
     <div class="npc-input-spd-val npc-sheet-centered">{{data.basicspeed.value}}</div>
     <div class="npc-input-mov npc-input-labelr">Move:</div>
-    <div class="npc-input-mov-val npc-sheet-centered">{{data.basicmove.value}}</div>
+    <div class="npc-input-mov-val npc-sheet-centered">{{data.currentmove}}</div>
     <div class="npc-input-sm npc-input-labelr">SM:</div>
     <div class="npc-input-sm-val npc-sheet-centered">{{data.traits.sizemod}}</div>
     <div class="npc-input-dr npc-input-labelr">DR:</div>

--- a/templates/simplified.html
+++ b/templates/simplified.html
@@ -1,8 +1,8 @@
 <form class="{{cssClass}} simple_form" autocomplete="off">
 
 <div class="simple_container">
-  <div class="simple_ST rollableicon" data-value="ST{{data.attributes.ST.value}}" data-otf='ST'><img class="simple_icon" src="systems/gurps/ui/ri_4t.png"/>
-		<label class="simple_input">{{simpleRating data.attributes.ST.value}}</label></div>
+  <div class="simple_ST rollableicon" data-value="ST{{data.attributes.ST.currentvalue}}" data-otf='ST'><img class="simple_icon" src="systems/gurps/ui/ri_4t.png"/>
+		<label class="simple_input">{{simpleRating data.attributes.ST.currentvalue}}</label></div>
   <div class="simple_DX rollableicon" data-value="DX{{data.attributes.DX.value}}" data-otf='DX'><img class="simple_icon" src="systems/gurps/ui/ri_6t.png"/>
 		<label class="simple_input">{{simpleRating data.attributes.DX.value}}</label></div>
   <div class="simple_IQ rollableicon" data-value="IQ{{data.attributes.IQ.value}}" data-otf='IQ'><img class="simple_icon" src="systems/gurps/ui/ri_8t.png"/>
@@ -10,7 +10,7 @@
   <div class="simple_HT rollableicon" data-value="HT{{data.attributes.HT.value}}" data-otf='HT'><img class="simple_icon" src="systems/gurps/ui/ri_10t.png"/>
 		<label class="simple_input">{{simpleRating data.attributes.HT.value}}</label></div>
   <div class="simple_ST-desc">
-		<label>Strength (</label><label class="rollable simple_lrg" data-path="attributes.ST.value" data-otf="ST">{{data.attributes.ST.value}}</label>
+		<label>Strength (</label><label class="rollable simple_lrg" data-path="attributes.ST.value" data-otf="ST">{{data.attributes.ST.currentvalue}}</label>
 		<label>): How <strong>strong</strong> and <strong>tough</strong></label>
 	</div>
   <div class="simple_DX-desc">


### PR DESCRIPTION
HP & FP condition off by 1 (should be less than 1/3 HP)
Fixed automatic encumbrance bug for Mooks (since encumbrances have no weight boundaries)
Fixed timing issue with encumbrance updates
Fixed simple and npc sheets to use new "current" move/dodge
Fixed update order for recalculating
Modified chat commands make space optional /fp+1 vs /fp  +1
Make "Total possible... Rof/Rcl:" text slightly smaller, to allow PDF reference.
![image](https://user-images.githubusercontent.com/8931036/110072392-b7868e00-7d4b-11eb-8842-be93a56a7ba6.png)
