### PR TITLE
0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.12.17 (compatible with Foundry 0.8.x)
+# Current Release Version 0.13.0 (compatible with Foundry 0.9.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.13.0  
+Release 0.13.0 1/8/2022
 
 - Fixed /ra help string
 - Added warning if trying to set maneuver /man when not in combat

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.12.17",
+  "version": "0.13.0",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
   "templateVersion": 2,
@@ -54,7 +54,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.12.17.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.13.0.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Fixed /ra help string
- Added warning if trying to set maneuver /man when not in combat
- Replace GURPS.genkey with zeroFill() 
- Fixed /uses reset eqt 
- Updated /light command to work with new Foundry V9 lighting model
- Fixed /tr# (where # = 0-3)
- Enhanced /tr & /qty commands to allow spaces between +-= and the number
- Fixed Foundry Item image hover
- Sorted /show output so highest results appear first, /showa (/sha) shows alphabetically
- Fixed Attacks that have () in the mode 
- Updated Effects Modifier Popup button to appear in upper left menu
- Fixed [ST26] OtFs (fixed target attribute rolls)
