### PR TITLE
Added support for Trigger Happy module (teleport and OTF)

### DIFF
--- a/module/chat/chat-processors.js
+++ b/module/chat/chat-processors.js
@@ -470,9 +470,12 @@ class SelectChatProcessor extends ChatProcessor {
           .filter(u => !u.isGM)
           .map(u => u.id)
         if (users.includes(game.user.id)) {
-          GURPS.SetLastActor(a)
           let tokens = canvas.tokens.placeables.filter(t => t.actor == a)
-          if (tokens.length == 1) tokens[0].control({ releaseOthers: true }) // Foundry 'select'
+          if (tokens.length == 1) {
+            tokens[0].control({ releaseOthers: true }) // Foundry 'select'
+            GURPS.SetLastActor(a, tokens[0])
+          } else
+            GURPS.SetLastActor(a)
           this.priv('Selecting ' + a.displayname)
           return
         }
@@ -850,7 +853,7 @@ class DevChatProcessor extends ChatProcessor {
         else ui.notifications.warn("Can't find Actor named '" + m[2] + "'")
         break
       } 
-      case 'flush': { // flush the chat log without confirming
+      case 'clear': { // flush the chat log without confirming
         game.messages.documentClass.deleteDocuments([], {deleteAll: true})
         break
       }

--- a/module/effects/dae.js
+++ b/module/effects/dae.js
@@ -1,0 +1,184 @@
+/**
+  This is a subset of Dynamic effects for Active Effects module (which only work with DnD5e).   
+  Mainly for the 'teleport token function.   ;-)
+**/
+
+export var socketlibSocket = undefined;
+export let setupSocket = () => {
+  if (globalThis.socketlib) {
+    socketlibSocket = globalThis.socketlib.registerSystem("gurps");
+    socketlibSocket.register("recreateToken", _recreateToken);
+    socketlibSocket.register("createToken", _createToken);
+    socketlibSocket.register("deleteToken", _deleteToken);
+    socketlibSocket.register("renameToken", _renameToken);
+    socketlibSocket.register("setTokenFlag", _setTokenFlag);
+    socketlibSocket.register("setFlag", _setFlag);
+    socketlibSocket.register("unsetFlag", _unsetFlag);
+    socketlibSocket.register("deleteUuid", _deleteUuid);
+  }
+  return !!globalThis.socketlib
+};
+
+function DAEfromUuid(uuid) {
+    let doc;
+    try {
+        let parts = uuid.split(".");
+        const [docName, docId] = parts.slice(0, 2);
+        parts = parts.slice(2);
+        const collection = CONFIG[docName].collection.instance;
+        doc = collection.get(docId);
+        // Embedded Documents
+        while (parts.length > 1) {
+            const [embeddedName, embeddedId] = parts.slice(0, 2);
+            doc = doc.getEmbeddedDocument(embeddedName, embeddedId);
+            parts = parts.slice(2);
+        }
+    } /*catch (err) {
+      error(`dae | could not fetch ${uuid} ${err}`)
+    } */
+    finally {
+        return doc || null;
+    }
+}
+function DAEfromActorUuid(uuid) {
+    let doc = DAEfromUuid(uuid);
+    if (doc instanceof CONFIG.Token.documentClass)
+        doc = doc.actor;
+    return doc || null;
+}
+async function _deleteUuid(data) {
+    const entity = await fromUuid(data.uuid);
+    if (entity && entity instanceof Item && !data.uuid.startsWith("Compendium") && !data.uuid.startsWith("Item")) { // only allow deletion of owned items
+        return await entity.delete();
+    }
+    if (entity && entity instanceof CONFIG.Token.documentClass && !data.uuid.startsWith("Compendium") && !data.uuid.startsWith("Item")) { // only allow deletion of owned items
+        return await entity.delete();
+    }
+    if (entity && entity instanceof CONFIG.ActiveEffect.documentClass)
+        return await entity.delete();
+    return false;
+}
+async function _unsetFlag(data) {
+    return await DAEfromActorUuid(data.actorUuid)?.unsetFlag("dae", data.flagId);
+}
+async function _setFlag(data) {
+    if (!data.actorUuid)
+        return await game.actors.get(data.actorId)?.setFlag("dae", data.flagId, data.value);
+    else
+        return await DAEfromActorUuid(data.actorUuid)?.setFlag("dae", data.flagId, data.value);
+}
+async function _setTokenFlag(data) {
+    const update = {};
+    update[`flags.dae.${data.flagName}`] = data.flagValue;
+    return await DAEfromUuid(data.tokenUuid)?.update(update);
+}
+async function _createToken(data) {
+    let scenes = game.scenes;
+    let targetScene = scenes.get(data.targetSceneId);
+    //@ts-ignore
+    return await targetScene.createEmbeddedDocuments('Token', [mergeObject(duplicate(data.tokenData), { "x": data.x, "y": data.y, hidden: false }, { overwrite: true, inplace: true })]);
+}
+async function _deleteToken(data) {
+    return await DAEfromUuid(data.tokenUuid)?.delete();
+}
+async function _recreateToken(data) {
+    await _createToken(data);
+    return await DAEfromUuid(data.tokenUuid)?.delete();
+}
+async function _renameToken(data) {
+    return await canvas.tokens.placeables.find(t => t.id === data.tokenData._id).update({ "name": data.newName });
+}
+let tokenScene = (tokenName, sceneName) => {
+    if (!sceneName) {
+        for (let scene of game.scenes) {
+            //@ts-ignore
+            let found = scene.tokens.getName(tokenName);
+            if (found)
+                return { scene, found };
+        }
+    }
+    else {
+        //@ts-ignore
+        let scene = game.scenes.getName(sceneName);
+        if (scene) {
+            //@ts-ignore
+            let found = scene.tokens.getName(tokenName);
+            if (found) {
+                return { scene, found };
+            }
+        }
+    }
+    return { scene: null, tokenDocument: null };
+};
+export let moveToken = async (token, targetTokenName, xGridOffset = 0, yGridOffset = 0, targetSceneName = "") => {
+    let { scene, found } = tokenScene(targetTokenName, targetSceneName);
+    if (!token) {
+        warn("Dynmaiceffects | moveToken: Token not found");
+        return ("Token not found");
+    }
+    if (!found) {
+        warn("dae | moveToken: Target Not found");
+        return `Token ${targetTokenName} not found`;
+    }
+    socketlibSocket.executeAsGM("recreateToken", {
+        userId: game.user.id,
+        startSceneId: canvas.scene.id,
+        tokenUuid: token.uuid,
+        targetSceneId: scene.id, tokenData: token.data,
+        x: found.data.x + xGridOffset * canvas.scene.data.grid,
+        y: found.data.y + yGridOffset * canvas.scene.data.grid
+    });
+    /*
+    return await requestGMAction(GMAction.actions.recreateToken,
+      { userId: game.user.id,
+        startSceneId: canvas.scene.id,
+        tokenUuid: token.uuid,
+         targetSceneId: scene.id, tokenData: token.data,
+         x: found.data.x + xGridOffset * canvas.scene.data.grid,
+         y: found.data.y + yGridOffset * canvas.scene.data.grid
+    });
+    */
+};
+export let teleportToDrawingInScene = async (token, drawing, scene) => {
+    return teleport(token, scene, drawing.data.x, drawing.data.y);
+};
+export async function createToken(tokenData, x, y) {
+    let targetSceneId = canvas.scene.id;
+    // requestGMAction(GMAction.actions.createToken, {userId: game.user.id, targetSceneId, tokenData, x, y})
+    return socketlibSocket.execuateAsGM("createToken", { userId: game.user.id, targetSceneId, tokenData, x, y });
+}
+export let teleport = async (token, targetScene, xpos, ypos) => {
+    let x = Number(xpos);
+    let y = parseInt(ypos);
+    if (isNaN(x) || isNaN(y)) {
+        error("dae| teleport: Invalid co-ords", xpos, ypos);
+        return `Invalid target co-ordinates (${xpos}, ${ypos})`;
+    }
+    if (!token) {
+        console.warn("dae | teleport: No Token");
+        return "No active token";
+    }
+    // Hide the current token
+    if (targetScene.name === canvas.scene.name) {
+        //@ts-ignore
+        CanvasAnimation.terminateAnimation(`Token.${token.id}.animateMovement`);
+        let sourceSceneId = canvas.scene.id;
+        socketlibSocket.executeAsGM("recreateToken", { userId: game.user.id, tokenUuid: token.uuid, startSceneId: sourceSceneId, targetSceneId: targetScene.id, tokenData: token.data, x: xpos, y: ypos });
+        //requestGMAction(GMAction.actions.recreateToken, { userId: game.user.id, tokenUuid: token.uuid, startSceneId: sourceSceneId, targetSceneId: targetScene.id, tokenData: token.data, x: xpos, y: ypos });
+        canvas.pan({ x: xpos, y: ypos });
+        return true;
+    }
+    // deletes and recreates the token
+    var sourceSceneId = canvas.scene.id;
+    Hooks.once("canvasReady", async () => {
+        await socketlibSocket.executeAsGM("createToken", { userId: game.user.id, startSceneId: sourceSceneId, targetSceneId: targetScene.id, tokenData: token.data, x: xpos, y: ypos });
+        // await requestGMAction(GMAction.actions.createToken, { userId: game.user.id, startSceneId: sourceSceneId, targetSceneId: targetScene.id, tokenData: token.data, x: xpos, y: ypos });
+        // canvas.pan({ x: xpos, y: ypos });
+        await socketlibSocket.executeAsGM("deleteToken", { userId: game.user.id, tokenUuid: token.document.uuid });
+        // await requestGMAction(GMAction.actions.deleteToken, { userId: game.user.id, tokenUuid: token.uuid});
+    });
+    // Need to stop animation since we are going to delete the token and if that happens before the animation completes we get an error
+    //@ts-ignore
+    CanvasAnimation.terminateAnimation(`Token.${token.id}.animateMovement`);
+    return await targetScene.view();
+};

--- a/module/effects/triggerhappy.js
+++ b/module/effects/triggerhappy.js
@@ -1,0 +1,66 @@
+import { setupSocket, teleportToDrawingInScene } from './dae.js'
+
+const Teleport = 'Teleport'
+const OTF = 'OTF'
+
+Hooks.once('setup', function () {
+  if (game.triggers) {
+    console.log('Registering Trigger Happy support')
+    game.triggers.registerEffect(Teleport);
+    game.triggers.registerEffect(OTF);
+    if (!setupSocket())
+      uconsole.log("Unable to set up socket lib for DAE")
+  }
+})
+
+
+export default class TriggerHappySupport {
+
+  static init() {
+    new TriggerHappySupport()._init()
+  }
+
+  _init() {
+    Hooks.on('TriggerHappy', (key, args) => {
+      switch (key) {
+        case Teleport: 
+          this.teleport(args)
+          break;
+        case OTF:
+          this.otf(args)
+        default:
+          console.log("Unknown key: " + key)
+      }
+    })   
+  }
+  teleport(args) {
+    if (!GURPS.LastToken) {
+      ui.notifications.warn("No last token")
+      return 
+    }
+    args = args.join(' ').split('/')
+    let sn = args[0]
+    let dn = args[1]
+    if (!sn || !dn) {
+      ui.notifications.warn('Requires  scene name / drawing name')
+      return 
+    }
+    let scene = game.scenes.contents.find(s => s.name == sn)
+    if (!scene) {
+      ui.notifications.warn("Unable to find scene " + sn)
+      return
+    }
+    let drawing =  scene.drawings.contents.find(d => d.data.text == dn)
+    if (!drawing) {
+      ui.notifications.warn("Unable to find drawing " + dn + " in scene " + sn)
+      return
+    }
+    
+    teleportToDrawingInScene(GURPS.LastToken, drawing, scene)
+  }
+  otf(args) {
+    args = args.join(' ')
+    GURPS.executeOTF(args)
+  }
+}
+

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -28,7 +28,7 @@ import ManeuverHUDButton from './actor/maneuver-button.js'
 import { ItemImporter } from '../module/item-import.js'
 import GURPSTokenHUD from './token-hud.js'
 import GurpsJournalEntry from './journal.js'
-
+import TriggerHappySupport from './effects/triggerhappy.js'
 /**
  * Added to color the rollable parts of the character sheet.
  * Made this part eslint compatible...
@@ -99,9 +99,10 @@ GURPS.LastActor = null
 GURPS.SJGProductMappings = SJGProductMappings
 GURPS.clearActiveEffects = GurpsActiveEffect.clearEffectsOnSelectedToken
 
-GURPS.SetLastActor = function (actor) {
+GURPS.SetLastActor = function (actor, token) {
   if (actor != GURPS.LastActor) console.log('Setting Last Actor:' + actor?.name)
   GURPS.LastActor = actor
+  GURPS.LastToken = token
   setTimeout(() => GURPS.ModifierBucket.refresh(), 100) // Need to make certain the mod bucket refresh occurs later
 }
 
@@ -2182,7 +2183,7 @@ Hooks.once('ready', async function () {
     if (args.length > 1) {
       let a = args[0]?.actor
       if (!!a) {
-        if (args[1]) GURPS.SetLastActor(a)
+        if (args[1]) GURPS.SetLastActor(a, args[0])
         else GURPS.ClearLastActor(a)
       }
     }
@@ -2275,6 +2276,7 @@ Hooks.once('ready', async function () {
   })
 
   GurpsToken.ready()
+  TriggerHappySupport.init()
 
   // End of system "READY" hook.
 })


### PR DESCRIPTION
Triggers can look like this:

[@Drawing[Up]@Trigger[move capture]@Teleport[Second Floor/Down]](url)

If a token move into (or touches, depending on the Trigger Happy setting) a drawing (square or polygon) with the text "Up", it will be 'teleported' to the scene "Second Floor", and placed on the drawing (text = 'Down').    You can make the drawings invisible as traps, or visible to indicate stairs, doors, etc.

[@Drawing[Test1]@Trigger[move capture]@OTF[/hp -1\\Ouch!]](url)

If a token moves on to a drawing (Test1), it will execute the OTF command [/hp -1\\Ouch!](url)

NOTE:  The trigger happy method of calling a chat message does not work for our system (unless you are also willing to install the Furnace module).   And even then, it is shorter to use OTF form (and doesn't require the additional module)

Ours: @OTF[/:macroname]
Theirs: @ChatMessage[/macroname]