### PR TITLE
0.11.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.11.3 (compatible with Foundry 0.8.x)
+# Current Release Version 0.11.4 (compatible with Foundry 0.8.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.11.4
+Release 0.11.4 - 7/01/2021
 
 - Fixed Fright Check /fc table roll
 - Added "move" to centered animations, scale affect targeted Y, c:xp,yp set offset

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Edition Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "minimumCoreVersion": "0.8.5",
   "compatibleCoreVersion": "0.8.8",
   "templateVersion": 2,
@@ -44,7 +44,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.11.3.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.11.4.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Fixed Fright Check /fc table roll
- Added "move" to centered animations, scale affect targeted Y, c:xp,yp set offset
- System setting to automatically save QTY/count on equipment
- Fixed "Level" column in melee/ranged weapons goes blank or NaN after using resource tracker
- Support for JB2A "Raishan" release (which includes new bullet and snipe animations)
- Fixed speaker token for dice rolls, so that modules that are expecting a token can use it, i.e. Cautious Gamemaster's Pack
- Integrated LegendSmith's NPC CI sheet and Survivable guns Special (4) Armor Divisor