### PR TITLE
0.13.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.13.1 (compatible with Foundry 0.9.x)
+# Current Release Version 0.13.2 (compatible with Foundry 0.9.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.13.2
+Release 0.13.2 1/24/2022
 
 - Added support for c:[] d:[] p:[] f:[] parsing from notes
 - Added support for upcoming vtt_notes from GCS

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
   "templateVersion": 2,
@@ -54,7 +54,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.13.1.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.13.2.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Added support for c:[] d:[] p:[] f:[] parsing from notes
- Added support for upcoming vtt_notes from GCS
- Added /show FP HP
- Update TriggerHappy teleport to be more selection friendly @Drawing[PortB]@Trigger[move capture]@Teleport[PortA]@OTF[1d-3 burn]@OTF[/wait 500\\/anim flames*orange*200 c270 *2]
- Updated Brazilian Portuguese language file. (Hi, Frerol!)
- Fixed spamming chat messages for reeling/exhausted.
- Fixed the 'user created equipment' flag on equipment creation.
- Added system setting to turn on/off chat messages for reeling/exhausted.
- Added warning for bad sound file
