### PR TITLE
rename sheet-tabs to gurps-sheet-tabs

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -18,7 +18,7 @@ export class GurpsActorSheet extends ActorSheet {
       template: 'systems/gurps/templates/actor-sheet-gcs.html',
       width: 800,
       height: 800,
-      tabs: [{ navSelector: '.sheet-tabs', contentSelector: '.sheet-body', initial: 'description' }],
+      tabs: [{ navSelector: '.gurps-sheet-tabs', contentSelector: '.sheet-body', initial: 'description' }],
       scrollY: [
         '.gurpsactorsheet #advantages #reactions #melee #ranged #skills #spells #equipment #other_equipment #notes',
       ],
@@ -1246,7 +1246,7 @@ export class GurpsActorTabSheet extends GurpsActorSheet {
       template: 'systems/gurps/templates/actor-tab-sheet.html',
       width: 860,
       height: 600,
-      tabs: [{ navSelector: '.sheet-tabs', contentSelector: '.sheet-body', initial: 'description' }],
+      tabs: [{ navSelector: '.gurps-sheet-tabs', contentSelector: '.sheet-body', initial: 'description' }],
       dragDrop: [{ dragSelector: '.item-list .item', dropSelector: null }],
     })
   }
@@ -1260,7 +1260,7 @@ export class GurpsActorCombatSheet extends GurpsActorSheet {
       template: 'systems/gurps/templates/combat-sheet.html',
       width: 600,
       height: 275,
-      tabs: [{ navSelector: '.sheet-tabs', contentSelector: '.sheet-body', initial: 'description' }],
+      tabs: [{ navSelector: '.gurps-sheet-tabs', contentSelector: '.sheet-body', initial: 'description' }],
       dragDrop: [{ dragSelector: '.item-list .item', dropSelector: null }],
     })
   }
@@ -1277,7 +1277,7 @@ export class GurpsActorEditorSheet extends GurpsActorSheet {
       ],
       width: 880,
       height: 800,
-      tabs: [{ navSelector: '.sheet-tabs', contentSelector: '.sheet-body', initial: 'description' }],
+      tabs: [{ navSelector: '.gurps-sheet-tabs', contentSelector: '.sheet-body', initial: 'description' }],
       dragDrop: [{ dragSelector: '.item-list .item', dropSelector: null }],
     })
   }
@@ -1427,7 +1427,7 @@ export class GurpsActorSimplifiedSheet extends GurpsActorSheet {
       template: 'systems/gurps/templates/simplified.html',
       width: 820,
       height: 900,
-      tabs: [{ navSelector: '.sheet-tabs', contentSelector: '.sheet-body', initial: 'description' }],
+      tabs: [{ navSelector: '.gurps-sheet-tabs', contentSelector: '.sheet-body', initial: 'description' }],
       dragDrop: [{ dragSelector: '.item-list .item', dropSelector: null }],
     })
   }

--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -12,7 +12,7 @@ export class GurpsItemSheet extends ItemSheet {
       width: 680,
       height: 'auto',
       resizable: false,
-      tabs: [{ navSelector: '.sheet-tabs', contentSelector: '.content', initial: 'melee-tab' }],
+      tabs: [{ navSelector: '.gurps-sheet-tabs', contentSelector: '.content', initial: 'melee-tab' }],
       dragDrop: [{ dragSelector: '.item-list .item', dropSelector: null }],
     })
   }

--- a/styles/css_boilerplate.css
+++ b/styles/css_boilerplate.css
@@ -182,7 +182,7 @@
   margin: 0;
 }
 
-.boilerplate .sheet-tabs {
+.boilerplate .gurps-sheet-tabs {
   -webkit-box-flex: 0;
   -ms-flex: 0;
   flex: 0;

--- a/styles/simple.css
+++ b/styles/simple.css
@@ -1868,14 +1868,14 @@ body {
   height: 100%;
 }
 
-.sheet-tabs {
+.gurps-sheet-tabs {
   display: block;
   height: 40px;
   border-top: 1px solid #AAA;
   border-bottom: 1px solid #AAA;
 }
 
-.sheet-tabs li {
+.gurps-sheet-tabs li {
   display: inline-block;
   margin: 0 10px 0 10px;
 }

--- a/templates/actor-tab-sheet.html
+++ b/templates/actor-tab-sheet.html
@@ -98,7 +98,7 @@
                 </div>
             </div>
         </div>
-        <nav id="nav-tabs" class="sheet-tabs" data-group="primary-tabs">
+        <nav id="nav-tabs" class="gurps-sheet-tabs" data-group="primary-tabs">
             <li><a class="tab-item" data-tab="stats">{{localize "GURPS.statsTab"}}</a></li>
             <li><a class="tab-item" data-tab="combat">{{localize "GURPS.combatTab"}}</a></li>
             <li><a class="tab-item" data-tab="advantages">{{localize "GURPS.advantagesTab"}}</a></li>

--- a/templates/item-sheet.html
+++ b/templates/item-sheet.html
@@ -71,7 +71,7 @@
       <h2>{{i18n "GURPS.itemFeatures"}}</h2>
 
       <div class='flexcol'>
-        <nav class='sheet-tabs tabs gurps-tabs' data-group='sections'>
+        <nav class='gurps-sheet-tabs tabs gurps-tabs' data-group='sections'>
           <a class='item' data-tab='melee-tab'><i class='fas fa-fist-raised'></i>&nbsp;{{i18n "GURPS.melee"}}&nbsp;<span
               style='font-size: 80%;'>{{#if (length data.melee)}}({{length data.melee}}){{/if}}</span></a>
           <a class='item' data-tab='range-tab'><i


### PR DESCRIPTION
sheet-tabs is a class already used by the core software, using it leads to all sorts of unexpected behavior including the issue with the tabs of the game settings not being centered properly.