### PR TITLE
0.8.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Users Guide for [GURPS 4e game aid for Foundry VTT](https://bit.ly/2JaSlQd)
 
-# Current Release Version 0.8.22
+# Current Release Version 0.8.23
 
 [If you like our work...](https://ko-fi.com/crnormand)
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 This is what we are currently working on:
 
-0.8.23
+## History
+
+0.8.23 - 4/13/2021
   
 - Fixed Equipment editing when using The Furnace, because I guess they never thought people might use {{count}} in their own dialogs.
 - Merged @Exxar's Damage Reduction: Injury Tolerance code into ADD
@@ -23,9 +25,6 @@ This is what we are currently working on:
 - Fixed Explosion damage calculation.
 - Added ability to override the text of the OtF buttons ["New Text" Dodge]
 - Auto import when in Foundry Data (GCS export includes Portrait)
-
-
-## History
 
 0.8.22 - 3/31/2021
 

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT (GCS/GCA edition)",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "minimumCoreVersion": "0.7.5",
   "compatibleCoreVersion": "0.7.9",
   "templateVersion": 2,
@@ -44,6 +44,6 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.8.22.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.8.23.zip",
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Fixed Equipment editing when using The Furnace, because I guess they never thought people might use {{count}} in their own dialogs.
- Merged @Exxar's Damage Reduction: Injury Tolerance code into ADD
- Adjust ADD results to show +3 bonus to HT checks when damage is Ranged, 1/2D.
- Fixed drag and drop macros to be compatible with The Furnace
- Initial implementation of a Slam calculator. Access via the chat message '/slam'. There must be a selected character, and it will fill in the HP and Velocity fields based on that character's HP and Basic Speed fields. If the user has a targeted token, that character's HP will be automatically entered.
- Added i18n tags to most of modifier bucket popup. Just need folks to submit translations!
- Re-skinned the modifier bucket UI.
- Fixed the problem of some browsers causing the Modifier Bucket tooltip to close when selecting something from a dropdown menu.
- Allow any damage type to be applied to a resource tracker. (Resource must be named, have a unique alias, and "Use as Damage Tracker" is checked.)
- Disabled the Min/Max/Current fields from a Resource Tracker editor if opened from the Tracker Manager.
- New/Updated Resource Tracker templates no longer need a Foundry restart to take effect.
- /ev now affects player owned tokens on current scene (and not all Player Characters)
- Made mapped attributes (ex: 'will', 'per', 'vision', etc.) case insensitive
- Allow multi-line entries in QuickNotes
- Added Initiative system setting
- Added GURPS.findAdDisad(), and updated GURPS.findSkillSpell() and GURPS.findAttack() for script macros
- Fixed Explosion damage calculation.
- Added ability to override the text of the OtF buttons ["New Text" Dodge]
- Auto import when in Foundry Data (GCS export includes Portrait)
