### PR TITLE
Fix equipment link on navigation bar

### DIFF
--- a/templates/actor/actor-sheet-gcs.hbs
+++ b/templates/actor/actor-sheet-gcs.hbs
@@ -96,7 +96,7 @@
           <div class='navigation-link' data-value='ranged'>RANGED</div>
           <div class='navigation-link' data-value='advantages'>ADVANTAGES</div>
           <div class='navigation-link' data-value='skills'>SKILLS</div>
-          <div class='navigation-link' data-value='equipment'>EQUIPMENT</div>
+          <div class='navigation-link' data-value='equipmentcarried'>EQUIPMENT</div>
           <div class='navigation-link' data-value='other_equipment'>OTHER</div>
           <div class='navigation-link' data-value='notes'>NOTES</div>
         </div>


### PR DESCRIPTION
This fixed click on `EQUIPMENT` on navigation bar not properly focusing carried equipment on Full View

![image](https://user-images.githubusercontent.com/413430/141606346-1b6669bc-a032-4d2e-b4d6-85a0cfad376d.png)
