### PR TITLE
0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Users Guide for [GURPS 4e game aid for Foundry VTT](https://bit.ly/2JaSlQd)
 
-# Current Release Version 0.8.23
+# Current Release Version 0.9.0
 
 [If you like our work...](https://ko-fi.com/crnormand)
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 This is what we are currently working on:
 
+## History
+
 0.9.0
 - rewrite of Modifier Bucket communication system, now commands are guaranteed to be sequential
 - refactor Chat command parsing
@@ -14,8 +16,6 @@ This is what we are currently working on:
 - /remote GM only command.   Execute OtF on the remote client
 - Press SHIFT key to make OtF rolls private
 - Show Move/Flight Move checkbox in Editor
-
-## History
 
 0.8.23 - 4/13/2021
   

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -1290,7 +1290,7 @@ export class GurpsActorEditorSheet extends GurpsActorSheet {
       scrollY: [
         '.gurpsactorsheet #advantages #reactions #melee #ranged #skills #spells #equipment #other_equipment #notes',
       ],
-      width: 800,
+      width: 880,
       height: 800,
       tabs: [{ navSelector: '.sheet-tabs', contentSelector: '.sheet-body', initial: 'description' }],
       dragDrop: [{ dragSelector: '.item-list .item', dropSelector: null }],

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT (GCS/GCA edition)",
-  "version": "0.8.23",
+  "version": "0.9.0",
   "minimumCoreVersion": "0.7.5",
   "compatibleCoreVersion": "0.7.9",
   "templateVersion": 2,
@@ -44,7 +44,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.8.23.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.9.0.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- rewrite of Modifier Bucket communication system, now commands are guaranteed to be sequential
- refactor Chat command parsing
- Added /if chat command  ["Acrobatic Dodge"/if [S:Acrobatics] /r [+2 Acrobatics] /else [-2 Failed Acrobatics]\\/r [Dodge]]
- Added OtF [D:AttackName].   Roll the Damage for attack (similiar to [A:AttackName], which rolls the skill)
- Fixed GM Send now also transfers the OtF label (ex: "Acrobatic Dodge" from above)
- Fixed Initiative formula propagating to client VMs
- /tracker (/tr) now resets "damage trackers" to zero, instead of max
- Continued i18n work on chat processors
- /remote GM only command.   Execute OtF on the remote client
- Press SHIFT key to make OtF rolls private
- Show Move/Flight Move checkbox in Editor
