### PR TITLE
0.12.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.12.5 (compatible with Foundry 0.8.x)
+# Current Release Version 0.12.6 (compatible with Foundry 0.8.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.
-
 
 
 If you like our work [Sponsor our development](https://github.com/sponsors/crnormand) or <a href="https://ko-fi.com/crnormand"><img height="36" src="https://cdn.ko-fi.com/cdn/kofi2.png?v=2"></a>

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.12.6 
+Release 0.12.6 11/30/2021
 
 - Updated GCA export to make OtF-able CR: when exporting (@Stevil)
 - Updated 'export to Foundry VTT.gce', moved the modifiers from the 'name' tag to be part of the 'text' tag in the Ads/Disads (@Stevil)

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "minimumCoreVersion": "0.8.5",
   "compatibleCoreVersion": "0.8.9",
   "templateVersion": 2,
@@ -49,7 +49,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.12.5.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.12.6.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Updated GCA export to make OtF-able CR: when exporting (@Stevil)
- Updated 'export to Foundry VTT.gce', moved the modifiers from the 'name' tag to be part of the 'text' tag in the Ads/Disads (@Stevil)
- Updated GCA export validation to GCA-10
- Add /maneuver /man chat command to set maneuver
- Fixed dragging multiple modifier buckets onto the same macro (replace works correctly now)
- Fixed equipped status mirrors carried status (and all items contained within)
- Fixed /showmbs command
- Fixed [S:skill -mod] where mod was being applied twice
- Fixed +/- buttons on equipment list
- Added +/- buttons to Uses column in equipment list
- Added HTTP link support for all lists (not just equipment)
- Added /show fright move speed
