### PR TITLE
0.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Users Guide for [GURPS 4e game aid for Foundry VTT](https://bit.ly/2JaSlQd)
 
-# Current Release Version 0.9.1
+# Current Release Version 0.9.2
 
 [If you like our work...](https://ko-fi.com/crnormand)
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ This is what we are currently working on:
 
 ## History
 
+0.9.2 - 4/29/201
+- CTRL-roll was broken for certain keyboard events, causing chat commands to fail (ex: /ra)
+
 0.9.1 - 4/28/2021
 - Modifier bucket is now scalable in the system settings. Its a client setting so every user can have a different scale factor. At its smallest size (80%) it fits on a 1024x640 monitor. Tiny laptop users, rejoice!!
 - The "Common Modifiers" pane of the Modifier Bucket is now a tabbed interface and the user can set any number of journal entries to display in that pane. Use journals to customize your MB!!! Which journal entries to use is a client setting. See this GitHub issue for more info: [#434](https://github.com/crnormand/gurps/issues/434#issuecomment-825715096) 

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT (GCS/GCA edition)",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "minimumCoreVersion": "0.7.5",
   "compatibleCoreVersion": "0.7.9",
   "templateVersion": 2,
@@ -44,7 +44,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.9.1.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.9.2.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- CTRL-roll was broken for certain keyboard events, causing chat commands to fail (ex: /ra)
