### PR TITLE
0.11.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.11.4 (compatible with Foundry 0.8.x)
+# Current Release Version 0.11.5 (compatible with Foundry 0.8.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.11.5
+Release 0.11.5 - 7/21/2021
 
 - Fixed mook parsing issue (for mooks with no Traits)
 - Update tooltip mods to include "-1 due to deceptive attack"

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "minimumCoreVersion": "0.8.5",
   "compatibleCoreVersion": "0.8.8",
   "templateVersion": 2,
@@ -44,7 +44,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.11.4.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.11.5.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Fixed mook parsing issue (for mooks with no Traits)
- Update tooltip mods to include "-1 due to deceptive attack"
- Added 'Quick Sheet' system setting
- Added quick roll for damage /dmg-formula or .dmg-formula
- Fixed compendium import for ROF field
- Fixed import DRs like "0 + 8" and correctly handles "Arms" to "Left Arm/Right Arm" mapping again.
- Added system setting for UTF-8 import encoding
- Mouse wheel over Modifier Bucket adds modifier
- Added /sound chat command
- Reskinned the Fright Check UI, added clickable margins of success/failure
- Added the ability for Trusted players or GM to roll physical dice and enter the results into the game aid.
- Shorten Foundry name so that it doesn't wrap on Game Settings tab
- Support for JB2A "Scanlan" release
- Don't display Item icon if it is the default "icons/svg/item-bag.svg"
- Added Dodge and Move to Combat tab of tabbed sheet
- Fixed /light command now accepts decimals /light 2.9 0.7
- Fixed /show skill where skill name contains a single quote
- Fixed drag and drop EQT in tabbed view
