### PR TITLE
Broadcast lastTargetedRoll & fixed objToString()

### DIFF
--- a/module/chat/anim.js
+++ b/module/chat/anim.js
@@ -172,7 +172,7 @@ export class AnimChatProcessor extends ChatProcessor {
       } catch (e) { //in case people have older versions of fxmaster
         canvas.fxmaster.playVideo(effectData)
       }
-      console.log(GURPS.objToString(effectData))
+      //console.log(GURPS.objToString(effectData))
       if (count > 0) await wait(effectData.delay)
     }
   }

--- a/module/dierolls/dieroll.js
+++ b/module/dierolls/dieroll.js
@@ -124,7 +124,7 @@ export async function doRoll(actor, formula, targetmods, prefix, thing, origtarg
     chatdata['modifier'] = modifier
   }
 
-  if (isTargeted) GURPS.lastTargetedRoll[actor.id] = chatdata
+  if (isTargeted) GURPS.setLastTargetedRoll(chatdata, speaker.actor, speaker.token, true)
 
   let message = await renderTemplate('systems/gurps/templates/die-roll-chat-message.hbs', chatdata)
 


### PR DESCRIPTION
GURPS.lastTargetedRolls[id] can be used with either the actor.id or the token.id (this assumes that the ids will not overlap during a gameplay ;-) )