### PR TITLE
change the import logic to remember the last import location

### DIFF
--- a/module/file-handlers/chrome-file-handler.js
+++ b/module/file-handlers/chrome-file-handler.js
@@ -1,0 +1,86 @@
+class ChromiumFile {
+  constructor(handle, path) {
+      this.handle = handle;
+      this.name = handle.name;
+      this.path = path !== "" ? path : handle.name;
+  }
+  async text() {
+      return (await this.handle.getFile()).text();
+  }
+}
+class ChromiumFolder {
+  constructor(handle) {
+      this.handle = handle;
+      this.name = handle.name;
+  }
+  async files(extensions) {
+      const allFiles = await this._getFiles();
+      return extensions ? allFiles.filter(f => extensions.some(ext => f.name.endsWith(ext))) : allFiles;
+  }
+  async _getFiles(handle, path) {
+      path = path ?? this.name;
+      handle = handle ?? this.handle;
+      const files = [];
+      for await (let [name, child] of handle.entries()) {
+          if (child instanceof FileSystemDirectoryHandle) {
+              files.push(...await this._getFiles(child, `${path}/${name}`));
+          }
+          else {
+              files.push(new ChromiumFile(child, `${path}/${child.name}`));
+          }
+      }
+      return files;
+  }
+}
+export class ChromiumFileHandler {
+    static File = ChromiumFile
+    static Folder = ChromiumFolder
+    static async _getFileOrFolder({template, templateOptions={}, mode, extensions=[]}) {
+        const promise = new Promise((resolve, reject) => {
+            const inputElement = `<button id="importButton" style="width: fit-content; line-height: 14px;">choose ${mode}</button>
+    <div id="selectedFile" style="display: inline-block;">no ${mode} chosen</div>`;
+            const content = template({ inputElement, ...templateOptions });
+            let handle;
+            Dialog.prompt( {
+                title: `Import Data`,
+                content,
+                label: "Import",
+                callback: () => {
+                    handle ? resolve(handle) : reject(`no ${mode} were chosen`);
+                },
+                rejectClose: false,
+            } );
+            Hooks.once('renderDialog', (dialog) => {
+                const fileChosenDiv = dialog.element.find('#selectedFile');
+                dialog.element.find('#importButton').on('click', async () => {
+                    const pickerOpts = {
+                        types: [
+                            {
+                                description: 'Allowed',
+                                accept: {
+                                    'custom/custom': extensions
+                                }
+                            },
+                        ],
+                        excludeAcceptAllOption: true,
+                        multiple: false
+                    };
+                    if (mode === 'file') {
+                        handle = (await (extensions.length > 0 ? showOpenFilePicker(pickerOpts) : showOpenFilePicker()))[0];
+                    }
+                    else {
+                        handle = await showDirectoryPicker();
+                    }
+                    fileChosenDiv[0].innerText = handle.name;
+                });
+            });
+        });
+        return promise;
+    }
+    static async getFile({template, templateOptions={}, extensions=[]}) {
+        return new ChromiumFile(await this._getFileOrFolder({template, templateOptions, mode:'file', extensions}), "");
+    }
+    static async getFolder({template, templateOptions={}}) {
+        return new ChromiumFolder(await this._getFileOrFolder({template, templateOptions, mode:'folder'}));
+    }
+}

--- a/module/file-handlers/fallback-file-handler.js
+++ b/module/file-handlers/fallback-file-handler.js
@@ -1,0 +1,52 @@
+class FallbackFile {
+  constructor(file) {
+      this.file = file;
+      this.name = file.name;
+      this.path = file.webkitRelativePath !== "" ? file.webkitRelativePath : file.name;
+  }
+  async text() {
+      return this.file.text();
+  }
+}
+class FallbackFolder {
+  constructor(files, name) {
+      this._files = files;
+      this.name = name ?? files[0].path.split('/')[0];
+  }
+  async files(extensions) {
+      return extensions ? this._files.filter(f => extensions.some(ext => f.name.endsWith(ext))) : this._files;
+  }
+}
+export class FallbackFileHandler {
+    static async _getFileOrFolder({template, templateOptions={}, mode, extensions=[]}) {
+      const inputElement = mode === 'file' ?
+          `<input id="inputFiles" type="file" accept="${extensions}" />` :
+          `<input id="inputFiles" type="file" webkitdirectory mozdirectory />`;
+      const content = template({ inputElement, ...templateOptions });
+      const promise = new Promise((resolve, reject) => {
+        Dialog.prompt( {
+            title: `Import Data`,
+            content,
+            label: "Import",
+            callback: (html) => {
+                const inputElementObject = html.find('#inputFiles')[0];
+                if (!(inputElementObject instanceof HTMLInputElement))
+                    return reject(`can't find input element`);
+                if (!inputElementObject.files)
+                    return reject(`input element isn't file input`);
+                let files = Array.from(inputElementObject.files);
+                files = extensions.length > 0 ? files.filter(f => extensions.some(ext => f.name.endsWith(ext))) : files;
+                files.length !== 0 ? resolve(files.map(f => new FallbackFile(f))) : reject('no files with the correct extensions were chosen');
+            },
+            rejectClose: false,
+        } );
+      });
+      return promise;
+  }
+  static async getFile({template, templateOptions={}, extensions=[]}) {
+      return (await this._getFileOrFolder({template, templateOptions, mode:'file', extensions}))[0];
+  }
+  static async getFolder({template, templateOptions={}}) {
+      return new FallbackFolder(await this._getFileOrFolder({template, templateOptions, mode:'folder'}));
+  }
+}

--- a/module/file-handlers/universal-file-handler.js
+++ b/module/file-handlers/universal-file-handler.js
@@ -1,0 +1,42 @@
+import { ChromiumFileHandler } from './chrome-file-handler.js';
+import { FallbackFileHandler } from './fallback-file-handler.js';
+function getBrowser() {
+  // the code is based on https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator
+  const sUsrAg = navigator.userAgent;
+  // The order matters here, and this may report false positives for unlisted browsers.
+  if (sUsrAg.indexOf("Firefox") > -1) {
+      return "Mozilla Firefox";
+  }
+  else if (sUsrAg.indexOf("SamsungBrowser") > -1) {
+      return "Samsung Internet";
+  }
+  else if (sUsrAg.indexOf("Opera") > -1 || sUsrAg.indexOf("OPR") > -1) {
+      return "Opera";
+  }
+  else if (sUsrAg.indexOf("Trident") > -1) {
+      return "Microsoft Internet Explorer";
+  }
+  else if (sUsrAg.indexOf("Edge") > -1) {
+      return "Microsoft Edge";
+  }
+  else if (sUsrAg.indexOf("Chrome") > -1) {
+      return "Chromium";
+  }
+  else if (sUsrAg.indexOf("Safari") > -1) {
+      return "Apple Safari";
+  }
+  else {
+      return "unknown";
+  }
+}
+const IS_CHROMIUM = ['Chromium', 'Microsoft Edge', 'Opera'].includes(getBrowser());
+const FileHandler = IS_CHROMIUM ? ChromiumFileHandler : FallbackFileHandler
+export class UniversalFileHandler {
+    static async getFile({template, templateOptions={}, extensions=[]}) {
+        extensions = typeof extensions === 'string' ? [extensions] : extensions;
+        return FileHandler.getFile({template, templateOptions, extensions});
+    }
+    static async getFolder({template, templateOptions={}}) {
+        return FileHandler.getFolder({template, templateOptions});
+    }
+}

--- a/module/smart-importer.js
+++ b/module/smart-importer.js
@@ -1,0 +1,13 @@
+import { UniversalFileHandler } from './file-handlers/universal-file-handler.js';
+export class SmartImporter {
+    static async getFileForActor(actor) {
+        const file = this.actorToFileMap.get(actor);
+        const template = await getTemplate('systems/gurps/templates/import-gcs-or-gca.hbs');
+        console.log(template)
+        return file ?? await UniversalFileHandler.getFile({template, templateOptions: {name: actor.name}, extensions:'.xml'});
+    }
+    static setFileForActor(actor, file) {
+        this.actorToFileMap.set(actor, file);
+    }
+}
+SmartImporter.actorToFileMap = new Map();

--- a/templates/import-gcs-or-gca.hbs
+++ b/templates/import-gcs-or-gca.hbs
@@ -1,0 +1,7 @@
+<p class="notes">Select a file exported from GCS or GCA.</p>
+<div class="form-group">
+    <label for="data">Source Data</label>
+    {{{inputElement}}}
+</div>
+<p class="notes"><br>The import will overwrite the data for {{name}}.</p>
+    <br><span class="fas fa-exclamation-triangle">NOTE: This cannot be un-done.</span>

--- a/templates/import-gcs-or-gca.hbs
+++ b/templates/import-gcs-or-gca.hbs
@@ -3,5 +3,5 @@
     <label for="data">Source Data</label>
     {{{inputElement}}}
 </div>
-<p class="notes"><br>The import will overwrite the data for {{name}}.</p>
+<p class="notes"><br>The import will overwrite the data for "{{name}}".</p>
     <br><span class="fas fa-exclamation-triangle">NOTE: This cannot be un-done.</span>

--- a/templates/import-gcs-v1-data.html
+++ b/templates/import-gcs-v1-data.html
@@ -1,9 +1,0 @@
-<form autocomplete="off" onsubmit="event.preventDefault();">
-    <p class="notes">Select a file exported from GCS or GCA.</p>
-    <div class="form-group">
-        <label for="data">Source Data</label>
-        <input type="file" name="data"/>
-    </div>
-   <p class="notes"><br>The import will overwrite the data for {{name}}.</p>
- 		<br><span class="fas fa-exclamation-triangle">NOTE: This cannot be un-done.</span>
-</form>


### PR DESCRIPTION
the Pull Request changes the _openImportDialog to remember the last import location for the duration of the session, and limit the files presented to choose from to those with the .xml format. <br>
It also creates a framework to import files with a certain extension, as well as folders and access the changes in them without needing to reimport again. <br>
Known and, as far as I know, unavoidable limitation of the framework is that you still need to select the files/folders upon reloading. In Firefox, the framework also doesn't have a way to know if a new file was added to an imported folder.