### PR TITLE
0.12.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.12.7 (compatible with Foundry 0.8.x)
+# Current Release Version 0.12.8 (compatible with Foundry 0.8.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/changelog.md
+++ b/changelog.md
@@ -2,12 +2,13 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.12.8
+Release 0.12.8 12/1/2021
 
 - Added drag drop into chat log and chat input field
 - Fixed equipped parry if weapon name contains more info than the equipment
 - Added drag and drop into mook generator (to quickly create entries)
 - Added link to Foundry lighting page for /light help
+- Updated animation list to JB2A 3.2 
 
 Release 0.12.7 11/30/2021
 

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "minimumCoreVersion": "0.8.5",
   "compatibleCoreVersion": "0.8.9",
   "templateVersion": 2,
@@ -49,7 +49,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.12.7.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.12.8.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Added drag drop into chat log and chat input field
- Fixed equipped parry if weapon name contains more info than the equipment
- Added drag and drop into mook generator (to quickly create entries)
- Added link to Foundry lighting page for /light help
- Updated animation list to JB2A 3.2 
