### PR TITLE
Fixed reaction and conditional modifier bonuses not importing correctly

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1514,12 +1514,12 @@ export class GurpsActor extends Actor {
         for (let f of i.features) {
           if (f.type == 'reaction_bonus') {
             temp_r.push({
-              modifier: f.amount,
+              modifier: f.amount*((f.per_level && !!i.levels)?parseInt(i.levels):1),
               situation: f.situation,
             })
           } else if (f.type == 'conditional_modifier') {
             temp_c.push({
-              modifier: f.amount,
+              modifier: f.amount*((f.per_level && !!i.levels)?parseInt(i.levels):1),
               situation: f.situation,
             })
           }


### PR DESCRIPTION
Reaction and conditional modifier bonuses were not importing correctly when the bonuses were "per level".
This addresses issue #1230.