### PR TITLE
0.12.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.12.4 (compatible with Foundry 0.8.x)
+# Current Release Version 0.12.5 (compatible with Foundry 0.8.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.12.5
+Release 0.12.5 11/23/2021
 
 - Fixed a bug with the ADD applying damage to a resource tracker.
 - Remove chat messages for ranged attack modifiers on postures. (Will be replaced by target modifier list window).

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "minimumCoreVersion": "0.8.5",
   "compatibleCoreVersion": "0.8.9",
   "templateVersion": 2,
@@ -49,7 +49,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.12.4.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.12.5.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Fixed a bug with the ADD applying damage to a resource tracker.
- Remove chat messages for ranged attack modifiers on postures. (Will be replaced by target modifier list window).
- Updated color picker to speed up GGA load time
- Added drag and drop of OtFs from chat & journals
- Changed drag and drop macros to be chat macros (instead of script)
- Allow OtF macros to be merged on drag and drop
