### PR TITLE
0.8.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Users Guide for [GURPS 4e game aid for Foundry VTT](https://bit.ly/2JaSlQd)
 
-# Current Release Version 0.8.15
+# Current Release Version 0.8.16
 
 [If you like our work...](https://ko-fi.com/crnormand)
 
@@ -21,7 +21,12 @@ Join us on Discord: [GURPS Foundry-VTT Discord](https://discord.gg/6xJBcYWyED)
 
 This is what we are currently working on:
 
-0.8.16
+0.9.0
+  - Items... yes... actual items.
+  
+## History
+
+0.8.16 - 3/6/2021
 
   - Bug fix for GCA exports. Now equipment with melee & ranged attacks appear in both (Spears)
   - Bug fix for GCA exports (with Armin's help!) Block is calculated correctly for items with DB (shields)
@@ -47,7 +52,6 @@ This is what we are currently working on:
   - Added /qty /uses /status /tracker(name) chat commands
   - Added .ra /sendmbs multiline chat msgs \\
 
-## History
 
 0.8.15 - 2/17/2021
 

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT (GCS/GCA edition)",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "minimumCoreVersion": "0.7.5",
   "compatibleCoreVersion": "0.7.9",
   "templateVersion": 2,
@@ -35,6 +35,6 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.8.15.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.8.16.zip",
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
  - Bug fix for GCA exports. Now equipment with melee & ranged attacks appear in both (Spears)
  - Bug fix for GCA exports (with Armin's help!) Block is calculated correctly for items with DB (shields)
  - Add doubleclick edit to NPC Sheet Notes, Melee, Ranged, Ads, Skill and Spells list
  - Bug fix for limb, extremity, and eye crippling calculation. Originally the calculation was taking "crippling" as 1/2 HP or 1/3 HP exactly, but the RAW say it should be *over* that threshold. Example: 10 HP character is hit in the arm with 8 points of damage; the arm is crippled if it takes *more than* 5 points of damage (i.e., 6).
  - High rate of fire weapons damage is supported directly. Right-click on a damage roll to get a menu to enter the number of hits. There will be a new "ALL THE DAMAGE" draggable section of the damage chat message. Dragging that onto a character will apply all damage rolls in the ADD. The ADD has been enhanced to allow each damage calculation to be displayed, while applying the total.
  - Updated GCS import to accept 'uses' and 'maxuses' columns for equipment (requires GCS 4.28 and Master Library 2.9)
  - Added Shotgun damage to Apply Damage Dialog.
  - Added split buttons to ADD.
  - Added navigation footer to GCS Full Sheet.
  - Added generic 'weight' icon to character sheet in preparation for (one day) handling metric.
  - Added 'apply multiple times' to ADD.
  - Added 'Reeling' and 'Tired' buttons to Full and Combat sheet (and Combat tracker)
  - Added system setting to allow automatic setting of Reeling and Tired
  - Add "Apply Damage to <Target>" button to Damage Chat Message. If the user who rolled the damage also has set a target, this adds the button only for the GM.
  - Better parsing of On-the-Fly formulas in Journal entries (especially unicode characters)
  - Restrict Apply Damage Calculator to GM only (system setting)
  - Updated /sendmb to allow optional OtF modifier: /sendmb [+1 to hit & +3 luck] <playername(s)>
  - Allow OtF skill check to use a different attribute than the default. (E.g., make a Per-based Traps skill check at -2 for difficulty: "[S:Traps -2 difficulty (Based:Per)]".)
  - Allow conditional text for Attribute and Skill checks [!Per ?"You sense something is there", "You hear nothing!"]
  - Bug fix for old chat messages.  Can now be clicked on
  - Added /hp /fp /qty /trackerN chat commands
  - Added /qty /uses /status /tracker(name) chat commands
  - Added .ra /sendmbs multiline chat msgs \\
