### PR TITLE
/uses autodetects, user name/note additions survive import

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ If you can't access the Google doc, here is a [PDF](https://github.com/crnormand
 0.9.11
 
 - Allow user additions to names or notes survive an import (if changes occur at END of imported data)!
+- Added /uses can now automatically detect if it is being run on equipment (like /qty)
 
 0.9.10
 

--- a/module/chat/chat-processors.js
+++ b/module/chat/chat-processors.js
@@ -350,10 +350,29 @@ class UsesChatProcessor extends ChatProcessor {
     let actor = GURPS.LastActor
     if (!actor) ui.notifications.warn(i18n('GURPS.chatYouMustHaveACharacterSelected'))
     else {
+      var eqt, key
       let m2 = m[3].trim().match(/^(o[\.:])?(.*)/i)
       let pattern = m2[2]
-      let [eqt, key] = actor.findEquipmentByName(pattern, !!m2[1])
-      if (!eqt)
+      if (this.msgs().event?.currentTarget) {
+        let t = this.msgs().event?.currentTarget
+        let k = $(t).closest('[data-key]').attr('data-key')
+        // if we find a data-key, then we assume that we are on the character sheet, and if the target
+        // is equipment, apply to that equipment. Except that the user might have specified the name of
+        // another piece of equipment in the command, in which case we should honor his request.
+        if (!!k) {
+          key = k
+          eqt = getProperty(actor.data, key)
+
+          // if its not equipment, ignore.
+          if (eqt.count == null) eqt = null
+          // if it is equipment and the name matches, use it
+          else if (eqt.name.match(pattern)) pattern = 'Current Equipment'
+          // if the name does not match, keep looking (see next block)
+          else eqt = null
+        }
+      }
+      if (!eqt) [eqt, key] = actor.findEquipmentByName(pattern, !!m2[1])
+      if (!eqt || !pattern)
         ui.notifications.warn(i18n('GURPS.chatNoEquipmentMatched', 'No equipment matched') + " '" + pattern + "'")
       else {
         if (!m[1]) {

--- a/module/chat/chat-processors.js
+++ b/module/chat/chat-processors.js
@@ -607,6 +607,10 @@ class LightChatProcessor extends ChatProcessor {
 }
 
 class ForceMigrateChatProcessor extends ChatProcessor {
+ help() {
+    return null
+  }
+
   matches(line) {
     this.match = line.match(/^\/forcemigrate/i)
     return !!this.match


### PR DESCRIPTION
Allow user additions to names or notes survive an import (if changes occur at END of imported data)!
Added /uses can now automatically detect if it is being run on equipment (like /qty)
