### PR TITLE
0.9.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
-# Current Release Version 0.9.8
+# Current Release Version 0.9.9
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.
 

--- a/module/actor.js
+++ b/module/actor.js
@@ -1665,6 +1665,7 @@ export class GurpsActor extends Actor {
       if (key == 'melee') {
         if (!isNaN(parseInt(e.parry))) {
           let m = e.parry.match(/([+-]\d+)(.*)/)
+          if (!m && e.parry.trim() == '0') m = [ 0, 0 ]  // allow '0' to mean 'no bonus', not skill level = 0
           if (!!m) {
             e.parrybonus = parseInt(m[1])
             e.parry = e.parrybonus + 3 + Math.floor(e.import / 2)
@@ -1673,6 +1674,7 @@ export class GurpsActor extends Actor {
         }
         if (!isNaN(e.block)) {
           let m = e.block.match(/([+-]\d+)(.*)/)
+          if (!m && e.block.trim() == '0') m = [ 0, 0 ]  // allow '0' to mean 'no bonus', not skill level = 0
           if (!!m) {
             e.blockbonus = parseInt(m[1])
             e.block = e.blockbonus + 3 + Math.floor(e.import / 2)

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "minimumCoreVersion": "0.7.5",
   "compatibleCoreVersion": "0.7.9",
   "templateVersion": 2,
@@ -44,7 +44,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.9.8.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.9.9.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Adding @neck/rinickolous's inventory sheet
- Replaced /light dialog with parameters torch = /light 6 2 torch (or candle = /light 1 0 t)
- Fixed changelog viewer to actually STOP after current version
- Fixed calculations of Item skill levels when there is a +/-
- Fixed the /qty command so that if defined in one piece of equipment, it can name another piece of equipment and modify that.
- Added /forcemigrate command for players who's actors didn't quite make it.
