### PR TITLE
Added margin of success/failure OtF button to targeted rolls

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ If you can't access the Google doc, here is a [PDF](https://github.com/crnormand
 - Items (and Item features) will hover display the Item icon (very basic... would love CSS help!)
 - Fixed GM "Send to" area to provide more room to see buttons
 - Fixed bug in Item creation.  Equipment can no longer contain other hidden equipment
+- Added OtF buttons for margin of success (Rolltable formula "3d6 + @gmodc")
 
 Release 0.10.2
 

--- a/module/dierolls/dieroll.js
+++ b/module/dierolls/dieroll.js
@@ -56,6 +56,8 @@ export async function doRoll(actor, formula, targetmods, prefix, thing, origtarg
     chatdata['margin'] = margin
     chatdata['failure'] = failure
     chatdata['seventeen'] = seventeen
+    chatdata['isDraggable'] = !seventeen && margin != 0
+    chatdata['otf'] = (margin >= 0 ? "+" + margin : margin) + " margin for " + thing
 
     if (margin > 0 && !!optionalArgs.obj && !!optionalArgs.obj.rcl) {		// if the attached obj (see handleRoll()) as Recoil information, do the additional math
       let rofrcl = Math.floor(margin / parseInt(optionalArgs.obj.rcl)) + 1;

--- a/module/modifier-bucket/bucket-app.js
+++ b/module/modifier-bucket/bucket-app.js
@@ -264,10 +264,11 @@ export class ModifierBucket extends Application {
       event.preventDefault();  
       event.stopPropagation();
       let dragData = JSON.parse(event.originalEvent?.dataTransfer?.getData('text/plain'))
-      if (!!dragData && !!dragData.actor && !!dragData.otf) {
+      if (!!dragData && !!dragData.otf) {
         let action = parselink(dragData.otf)
         action.action.blindroll = true
-        GURPS.performAction(action.action, game.actors.get(dragData.actor))
+        if (action.action.type == "modifier" || !!dragData.actor)
+          GURPS.performAction(action.action, game.actors.get(dragData.actor))
       }
     });
 

--- a/templates/die-roll-chat-message.html
+++ b/templates/die-roll-chat-message.html
@@ -30,12 +30,12 @@
         {{else}}{{#if (not failure)}}
         <span class='success'>Success!</span>
         {{/if}}{{/if}}{{/if}}{{/if}}
-        <span class='aside'>
+        <span class='aside' {{#if isDraggable}}' data-otf="{{otf}}"{{/if}}>
           {{#if seventeen}}17 & 18 always fail.
           {{else}}
             {{#if (eq margin 0)}}Just made it.{{/if}}
-            {{#if (gt margin 0)}}Made it by {{margin}}.{{/if}}
-            {{#if (lt margin 0)}}Missed it by {{abs margin}}.{{/if}}
+            {{#if (gt margin 0)}}["Made it by {{margin}}."{{otf}}]{{/if}}
+            {{#if (lt margin 0)}}["Missed it by {{abs margin}}."{{otf}}]{{/if}}
           {{/if}}
         </span>
       </span>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8931036/121464752-745b3d00-c982-11eb-9388-52e061c70906.png)

Reaction table formula can then be "3d6 + @gmodc" which rolls 3d6, and then adds the Global MODifier bucket (and then Clears it).