### PR TITLE
Make Armor divisor code work with Survivable guns Special (4) AD Step.

### DIFF
--- a/module/damage/damagecalculator.js
+++ b/module/damage/damagecalculator.js
@@ -280,8 +280,9 @@ export class CompositeDamageCalculator {
     if (this._isExplosion) return 1
 
     if ((this._armorDivisor > 1 || this._armorDivisor === -1) && this._isHardenedDR) {
+      let _divisor = (this._armorDivisor == 4) ? 3 : this._armorDivisor //If you're using survivable guns check if it's (4) because it's not part of the regular progression, thus we treat it as 3.
       let maxIndex = armorDivisorSteps.length - 1
-      let index = armorDivisorSteps.indexOf(this._armorDivisor)
+      let index = armorDivisorSteps.indexOf(_divisor)
       index = Math.min(index + this._hardenedDRLevel, maxIndex)
       return armorDivisorSteps[index]
     }

--- a/templates/apply-damage/apply-damage-dialog.html
+++ b/templates/apply-damage/apply-damage-dialog.html
@@ -232,6 +232,7 @@
                     <option value='0.5' {{select-if CALC.armorDivisor 0.5}}>(0.5)</option>
                     <option value='2' {{select-if CALC.armorDivisor 2}}>(2)</option>
                     <option value='3' {{select-if CALC.armorDivisor 3}}>(3)</option>
+                    <option value='4' {{select-if CALC.armorDivisor 4}}>(4)</option>
                     <option value='5' {{select-if CALC.armorDivisor 5}}>(5)</option>
                     <option value='10' {{select-if CALC.armorDivisor 10}}>(10)</option>
                     <option value='100' {{select-if CALC.armorDivisor 100}}>(100)</option>


### PR DESCRIPTION
This adds a (4) AD and does NOT slot it into the regular progression, instead it's treated as (3) with hardened by the code because it doesn't actually add a new step, it's just an alternate step. I don't think it needs to be put anywhere else.