### PR TITLE
0.9.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
-# Current Release Version 0.9.11
+# Current Release Version 0.9.12
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.
 

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "minimumCoreVersion": "0.7.5",
   "compatibleCoreVersion": "0.7.9",
   "templateVersion": 2,
@@ -44,7 +44,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.9.11.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.9.12.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Equipment name searches for /qty and /use now start at the front of the name for matching
- Fixed /uses /qty when equipment name is being used
- Only show max the last 5 changes (for new users on browsers)
- Add GM command /reimport to ask all player characters to import
- Items bonuses only applied when Item-equipment is equipped (like GCS)
- Refactor weight calculation
- Protect against dragging Items from unlinked actors
- Add scroll bars to the "Send Modifiers to Players" part of the modifier bucket window.
- Show combat maneuver drop-down on character sheet.
