### PR TITLE
0.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
-# Current Release Version 0.9.3
+# Current Release Version 0.9.4
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,10 @@ If you can't access the Google doc, here is a [PDF](https://github.com/crnormand
 
 This is what we are currently working on:
 
+## History
+
+0.9.4 - 5/06/2021
+
 - Fixed /status command to accept either 't' or 'toggle'
 - Added new syntax to /if command to allow nested /ifs {}
 - Fixed synchronization of /if "then" and "else" clauses
@@ -12,8 +16,6 @@ This is what we are currently working on:
 - Added "named token/actor" to /status command (format: `/st + sleep* :Name`). ':Name' may contain a wildcard and will match either a token name or an actor name (first it tries tokens, then actors). The token must be in the active scene. 
 - Fixed older actors not having currentmove/dodge or flight values
 - Add warning if trying to Edit an empty actor
-
-## History
 
 0.9.3 - 5/04/2021
 

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "minimumCoreVersion": "0.7.5",
   "compatibleCoreVersion": "0.7.9",
   "templateVersion": 2,
@@ -44,7 +44,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.9.3.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.9.4.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Fixed /status command to accept either 't' or 'toggle'
- Added new syntax to /if command to allow nested /ifs {}
- Fixed synchronization of /if "then" and "else" clauses
- Forgot to add Foundry selection for /select @self
- Fixed 'reeling' and 'tired' statuses (tired was actually reeling, and you couldn't manually set tired)
- Fixed /status command with @self -- now it will toggle a status on a token owned by the user (if there is only one)
- Added "named token/actor" to /status command (format: `/st + sleep* :Name`). ':Name' may contain a wildcard and will match either a token name or an actor name (first it tries tokens, then actors). The token must be in the active scene. 
- Fixed older actors not having currentmove/dodge or flight values
- Add warning if trying to Edit an empty actor