### PR TITLE
small adjustment for the sheet with tabs to avoid the appearance of two scroll bars

### DIFF
--- a/styles/simple.css
+++ b/styles/simple.css
@@ -532,6 +532,10 @@
   overflow: hidden;
 }
 
+.gurps .sheet-body.tabbed-sheet {
+  height: auto !important; /* hack to avoid the automatic calculation of the tab size in the SetPosition function of the actor-sheet.js file */
+}
+
 .gurps .sheet-body .tab {
   height: 100%;
   overflow-y: auto;

--- a/styles/simple.css
+++ b/styles/simple.css
@@ -1916,15 +1916,19 @@ body {
 }
 
 .desc {
-  position: relative;
+  /* position: relative; needed so that the tooltip was not limited to the tab area. */
 }
 
 .desc .tooltippic {
   visibility: hidden;
   position: absolute;
   z-index:999;
-  bottom: 20px;
-  left: 85%;
+  left: 60%;
+  margin-top: -102px;
+}
+
+.desc .tooltippic img {
+  max-height: 100px;
 }
 
 .desc:hover .tooltippic {

--- a/templates/actor-tab-sheet.html
+++ b/templates/actor-tab-sheet.html
@@ -108,7 +108,7 @@
             {{/if}}
             <li><a class="tab-item" data-tab="equipment">{{localize "GURPS.equipmentTab"}}</a></li>
         </nav>
-        <section class="sheet-body">
+        <section class="sheet-body tabbed-sheet">
             <div class="tab" data-tab="stats" data-group="primary-tabs">
                 <div id="stats">
                     <div id="attributes">


### PR DESCRIPTION
I added a little css hack to avoid the automatic calculation of the tab size in the SetPosition function of the actor-sheet.js file