### PR TITLE
0.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.11.0 (compatible with Foundry 0.8.x)
+# Current Release Version 0.11.1 (compatible with Foundry 0.8.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
+Release 0.11.1 - 6/25/2021
+
+- Fixed error that could occur during import "TypeError: rng.match is not a function"
+
 Release 0.11.0 - 6/25/2021
 
 - Merged in Rinickolous/neck's GCS Equipment importer!

--- a/module/actor.js
+++ b/module/actor.js
@@ -382,7 +382,7 @@ export class GurpsActor extends Actor {
     let st = +this.data.data.attributes.ST.value
     recurselist(this.data.data.ranged, r => {
       let rng = r.range || ''   // Data protection
-      rng = rng + '' //I  (convert to string)
+      rng = rng + '' // force to string
       let m = rng.match(/^ *[xX]([\d\.]+) *$/)
       if (m) {
         rng = parseFloat(m[1]) * st

--- a/system.json
+++ b/system.json
@@ -2,9 +2,9 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "minimumCoreVersion": "0.8.5",
-  "compatibleCoreVersion": "0.8.7",
+  "compatibleCoreVersion": "0.8.8",
   "templateVersion": 2,
   "author": "Chris Normand/Nose66",
   "esmodules": ["module/gurps.js", "lib/xregexp-all.js"],
@@ -44,7 +44,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.11.0.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.11.1.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Fixed error that could occur during import "TypeError: rng.match is not a function"
