### PR TITLE
0.12.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.12.9 (compatible with Foundry 0.8.x)
+# Current Release Version 0.12.10 (compatible with Foundry 0.8.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "minimumCoreVersion": "0.8.5",
   "compatibleCoreVersion": "0.8.9",
   "templateVersion": 2,
@@ -49,7 +49,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.12.9.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.12.10.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Fixed "crash the world" bug if user enters a bad modifier in tooltip
- Removed unnecessary leading space when dropped in quick note
