### PR TITLE
Implemented support for Injury Tolerance (Damage Reduction) in ADD

### DIFF
--- a/module/damage/applydamage.js
+++ b/module/damage/applydamage.js
@@ -238,6 +238,29 @@ export default class ApplyDamageDialog extends Application {
       .find('input[name="injury-tolerance"]')
       .click(ev => this._updateModelFromRadioValue($(ev.currentTarget), 'injuryToleranceType'))
 
+    // if checked, target has Injury Tolerance (Damage Reduction)
+    html
+        .find('#damage-reduction')
+        .click(ev => {
+          if (!$(ev.currentTarget).is(':checked')) {
+            this._calculator.damageReductionLevel = null
+            this.updateUI()
+          }
+          this._updateModelFromBooleanElement($(ev.currentTarget), 'useDamageReduction')
+        })
+
+    // damage reduction level field
+    html.find('#damage-reduction-field input')
+        .on('change', ev =>
+            this._updateModelFromInputText($(ev.currentTarget), 'damageReductionLevel', parseIntFrom)
+        )
+
+    // clear the damage reduction level field
+    html.find('#damage-reduction-field button').click(() => {
+      this._calculator.damageReductionLevel = null
+      this.updateUI()
+    })
+
     // if checked, target has flexible armor; check for blunt trauma
     html
       .find('#flexible-armor')

--- a/module/damage/damagecalculator.js
+++ b/module/damage/damagecalculator.js
@@ -86,6 +86,9 @@ export class CompositeDamageCalculator {
 
     this._isInjuryTolerance = false
     this._injuryToleranceType = null
+    // Injury Tolerance (Damage Reduction) is handled separately from other types of IT
+    this._useDamageReduction = false
+    this._damageReductionLevel = null
 
     this._isExplosion = false
     this._hexesFromExplosion = 1
@@ -445,6 +448,22 @@ export class CompositeDamageCalculator {
 
   set injuryToleranceType(value) {
     this._injuryToleranceType = value
+  }
+
+  get useDamageReduction() {
+    return this._useDamageReduction
+  }
+
+  set useDamageReduction(value) {
+    this._useDamageReduction = value
+  }
+
+  get damageReductionLevel() {
+    return this._damageReductionLevel
+  }
+
+  set damageReductionLevel(value) {
+    this._damageReductionLevel = value
   }
 
   get isCrippleableLocation() {
@@ -810,6 +829,11 @@ class DamageCalculator {
     let injury = Math.floor(
       (this.penetratingDamage * this._parent.totalWoundingModifier) / this._parent.explosionDivisor
     )
+
+    if (this._parent._damageReductionLevel !== null && this._parent._damageReductionLevel != 0) {
+      // Injury Tolerance (Damage Reduction) can't reduce damage below 1
+      injury = Math.max(1, Math.floor(injury / this._parent._damageReductionLevel));
+    }
 
     // B380: A target with Injury Tolerance (Diffuse) is even harder to damage!
     if (this._parent.isInjuryTolerance && this._parent.injuryToleranceType === DIFFUSE) {

--- a/templates/apply-damage/apply-damage-dialog.html
+++ b/templates/apply-damage/apply-damage-dialog.html
@@ -244,7 +244,21 @@
             </div>
           </div>
 
-          <div class='collapsible-wrapper options-drawer'>
+          <div style='display: flex; flex-direction: column; justify-content: center;'>
+            <div id='damage-reduction-container' class='gurps-3col'>
+              <input id='damage-reduction' type='checkbox' value='damage-reduction' {{#if
+                     CALC.useDamageReduction}}checked{{/if}}>
+              <label for='damage-reduction'>Damage Reduction</label>
+              <div id='damage-reduction-field' class='with-button'>
+                <input type='text' id='damage-reduction-level' class='digits-only'
+                       value='{{CALC.damageReductionLevel}}' {{#unless CALC.useDamageReduction}}disabled{{/unless}}
+                style='border: 1px solid #7a7971;'>
+                <button name='clear'><span class='fas fa-times-circle'></button>
+              </div>
+            </div>
+          </div>
+
+          <div class='shaded collapsible-wrapper options-drawer'>
             <input id='explosion-damage' class='toggle' type='checkbox' value='explosion-damage' {{#if
               CALC.isExplosion}}checked{{/if}}></input>
             <label for='explosion-damage' class='label-toggle'>Explosion:<span class='pdflink'>B414</span></label>
@@ -258,7 +272,7 @@
 
           {{#if CALC.useBluntTrauma}}
           <div style='display: flex; flex-direction: column; justify-content: center;'>
-            <div id='specials-insert-point' class='shaded gurps-3col'>
+            <div id='specials-insert-point' class='gurps-3col'>
               <input id='flexible-armor' type='checkbox' value='flexible-armor' {{#if
                 CALC.isFlexibleArmor}}checked{{/if}}>
               <label for='flexible-armor'>{{localize "GURPS.addFlexibleArmor"}}
@@ -274,7 +288,7 @@
           </div>
           {{/if}}
 
-          <div class='collapsible-wrapper options-drawer'>
+          <div class='shaded collapsible-wrapper options-drawer'>
             <input id='shotgun-damage' class='toggle' type='checkbox' value='shotgun-damage' {{#if
               CALC.isShotgun}}checked{{/if}}></input>
             <label for='shotgun-damage' class='label-toggle'>{{localize "GURPS.addShotgunCloseRange"}}:<span


### PR DESCRIPTION
This is a form of Injury Tolerance introduced in GURPS Powers and used extensively in GURPS Supers. It divides injury by a specific number. I've implemented it to be separate from the existing Injury Tolerance values in the ADD because you can both have Injury Tolerance (Unliving/Homogenous) and Injury Tolerance (Damage Reduction) and they are cumulative. Since Injury Tolerance (Damage Reduction) comes in infinite levels (divides injury by 2, 3, 4, 5, 6 etc) I've implemented it as a numeric input field instead of a radio selection or similar.