### PR TITLE
0.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e game aid for Foundry VTT
+If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 # Current Release Version 0.9.3
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,17 @@
-### Users Guide for [GURPS 4e game aid for Foundry VTT](https://bit.ly/2JaSlQd)
+# [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e game aid for Foundry VTT
+# Current Release Version 0.9.3
+### [Change Log](changelog.md)
+The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.
 
-# Current Release Version 0.9.2
-
-[If you like our work...](https://ko-fi.com/crnormand)
-
-<a href="https://ko-fi.com/crnormand"><img height="36" src="https://cdn.ko-fi.com/cdn/kofi2.png?v=2"></a>
-
-To install the latest stable release, use this manifest URL:  
-[https://raw.githubusercontent.com/crnormand/gurps/release/system.json](https://raw.githubusercontent.com/crnormand/gurps/release/system.json)
-
-[Getting Started video](https://youtu.be/FUqtOkdyBCo) / [Players Guide video](https://youtu.be/x-xD39x_JQw)
+[If you like our work...](https://ko-fi.com/crnormand) <a href="https://ko-fi.com/crnormand"><img height="36" src="https://cdn.ko-fi.com/cdn/kofi2.png?v=2"></a>
 
 Join us on Discord: [GURPS Foundry-VTT Discord](https://discord.gg/6xJBcYWyED)
 
-### If you are looking for the latest stable release, use the manifest URL above.
-We are actively developing on the 'main' branch, and sometimes things break ;-)
-
 [Current GCA Export version: 'GCA-7' 2/18/2021 / Current GCS Export version: 'GCS-5' 3/8/2021](https://drive.google.com/file/d/1vbDb9WtYQiZI78Pwa_TlEvYpJnR_S67B/view?usp=sharing)
 
-## [Change Log](changelog.md)
-The list was getting just too long, so it has been moved to a separate file.   Click to see what has changed.
 
+
+#### Legal
 The material presented here is my original creation, intended for use with the [GURPS](http://www.sjgames.com/gurps) system from [Steve Jackson Games](ttp://www.sjgames.com). This material is not official and is not endorsed by Steve Jackson Games.
 
 [GURPS](http://www.sjgames.com/gurps) is a trademark of Steve Jackson Games, and its rules and art are copyrighted by Steve Jackson Games. All rights are reserved by Steve Jackson Games. This game aid is the original creation of Chris Normand/Nose66 and is released for free distribution, and not for resale, under the permissions granted in the [Steve Jackson Games Online Policy](http://www.sjgames.com/general/online_policy.html)

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 ### [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e game aid for Foundry VTT
+If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
 This is what we are currently working on:
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,10 @@
-### Users Guide for [GURPS 4e game aid for Foundry VTT](https://bit.ly/2JaSlQd)
+### [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e game aid for Foundry VTT
 
 This is what we are currently working on:
 
-0.9.3
+## History
+
+0.9.3 - 5/04/2021
 
  - Changed the 'persistent' equipment and notes (those that survive a GCS/GCA import) icon to a blue bookmark and right-justified the icon for equipment.
  - Fixed modifier bucket to respect permissions on journal entries selected for viewing.
@@ -10,12 +12,12 @@ This is what we are currently working on:
  - /select now also changes Foundry's selection.  /sel Bog \\\\ /status on prone
  - /sendMB (and MB send) now works for Assistants
 
-## History
-
 0.9.2 - 4/29/2021
+
 - CTRL-roll was broken for certain keyboard events, causing chat commands to fail (ex: /ra)
 
 0.9.1 - 4/28/2021
+
 - Modifier bucket is now scalable in the system settings. Its a client setting so every user can have a different scale factor. At its smallest size (80%) it fits on a 1024x640 monitor. Tiny laptop users, rejoice!!
 - The "Common Modifiers" pane of the Modifier Bucket is now a tabbed interface and the user can set any number of journal entries to display in that pane. Use journals to customize your MB!!! Which journal entries to use is a client setting. See this GitHub issue for more info: [#434](https://github.com/crnormand/gurps/issues/434#issuecomment-825715096) 
 - Fixed a bug so that the ADD will use "effective damage" instead of "basic damage" to calculate knockback. This fixes the problems with explosions and knockback.
@@ -31,6 +33,7 @@ This is what we are currently working on:
 - Added System setting to show 'saved' icon next to user created equipment and notes.
 
 0.9.0 - 4/22/2021
+
 - rewrite of Modifier Bucket communication system, now commands are guaranteed to be sequential
 - refactor Chat command parsing
 - Added /if chat command  ["Acrobatic Dodge"/if [S:Acrobatics] /r [+2 Acrobatics] /else [-2 Failed Acrobatics]\\/r [Dodge]]

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "minimumCoreVersion": "0.7.5",
   "compatibleCoreVersion": "0.7.9",
   "templateVersion": 2,
@@ -44,7 +44,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.9.2.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.9.3.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
•Changed the 'persistent' equipment and notes (those that survive a GCS/GCA import) icon to a blue bookmark and right-justified the icon for equipment.
•Fixed modifier bucket to respect permissions on journal entries selected for viewing.
•Fixed OtF buttons in a journal entry being viewed in the Modifier Bucket from being truncated at the first HTML escaped character (such as '\ü').
•/select now also changes Foundry's selection. /sel Bog \\ /status on prone
•/sendMB (and MB send) now works for Assistants