### PR TITLE
0.11.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.11.7 (compatible with Foundry 0.8.x)
+# Current Release Version 0.11.8 (compatible with Foundry 0.8.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "minimumCoreVersion": "0.8.5",
   "compatibleCoreVersion": "0.8.8",
   "templateVersion": 2,
@@ -44,7 +44,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.11.7.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.11.8.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Added system setting, unequipped items not displayed in melee or ranged attacks
- Added danialrab's browser support to remember the last import location (and system setting)
- Updated anim support for JB2A's Vasselheim release (0.2.6)
- Rewrote the Maneuver system to be Foundry ActiveEffects.
- Resolved several bugs with Maneuvers (randomly not clearing, UI warnings when changing Maneuver settings, keeping Maneuver as the first icon in the list).
- Store the last targeted roll for every actor in the GURPS object (`GURPS.lastTargetedRolls`). Use the actor's or token's ID to fetch a data object with the results of that roll. This might be used in a macro to get and use margin of success,.
- Fixed the /li (light) chat command to correctly accept color intensity value
- Added [Cool Macros](https://github.com/crnormand/gurps/wiki/Cool-Macros) example wiki page.
- Implemented double knockback (dkb) damage modifier. E.g., `[3d+1 cr dkb]` works.
- Implemented no knockback (nkb) damage modifier (`[3d+1 cr nkb]` results in no knockback regardless of target's ST).
- Updated Brazilian Portuguese language file (thanks, Frerol!). Who wants to tackle Russian and German?
- Optionally allow a damage OTF to include a hit location. E.g., `[3d cr dkb @Vitals]`. Location must exactly match a hit location on the targeted actor.
- Fixed an issue with Western European style decimals (such as '6,25') in the Basic Speed field during imports. If the value contains a comma (',') character, it is parsed as if it is Western European; otherwise it is parsed as if it is US/UK ('6.25').
- More maneuver tweaks -- I think it really works correctly now.
- Implemented tight beam burning from B399. To use this, add the 'tbb' damage modifier with the 'burn' damage type (for example, `[6d burn tbb]`).
- Added portrait to NPC and NPC-CI actor sheets.
- Added Encumbrance, Move & Dodge and Lifting & Moving Things to Combat tab in the Tabbed Actor sheet.
- Report all rolled items as OtF formulas (so they can be re-rolled).