### PR TITLE
minor fix for the parry and block buttons

### DIFF
--- a/templates/actor/sections/melee.hbs
+++ b/templates/actor/sections/melee.hbs
@@ -36,8 +36,8 @@
       data-key='data.melee.{{@key}}'
       data-otf='M:"{{this.name}} ({{this.mode}})"'
     >{{this.level}}</div>
-    <div class='parry rollable center' data-otf='P:{{this.name}} ({{this.mode}})'>{{this.parry}}</div>
-    <div class='block rollable center' data-otf='B:{{this.name}} ({{this.mode}})'>{{this.block}}</div>
+    <div class='parry rollable center' data-otf='P:"{{this.name}} ({{this.mode}})"'>{{this.parry}}</div>
+    <div class='block rollable center' data-otf='B:"{{this.name}} ({{this.mode}})"'>{{this.block}}</div>
     <div class='damage rollable center' data-damage data-otf='{{this.damage}}'>{{this.damage}}</div>
     <div class='reach center'>{{this.reach}}</div>
     <div class='st center'>{{this.st}}</div>


### PR DESCRIPTION
the lack of quotes was causing the buttons to only consider the first word of the  weapon name