### PR TITLE
0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.10.5 (compatible with Foundry 0.8.x)
+# Current Release Version 0.11.0 (compatible with Foundry 0.8.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.11.0
+Release 0.11.0 - 6/25/2021
 
 - Merged in Rinickolous/neck's GCS Equipment importer!
 - Fixed ST based ranged calc so it will also apply to Items

--- a/system.json
+++ b/system.json
@@ -2,9 +2,9 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.10.5",
+  "version": "0.11.0",
   "minimumCoreVersion": "0.8.5",
-  "compatibleCoreVersion": "0.8.6",
+  "compatibleCoreVersion": "0.8.7",
   "templateVersion": 2,
   "author": "Chris Normand/Nose66",
   "esmodules": ["module/gurps.js", "lib/xregexp-all.js"],
@@ -44,7 +44,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.10.5.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.11.0.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Merged in Rinickolous/neck's GCS Equipment importer!
- Fixed ST based ranged calc so it will also apply to Items
- Fixed order dependency when applying Item bonuses
- Kirlian Silvestre/3darkman, fixed Item icon hover picture
- Added /anim command
- Fixed NaN skill levels for containers
- Promoted tabbed view
- Added /w @ to whisper to selected character(s)
- Fixed "user does not have permission to update" when tired/reeling status changes
- Added combat maneuver icons to all tokens in a combat. Two new settings control the appearance of the maneuver icons.
- reinstate /rolltable command
- Added support Advanced Macros module argument passing
- Added support for drag and drop Journal entries, Actors, Items and Rolltables as OtFs
- Added support to drag and drop Items from compendiums and Item sheet
- Support opening and closing the navigation bar (Full Sheet) without going to the system settings.
- Provide UI feedback when doing navigation via the navigation bar.
- Fixed wounding modifiers for imp and pi types on Injury Tolerance: Unliving.
