### PR TITLE
0.12.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.12.10 (compatible with Foundry 0.8.x)
+# Current Release Version 0.12.11 (compatible with Foundry 0.8.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.12.11
+Release 0.12.11 12/23/2021
 
 - Update /show help
 - Add Portrait share for GM users

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "minimumCoreVersion": "0.8.5",
   "compatibleCoreVersion": "0.8.9",
   "templateVersion": 2,
@@ -54,7 +54,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.12.10.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.12.11.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Update /show help
- Add Portrait share for GM users
- Fixed applying basic damage for multiple damage rolls
- Updated GCS exporter to do Conditional Modifiers (needs a bug fixed in GCS before it works)
- Fixed equipment menus to only open on a contextmenu event.
- Add target modifiers to Effects Modifier popup window.
- Add SM to target modifiers.
- Added another range/speed table (-1 per 10 yards/meters).
- Possibly fixed adding two statuses at the same time, such as stun + prone.
- Fixed Full GCS sheet's navigation widget operating on wrong sheet.
- Added effect modifiers for the "Blind" status.
- Fixed the Dodge column in Encumbrance to enable 'rollable' only on the current encumbrance level.
- Added GCS direct import by rinickolous / neck
- ADD will now automatically select Injury Tolerance (Unliving, Diffuse, or Homogenous) if any of the following exists as an Advantage on the actor sheet: (Name is 'Injury Tolerance (\<type\>)' or '\<type\>') or (Name is 'Injury Tolerance' AND Notes contains '\<type\>') where \<type\> is one of Unliving, Diffuse, or Homogenous.
- Fix for Foundry v.0.9 layout.
- Added targeted token modifiers to Effect Modifier popup.
- Updated GCA export to GCA-11, supporting Conditional Modifiers
- Added beta GCA5 export mehalforc / Stevil
