### PR TITLE
Ok, a whole new migration strategy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,8 @@ This is what we are currently working on:
 
 0.9.6 
 
-- Updating migration code to remove possible infinite loop issue.
+- Update migration code to remove possible infinite loop issue
+- Make Skill/Spell/Attack (Melee/Ranged/Damage) OtF formulas case insensitive
 
 0.9.5 - 5/19/2021
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,14 @@ If you can't access the Google doc, here is a [PDF](https://github.com/crnormand
 
 This is what we are currently working on:
 
+## History
+
+0.9.6 
+
+- Updating migration code to remove possible infinite loop issue.
+
+0.9.5 - 5/19/2021
+
 - Fixed /status command when token.actor == null
 - Refactor regex pattern matching to utilities.js
 - Added "apply condition" buttons to slam results chat messages. These buttons will select the affected combatant and either roll DX and apply the Prone condition if failed, or directly apply Prone if appropriate.
@@ -34,8 +42,6 @@ This is what we are currently working on:
 - Added support for /if [/qty -?] /hp +1d]
 - Added support for /qty detecting the current equipment
 - Added support for parameters and return values from script macros (GURPS.chatargs & GURPS.chatreturn)
-
-## History
 
 0.9.4 - 5/06/2021
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -8,7 +8,7 @@ export class Migration {
     ui.notifications.info("Please wait, migrating Actors to v0.9.6")
     console.log("Migrating Actors to v0.9.6")
     for ( let actor of game.actors.entities ) {
-      let commit = {}
+      let commit = { "data.migrationversion" : '0.9.6' }
       for (const attr in actor.data.data.attributes) {
         if (actor.data.data.attributes[attr].import == null)
           commit = { ...commit, ...{ ['data.attributes.' + attr + '.import']: actor.data.data.attributes[attr].value } }

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -4,7 +4,7 @@ import * as Settings from './miscellaneous-settings.js'
 
 export class Migration {
 
-  static migrateTo096() {
+  static async migrateTo096() {
     ui.notifications.info("Please wait, migrating Actors to v0.9.6")
     console.log("Migrating Actors to v0.9.6")
     for ( let actor of game.actors.entities ) {
@@ -29,7 +29,7 @@ export class Migration {
       if (Object.keys(commit).length > 0) {
         console.log("Updating " + actor.name)
         console.log(GURPS.objToString(commit))
-        actor.update(commit)
+        await actor.update(commit)
       }
     }
     ui.notifications.info("Migration to v0.9.6 complete!")

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -1,0 +1,36 @@
+import { recurselist } from './utilities.js'
+
+
+export class Migration {
+
+  static migrateTo096() {
+    ui.notifications.info("Please wait, migrating Actors to v0.9.6")
+    console.log("Migrating Actors to v0.9.6")
+    for ( let actor of game.actors.entities ) {
+      let commit = {}
+      for (const attr in actor.data.data.attributes) {
+        if (actor.data.data.attributes[attr].import == null)
+          commit = { ...commit, ...{ ['data.attributes.' + attr + '.import']: actor.data.data.attributes[attr].value } }
+      }
+      recurselist(actor.data.data.skills, (e, k, d) => {
+        if (e.import == null) commit = { ...commit, ...{ ['data.skills.' + k + '.import']: e.level || 1 } }
+      })
+      recurselist(actor.data.data.spells, (e, k, d) => {
+        if (e.import == null) commit = { ...commit, ...{ ['data.spells.' + k + '.import']: e.level | 1 } }
+      })
+      recurselist(actor.data.data.melee, (e, k, d) => {
+        if (e.import == null) commit = { ...commit, ...{ ['data.melee.' + k + '.import']: e.level | 1 } }
+      })
+      recurselist(actor.data.data.ranged, (e, k, d) => {
+        if (e.import == null) commit = { ...commit, ...{ ['data.ranged.' + k + '.import']: e.level | 1} }
+      })
+      // We must delay the upgrade of older actor's 'import' keys, since upon startup, the actor may not know which collection it belongs to
+      if (Object.keys(commit).length > 0) {
+        console.log("Updating " + actor.name)
+        console.log(GURPS.objToString(commit))
+        actor.update(commit)
+      }
+    }
+    ui.notifications.info("Migration to v0.9.6 complete!")
+  }
+}

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -1,4 +1,5 @@
 import { recurselist } from './utilities.js'
+import * as Settings from './miscellaneous-settings.js'
 
 
 export class Migration {
@@ -32,5 +33,6 @@ export class Migration {
       }
     }
     ui.notifications.info("Migration to v0.9.6 complete!")
+    game.settings.set(Settings.SYSTEM_NAME, Settings.SETTING_MIGRATION_VERSION, '0.9.6') 
   }
 }

--- a/lib/miscellaneous-settings.js
+++ b/lib/miscellaneous-settings.js
@@ -5,6 +5,7 @@ import Initiative from './initiative.js'
 import { i18n } from '../lib/utilities.js'
 
 export const SYSTEM_NAME = 'gurps'
+export const SETTING_MIGRATION_VERSION = 'migration-version'
 export const SETTING_DEFAULT_LOCATION = 'default-hitlocation'
 export const SETTING_SIMPLE_DAMAGE = 'combat-simple-damage'
 export const SETTING_APPLY_DIVISOR = 'combat-apply-divisor'
@@ -55,6 +56,16 @@ export function initializeSettings() {
       type: String,
       default: '0.0.0',
       onChange: value => console.log(`Change Log version : ${value}`),
+    })
+
+    // Keep track of the last version number
+    game.settings.register(SYSTEM_NAME, SETTING_MIGRATION_VERSION, {
+      name: 'Migration Version',
+      scope: 'world',
+      config: false,
+      type: String,
+      default: '0.0.0',
+      onChange: value => console.log(`Migration Log version : ${value}`),
     })
 
     // In case the user wants to see what changed between versions

--- a/lib/parselink.js
+++ b/lib/parselink.js
@@ -314,10 +314,10 @@ export function parselink(str, htmldesc, clrdmods = false) {
   //  - ([^\|])* - COMMENT - zero or more run of characters that do not include |
   //  - (\|.*)? - REMAINDER - | followed by any run of characters (optional)
   //
-  let parse = str.replace(/^S[pkPK]?:"([^"]+)" ?([-+]\d+)? ?([^\|]*)(\|.*)?/g, '$1~$2~$3~$4')
+  let parse = str.replace(/^S[pkPK]?:"([^"]+)" ?([-+]\d+)? ?([^\|]*)(\|.*)?/gi, '$1~$2~$3~$4')
   if (parse == str) {
     // Use quotes to capture skill/spell name (with as many * as they want to embed)
-    parse = str.replace(/^S[pkPK]?:([^\| \?\(+-]+\*?) ?([-+]\d+)? ?([^\|]*)(\|.*)?/g, '$1~$2~$3~$4')
+    parse = str.replace(/^S[pkPK]?:([^\| \?\(+-]+\*?) ?([-+]\d+)? ?([^\|]*)(\|.*)?/gi, '$1~$2~$3~$4')
   }
 
   if (parse != str) {
@@ -333,9 +333,9 @@ export function parselink(str, htmldesc, clrdmods = false) {
       let floatingAttribute = null
       let floatingLabel = null
       let floatingType = null
-      let matches = comment.match(/(\((Based|Base|B): ?[^\)]+\))/g)
+      let matches = comment.match(/(\((Based|Base|B): ?[^\)]+\))/gi)
       if (!!matches) {
-        floatingLabel = comment.replace(/.*\((Based|Base|B): ?([^\)]+)\).*/g, '$2')
+        floatingLabel = comment.replace(/.*\((Based|Base|B): ?([^\)]+)\).*/gi, '$2')
         //console.log(`floating ${floatingLabel}`)
 
         comment = comment
@@ -420,10 +420,10 @@ export function parselink(str, htmldesc, clrdmods = false) {
   }
 
   // Simple, no-spaces, no quotes melee/ranged name (with optional *s)
-  parse = str.replace(/^[MRAD]:([^ "+-]+\*?) ?([-+]\d+)? ?(.*)/g, '$1~$2~$3')
+  parse = str.replace(/^[MRAD]:([^ "+-]+\*?) ?([-+]\d+)? ?(.*)/gi, '$1~$2~$3')
   if (parse == str) {
     // Use quotes to capture skill/spell name (with optional *s)
-    parse = str.replace(/^[MRAD]:"([^"]+)" ?([-+]\d+)? ?(.*)/g, '$1~$2~$3')
+    parse = str.replace(/^[MRAD]:"([^"]+)" ?([-+]\d+)? ?(.*)/gi, '$1~$2~$3')
   }
   if (parse != str) {
     let a = parse.split('~')
@@ -451,8 +451,8 @@ export function parselink(str, htmldesc, clrdmods = false) {
         comment = ''
       }
       if (!!costs) spantext += ' ' + costs
-      let isMelee = !!str.match(/^[AMD]/)
-      let isRanged = !!str.match(/^[ARD]/)
+      let isMelee = !!str.match(/^[AMD]/i)
+      let isRanged = !!str.match(/^[ARD]/i)
       let action = {
         orig: str,
         type: str.startsWith('D') ? 'attackdamage' : 'attack',

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -150,7 +150,7 @@ export class GurpsActorSheet extends ActorSheet {
             const w = 50;
             const h = 50;
             const preview = DragDrop.createDragImage(img, w, h);
-            ev.dataTransfer.setDragImage(preview, w/2, h/2); 
+            ev.dataTransfer.setDragImage(preview, 0, 0); 
           }
           let newd = {
             actorid: this.actor.id, 

--- a/module/actor.js
+++ b/module/actor.js
@@ -49,27 +49,20 @@ export class GurpsActor extends Actor {
 
   // Initialize the attribute current values/levels.   The code is expecting 'value' or 'level' for many things, and instead of changing all of the GUIs and OTF logic
   // we are just going to switch the rug out from underneath.   "Import" data will be in the 'import' key and then we will calculate value/level when the actor is loaded.
-  // If import keys don't exist, set them to the current value and commit to upgrade older actors
   _initCurrents() {
     // Attributes need to have 'value' set because Foundry expects objs with value and max to be attributes (so we can't use currentvalue)
     let commit = {}
     for (const attr in this.data.data.attributes) {
-      if (this.data.data.attributes[attr].import == null)
-        commit = { ...commit, ...{ ['data.attributes.' + attr + '.import']: this.data.data.attributes[attr].value } }
-      // backward compat
-      else this.data.data.attributes[attr].value = this.data.data.attributes[attr].import
+      this.data.data.attributes[attr].value = this.data.data.attributes[attr].import
     }
     recurselist(this.data.data.skills, (e, k, d) => {
-      if (e.import == null && e.level != null) commit = { ...commit, ...{ ['data.skills.' + k + '.import']: e.level } }
-      else e.level = parseInt(e.import)
+      e.level = parseInt(e.import)
     })
     recurselist(this.data.data.spells, (e, k, d) => {
-      if (e.import == null && e.level != null) commit = { ...commit, ...{ ['data.spells.' + k + '.import']: e.level } }
-      else e.level = parseInt(e.import)
+      e.level = parseInt(e.import)
     })
     recurselist(this.data.data.melee, (e, k, d) => {
-      if (e.import == null && e.level != null) commit = { ...commit, ...{ ['data.melee.' + k + '.import']: e.level } }
-      else e.level = parseInt(e.import)
+      e.level = parseInt(e.import)
       if (!isNaN(parseInt(e.parry))) {
         // allows for '14f' and 'no'
         let base = 3 + Math.floor(e.level / 2)
@@ -87,11 +80,8 @@ export class GurpsActor extends Actor {
       }
     })
     recurselist(this.data.data.ranged, (e, k, d) => {
-      if (e.import == null && e.level != null) commit = { ...commit, ...{ ['data.ranged.' + k + '.import']: e.level } }
-      else e.level = parseInt(e.import)
+      e.level = parseInt(e.import)
     })
-    // We must delay the upgrade of older actor's 'import' keys, since upon startup, the actor may not know which collection it belongs to
-    if (Object.keys(commit).length > 0) setTimeout(() => this.update(commit), 1000)
   }
 
   _applyItemBonuses() {

--- a/module/actor.js
+++ b/module/actor.js
@@ -15,6 +15,7 @@ import { ResourceTrackerManager } from '../module/actor/resource-tracker-manager
 import ApplyDamageDialog from './damage/applydamage.js'
 import * as HitLocations from '../module/hitlocation/hitlocation.js'
 import * as settings from '../lib/miscellaneous-settings.js'
+import { SemanticVersion } from '../lib/semver.js'
 
 export class GurpsActor extends Actor {
   /** @override */
@@ -50,22 +51,20 @@ export class GurpsActor extends Actor {
   // Initialize the attribute current values/levels.   The code is expecting 'value' or 'level' for many things, and instead of changing all of the GUIs and OTF logic
   // we are just going to switch the rug out from underneath.   "Import" data will be in the 'import' key and then we will calculate value/level when the actor is loaded.
   _initCurrents() {
+    let v = this.data.data.migrationversion
+    if (!v) return // currently, only need to check for the initial version, but in the future, we might need to check against SemanticVersion.fromString(v)
     // Attributes need to have 'value' set because Foundry expects objs with value and max to be attributes (so we can't use currentvalue)
     let commit = {}
     for (const attr in this.data.data.attributes) {
-      if (!this.data.data.attributes[attr].import) this.data.data.attributes[attr].import = this.data.data.attributes[attr].value
       this.data.data.attributes[attr].value = this.data.data.attributes[attr].import
     }
     recurselist(this.data.data.skills, (e, k, d) => {
-      if (!e.import) e.import = e.level
       e.level = parseInt(e.import)
     })
     recurselist(this.data.data.spells, (e, k, d) => {
-      if (!e.import) e.import = e.level
       e.level = parseInt(e.import)
     })
     recurselist(this.data.data.melee, (e, k, d) => {
-      if (!e.import) e.import = e.level
       e.level = parseInt(e.import)
       if (!isNaN(parseInt(e.parry))) {
         // allows for '14f' and 'no'
@@ -84,8 +83,7 @@ export class GurpsActor extends Actor {
       }
     })
     recurselist(this.data.data.ranged, (e, k, d) => {
-      if (!e.import) e.import = e.level
-      e.level = parseInt(e.import)
+       e.level = parseInt(e.import)
     })
   }
 

--- a/module/actor.js
+++ b/module/actor.js
@@ -365,7 +365,7 @@ export class GurpsActor extends Actor {
     console.log("Importing '" + nm + "'")
     // this is how you have to update the domain object so that it is synchronized.
 
-    let commit = {}
+    let commit = { "data.migrationversion" : game.system.data.version }
 
     if (!game.settings.get(settings.SYSTEM_NAME, settings.SETTING_IGNORE_IMPORT_NAME)) {
       commit = { ...commit, ...{ name: nm } }

--- a/module/actor.js
+++ b/module/actor.js
@@ -53,15 +53,19 @@ export class GurpsActor extends Actor {
     // Attributes need to have 'value' set because Foundry expects objs with value and max to be attributes (so we can't use currentvalue)
     let commit = {}
     for (const attr in this.data.data.attributes) {
+      if (!this.data.data.attributes[attr].import) this.data.data.attributes[attr].import = this.data.data.attributes[attr].import
       this.data.data.attributes[attr].value = this.data.data.attributes[attr].import
     }
     recurselist(this.data.data.skills, (e, k, d) => {
+      if (!e.import) e.import = e.level
       e.level = parseInt(e.import)
     })
     recurselist(this.data.data.spells, (e, k, d) => {
+      if (!e.import) e.import = e.level
       e.level = parseInt(e.import)
     })
     recurselist(this.data.data.melee, (e, k, d) => {
+      if (!e.import) e.import = e.level
       e.level = parseInt(e.import)
       if (!isNaN(parseInt(e.parry))) {
         // allows for '14f' and 'no'
@@ -80,6 +84,7 @@ export class GurpsActor extends Actor {
       }
     })
     recurselist(this.data.data.ranged, (e, k, d) => {
+      if (!e.import) e.import = e.level
       e.level = parseInt(e.import)
     })
   }

--- a/module/actor.js
+++ b/module/actor.js
@@ -53,7 +53,7 @@ export class GurpsActor extends Actor {
     // Attributes need to have 'value' set because Foundry expects objs with value and max to be attributes (so we can't use currentvalue)
     let commit = {}
     for (const attr in this.data.data.attributes) {
-      if (!this.data.data.attributes[attr].import) this.data.data.attributes[attr].import = this.data.data.attributes[attr].import
+      if (!this.data.data.attributes[attr].import) this.data.data.attributes[attr].import = this.data.data.attributes[attr].value
       this.data.data.attributes[attr].value = this.data.data.attributes[attr].import
     }
     recurselist(this.data.data.skills, (e, k, d) => {

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -871,6 +871,7 @@ function findSkillSpell(actor, sname, isSkillOnly = false, isSpellOnly = false) 
   if (!actor) return t
   if (!!actor.data?.data?.additionalresources) actor = actor.data
   sname = makeRegexPatternFrom(sname, false)
+  sname = new RegExp(sname, "i");
   let best = 0
   if (!isSpellOnly)
     recurselist(actor.data.skills, s => {
@@ -896,6 +897,7 @@ function findAdDisad(actor, sname) {
   if (!actor) return t
   if (!!actor.data?.data?.additionalresources) actor = actor.data
   sname = makeRegexPatternFrom(sname, false)
+  sname = new RegExp(sname, "i");
   recurselist(actor.data.ads, s => {
     if (s.name.match(sname)) {
       t = s
@@ -910,6 +912,7 @@ function findAttack(actor, sname, isMelee = true, isRanged = true) {
   if (!actor) return t
   if (!!actor.data?.data?.additionalresources) actor = actor.data
   sname = makeRegexPatternFrom(sname, false)
+  sname = new RegExp(sname, "i");
   if (isMelee)
     t = actor.data.melee?.findInProperties(a => (a.name + (!!a.mode ? ' (' + a.mode + ')' : '')).match(sname))
   if (isRanged && !t)

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1557,7 +1557,7 @@ Hooks.once('ready', async function () {
   console.log("Migration version: " + mv)
   const migrationVersion = SemanticVersion.fromString(mv)
   const v096 = SemanticVersion.fromString('0.9.6')
-  //if (migrationVersion.isLowerThan(v096)) setTimeout(() => Migration.migrateTo096(), 5000)
+  if (migrationVersion.isLowerThan(v096)) Migration.migrateTo096()
 
   // Show changelog
   const v = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_CHANGELOG_VERSION) || '0.0.1'

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1557,7 +1557,7 @@ Hooks.once('ready', async function () {
   console.log("Migration version: " + mv)
   const migrationVersion = SemanticVersion.fromString(mv)
   const v096 = SemanticVersion.fromString('0.9.6')
-  if (migrationVersion.isLowerThan(v096)) Migration.migrateTo096()
+  //if (migrationVersion.isLowerThan(v096)) setTimeout(() => Migration.migrateTo096(), 5000)
 
   // Show changelog
   const v = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_CHANGELOG_VERSION) || '0.0.1'

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -20,6 +20,7 @@ import { doRoll } from '../module/dierolls/dieroll.js'
 import { ResourceTrackerManager } from './actor/resource-tracker-manager.js'
 import { DamageTables, initializeDamageTables } from '../module/damage/damage-tables.js'
 import RegisterChatProcessors from '../module/chat/chat-processors.js'
+import { Migration } from '../lib/migration.js'
 
 export const GURPS = {}
 window.GURPS = GURPS // Make GURPS global!
@@ -1555,6 +1556,7 @@ Hooks.once('ready', async function () {
   const v = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_CHANGELOG_VERSION) || '0.0.1'
   const changelogVersion = SemanticVersion.fromString(v)
   const curVersion = SemanticVersion.fromString(game.system.data.version)
+  const v096 = SemanticVersion.fromString('0.9.6')
 
   if (curVersion.isHigherThan(changelogVersion)) {
     if ($(ui.chat.element).find('#GURPS-LEGAL').length == 0)
@@ -1579,6 +1581,7 @@ Hooks.once('ready', async function () {
       app.render(true)
       game.settings.set(settings.SYSTEM_NAME, settings.SETTING_CHANGELOG_VERSION, curVersion.toString())
     }
+    if (changelogVersion.isLowerThan(v096)) Migration.migrateTo096()
   }
 
   // get all aliases defined in the resource tracker templates and register them as damage types

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1551,6 +1551,13 @@ Hooks.once('ready', async function () {
     template: 'systems/gurps/templates/threed6.html',
     classes: [],
   }).render(true)
+  
+  // Test for migration
+  const mv = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_MIGRATION_VERSION) || '0.0.1'
+  console.log("Migration version: " + mv)
+  const migrationVersion = SemanticVersion.fromString(mv)
+  const v096 = SemanticVersion.fromString('0.9.6')
+  if (migrationVersion.isLowerThan(v096)) Migration.migrateTo096()
 
   // Show changelog
   const v = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_CHANGELOG_VERSION) || '0.0.1'
@@ -1580,11 +1587,6 @@ Hooks.once('ready', async function () {
       app.render(true)
       game.settings.set(settings.SYSTEM_NAME, settings.SETTING_CHANGELOG_VERSION, curVersion.toString())
     }
-    
-    // Test for migration
-    const mig = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_MIGRATION_VERSION) || '0.0.1'
-    const v096 = SemanticVersion.fromString('0.9.6')
-    if (mig.isLowerThan(v096)) Migration.migrateTo096()
   }
 
   // get all aliases defined in the resource tracker templates and register them as damage types

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1556,7 +1556,6 @@ Hooks.once('ready', async function () {
   const v = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_CHANGELOG_VERSION) || '0.0.1'
   const changelogVersion = SemanticVersion.fromString(v)
   const curVersion = SemanticVersion.fromString(game.system.data.version)
-  const v096 = SemanticVersion.fromString('0.9.6')
 
   if (curVersion.isHigherThan(changelogVersion)) {
     if ($(ui.chat.element).find('#GURPS-LEGAL').length == 0)
@@ -1581,7 +1580,11 @@ Hooks.once('ready', async function () {
       app.render(true)
       game.settings.set(settings.SYSTEM_NAME, settings.SETTING_CHANGELOG_VERSION, curVersion.toString())
     }
-    if (changelogVersion.isLowerThan(v096)) Migration.migrateTo096()
+    
+    // Test for migration
+    const mig = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_MIGRATION_VERSION) || '0.0.1'
+    const v096 = SemanticVersion.fromString('0.9.6')
+    if (mig.isLowerThan(v096)) Migration.migrateTo096()
   }
 
   // get all aliases defined in the resource tracker templates and register them as damage types

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "minimumCoreVersion": "0.7.5",
   "compatibleCoreVersion": "0.7.9",
   "templateVersion": 2,
@@ -44,7 +44,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.9.5.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.9.6.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
Because we needed to "swap" out data from 'level' attributes to 'import' attributes, we had to take a 2 prong approach.   There is a world system setting for the migration version (which will update to 0.9.6) and then there is an individual migration version for each actor.  This is necessary so that the "swap" code doesn't try to swap level for import, right before the migration code swaps import for level.

Don't worry... it all makes sense.   But from now on, actors will have a 'data.migrationversion' variable, which will be the game system version of when they were last imported.   

We might be able to use that in the future... but in any case, it works as a semaphore to block the _initCurrents() code from executing before the migration code can do its work.