### PR TITLE
Equipment Library Import

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -572,5 +572,7 @@
   "GURPS.toAllDXBasedRolls": "auf alle DX-basierten Würfe",
   "GURPS.update": "Aktualisieren",
   "GURPS.usage": "Nutzung",
-  "GURPS.yards": " yards"
+  "GURPS.yards": " yards",
+
+  "GURPS.itemImport": "Artikelsammlung Importieren"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -890,5 +890,7 @@
   "GURPS.advantagesTab": "Advantages and Disadvantages",
   "GURPS.skillsTab": "Skills",
   "GURPS.spellsTab": "Spells",
-  "GURPS.equipmentTab": "Equipment"
+  "GURPS.equipmentTab": "Equipment",
+
+  "GURPS.itemImport": "Import Equipment Library"
 }

--- a/lang/pt_br.json
+++ b/lang/pt_br.json
@@ -804,5 +804,7 @@
   "GURPS.advantagesTab": "Vantagens e Desvantagens",
   "GURPS.skillsTab": "Perícias",
   "GURPS.spellsTab": "Mágicas",
-  "GURPS.equipmentTab": "Equipamentos"
+  "GURPS.equipmentTab": "Equipamentos",
+
+  "GURPS.itemImport": "Importar uma Coleção de Equipamentos"
 }

--- a/lang/pt_br.json
+++ b/lang/pt_br.json
@@ -806,5 +806,5 @@
   "GURPS.spellsTab": "Mágicas",
   "GURPS.equipmentTab": "Equipamentos",
 
-  "GURPS.itemImport": "Importar uma Coleção de Equipamentos"
+  "GURPS.itemImport": "Importar Catálogo De Equipamento"
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -430,5 +430,7 @@
   "GURPS.advantagesTab": "Преимущества и Недостатки",
   "GURPS.skillsTab": "Навыки",
   "GURPS.spellsTab": "Заклинания",
-  "GURPS.equipmentTab": "Снаряжение"
+  "GURPS.equipmentTab": "Снаряжение",
+
+  "GURPS.itemImport": "Импортой Сбор Оборудования"
 }

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1475,13 +1475,14 @@ GURPS.importItems = async function(text, filename, filepath) {
     package: "world",
   });
   for (let i of j.rows) {
-    let itemData = await GURPS.importItem(i);
-    await Item.create(itemData,{pack:`world.${filename}`});
+    await GURPS.importItem(i,filename);
   }
 }
 
-GURPS.importItem = async function(i) {
-  console.log(i);
+GURPS.importItem = async function(i, filename) {
+  if (i.children?.length) for (let ch of i.children) {
+    await GURPS.importItem(ch,filename);
+  }
   let itemData = {
     name: i.description,
     type: "equipment",
@@ -1558,7 +1559,7 @@ GURPS.importItem = async function(i) {
   }
   let bonus_list = []
   if (i.features?.length) for (let f of i.features) {
-    let bonus = (f.amount > -1) ? `+${f.amount}` : f.amount.toString();
+    let bonus = (!!f.amount) ? ((f.amount > -1) ? `+${f.amount}` : f.amount.toString()) : "";
     if (f.type === "attribute_bonus") {
       bonus_list.push(`${f.attribute} ${bonus}`);
     } else if (f.type === "dr_bonus") {
@@ -1590,7 +1591,7 @@ GURPS.importItem = async function(i) {
     }
   }
   itemData.data.bonuses = bonus_list.join("\n");
-  return itemData;
+  return Item.create(itemData,{pack:`world.${filename}`});
 }
 
 /*********************  HACK WARNING!!!! *************************/

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1571,7 +1571,7 @@ GURPS.importItem = async function(i, filename) {
     if (f.type === "attribute_bonus") {
       bonus_list.push(`${f.attribute} ${bonus}`);
     } else if (f.type === "dr_bonus") {
-      bonus_list.push(`DR ${bonus} ${f.location}`);
+      bonus_list.push(`DR ${bonus} *${f.location}`);
     } else if (f.type === "skill_bonus") {
       if (f.selection_type === "skills_with_name" && f.name.compare === "is") {
         if (f.specialization?.compare === "is") {

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1692,7 +1692,7 @@ Hooks.once('init', async function () {
 
   Hooks.on("renderSidebarTab", async (app, html) => {
     if (app.options.id === "compendium") {
-      let button = $('<button class="import-items"><i class="fas fa-file-import"></i>' + game.i18n.localize("gurps.item-import") + '</button>')
+      let button = $('<button class="import-items"><i class="fas fa-file-import"></i>' + game.i18n.localize("GURPS.itemImport") + '</button>')
 
       button.click(function () {
         setTimeout(async () => {

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1585,6 +1585,8 @@ GURPS.importItem = async function(i, filename) {
         } else if (!f.specialization) {
           bonus_list.push(`A:${(f.name.qualifier||"").replace(/ /g,"*")} ${bonus}`);
         }
+      } else if (f.selection_type === "this_weapon") {
+        bonus_list.push(`A:${(itemData.name).replace(/ /g,"*")} ${bonus}`);
       }
     } else if (f.type === "spell_bonus") {
       if (f.match === "spell_name" && f.name.compare === "is") {
@@ -1593,10 +1595,12 @@ GURPS.importItem = async function(i, filename) {
     } else if (f.type === "weapon_bonus") {
       if (f.selection_type === "weapons_with_name") {
         if (f.specialization?.compare === "is") {
-          bonus_list.push(`A:${(f.name?.qualifier||"").replace(/ /g,"*")}${(f.specialization.qualifier||"").replace(/ /g,"*")} ${bonus}`);
+          bonus_list.push(`D:${(f.name?.qualifier||"").replace(/ /g,"*")}${(f.specialization.qualifier||"").replace(/ /g,"*")} ${bonus}`);
         } else if (!f.specialization) {
-          bonus_list.push(`A:${(f.name?.qualifier||"").replace(/ /g,"*")} ${bonus}`);
+          bonus_list.push(`D:${(f.name?.qualifier||"").replace(/ /g,"*")} ${bonus}`);
         }
+      } else if (f.selection_type === "this_weapon") {
+        bonus_list.push(`D:${(itemData.name).replace(/ /g,"*")} ${bonus}`);
       }
     }
   }

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1513,8 +1513,6 @@ GURPS.importItem = async function(i, filename) {
     }
   }
   if (i.weapons?.length) for (let w of i.weapons) {
-    console.log(w);
-    
     let otf_list = [];
     if (w.defaults) for (let d of w.defaults) {
       let mod = (!!d.modifier)? ((d.modifier > -1) ? `+${d.modifier}` : d.modifier.toString()) : "";
@@ -1717,7 +1715,7 @@ Hooks.once('init', async function () {
                   } else {
                     file = files[0];
                     console.log(file);
-                    readTextFromFile(file).then(text => GURPS.importItems(text, file.name.split(".").slice(0,-1).join("."), file.path));
+                    GURPS.readTextFromFile(file).then(text => GURPS.importItems(text, file.name.split(".").slice(0,-1).join("."), file.path));
                   }
                 }
               },

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1557,7 +1557,16 @@ GURPS.importItem = async function(i, filename) {
     }
   }
   let bonus_list = []
+  let feat_list = []
   if (i.features?.length) for (let f of i.features) {
+    feat_list.push(f);
+  }
+  if (i.modifiers?.length) for (let m of i.modifiers) {
+    if (!m.disabled && m.features?.length) for (let f of m.features) {
+      feat_list.push(f);
+    } 
+  }
+  if (feat_list.length) for (let f of feat_list) {
     let bonus = (!!f.amount) ? ((f.amount > -1) ? `+${f.amount}` : f.amount.toString()) : "";
     if (f.type === "attribute_bonus") {
       bonus_list.push(`${f.attribute} ${bonus}`);

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1480,6 +1480,7 @@ GURPS.importItems = async function(text, filename, filepath) {
 }
 
 GURPS.importItem = async function(i, filename) {
+  console.log(i);
   if (i.children?.length) for (let ch of i.children) {
     await GURPS.importItem(ch,filename);
   }
@@ -1518,7 +1519,7 @@ GURPS.importItem = async function(i, filename) {
     if (w.defaults) for (let d of w.defaults) {
       let mod = (!!d.modifier)? ((d.modifier > -1) ? `+${d.modifier}` : d.modifier.toString()) : "";
       if (d.type === "skill") {
-        otf_list.push(`S:${d.name.replace(" ","*")}`+(d.specialization?` (${d.specialization.replace(" ","*")})`:"")+mod);
+        otf_list.push(`S:${d.name.replace(/ /g,"*")}`+(d.specialization?`*(${d.specialization.replace(/ /g,"*")})`:"")+mod);
       } else if (["10","st","dx","iq","ht","per","will","vision","hearing","taste_smell","touch","parry","block"].includes(d.type)) {
         otf_list.push(d.type.replace("_"," ")+mod)
       }
@@ -1567,27 +1568,29 @@ GURPS.importItem = async function(i, filename) {
     } else if (f.type === "skill_bonus") {
       if (f.selection_type === "skills_with_name" && f.name.compare === "is") {
         if (f.specialization?.compare === "is") {
-          bonus_list.push(`A:${(f.name.qualifier||"").replace(" ","*")}${(f.specialization.qualifier||"").replace(" ","*")} ${bonus}`);
+          bonus_list.push(`A:${(f.name.qualifier||"").replace(/ /g,"*")}${(f.specialization.qualifier||"").replace(/ /g,"*")} ${bonus}`);
         } else if (!f.specialization) {
-          bonus_list.push(`A:${(f.name.qualifier||"").replace(" ","*")} ${bonus}`);
+          bonus_list.push(`A:${(f.name.qualifier||"").replace(/ /g,"*")} ${bonus}`);
         }
       } else if (f.selection_type === "weapons_with_name" && f.name.compare === "is") {
         if (f.specialization?.compare === "is") {
-          bonus_list.push(`A:${(f.name.qualifier||"").replace(" ","*")}${(f.specialization.qualifier||"").replace(" ","*")} ${bonus}`);
+          bonus_list.push(`A:${(f.name.qualifier||"").replace(/ /g,"*")}${(f.specialization.qualifier||"").replace(/ /g,"*")} ${bonus}`);
         } else if (!f.specialization) {
-          bonus_list.push(`A:${(f.name.qualifier||"").replace(" ","*")} ${bonus}`);
+          bonus_list.push(`A:${(f.name.qualifier||"").replace(/ /g,"*")} ${bonus}`);
         }
       }
     } else if (f.type === "spell_bonus") {
       if (f.match === "spell_name" && f.name.compare === "is") {
-        bonus_list.push(`S:${(f.name.qualifier||"").replace(" ","*")} ${bonus}`);
+        bonus_list.push(`S:${(f.name.qualifier||"").replace(/ /g,"*")} ${bonus}`);
       }
     } else if (f.type === "weapon_bonus") {
-      if (f.specialization?.compare === "is") {
-          bonus_list.push(`A:${(f.name.qualifier||"").replace(" ","*")}${(f.specialization.qualifier||"").replace(" ","*")} ${bonus}`);
+      if (f.selection_type === "weapons_with_name") {
+        if (f.specialization?.compare === "is") {
+          bonus_list.push(`A:${(f.name?.qualifier||"").replace(/ /g,"*")}${(f.specialization.qualifier||"").replace(/ /g,"*")} ${bonus}`);
         } else if (!f.specialization) {
-          bonus_list.push(`A:${(f.name.qualifier||"").replace(" ","*")} ${bonus}`);
+          bonus_list.push(`A:${(f.name?.qualifier||"").replace(/ /g,"*")} ${bonus}`);
         }
+      }
     }
   }
   itemData.data.bonuses = bonus_list.join("\n");

--- a/module/item-import.js
+++ b/module/item-import.js
@@ -1,0 +1,9 @@
+export class ItemImporter {
+    constructor() {
+        this.importItems = importItems();
+    }
+    importItems(text, filename, filepath) {
+        return console.log("michael check?");
+    }
+}
+

--- a/templates/item-import.html
+++ b/templates/item-import.html
@@ -1,0 +1,7 @@
+<form autocomplete="off" onsubmit="event.preventDefault();">
+    <p class="notes">Select a GCS .eqp file</p>
+    <div class="form-group">
+        <label for="data">Source Data</label>
+        <input type="file" name="data"/>
+    </div>
+</form>


### PR DESCRIPTION
Added the ability to import GCS equipment libraries directly into Foundry.
What this currently does:
- Imports the basic equipment info.
- Imports melee and ranged weapons.
- Imports the following GCS item features:
  - Attribute bonuses (except for Basic Speed and Basic Move, which seem to be unsupported for OTF).
  - DR bonuses.
  - Skill and spell bonuses, as well as attack bonuses.
  - Weapon damage bonuses*.

Other features (reaction modifiers, conditional modifiers, skill/spell point bonuses, *weapon bonuses by required skill, attribute cost reduction, and contained weight reduction) don't seem to be currently possible to implement using OTF formulas.

All imported equipment is currently imported and displayed as a flat list (afaik, Foundry doesn't support items containing other items by default anyway). I tested the import function with DFRPG Equipment as well as the Basic Set. With those two, no obvious errors were produced, but some things may have slipped through the cracks.
The import function seems to screw up Unicode characters (e.g. "ð" is displayed as "Ã°"). I'm not sure how to fix this, but would like to fix it before committing.