### PR TITLE
0.13.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.13.4 (compatible with Foundry 0.9.x)
+# Current Release Version 0.13.5 (compatible with Foundry 0.9.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.
@@ -11,7 +11,7 @@ If you like our work [Sponsor our development](https://github.com/sponsors/crnor
 
 Join us on Discord: [GURPS Foundry-VTT Discord](https://discord.gg/6xJBcYWyED)
 
-[Current GCA Export version: 'GCA-11' 12/23/2021 / Current GCS Export version: 'GCS-5' 3/8/2021](https://drive.google.com/file/d/1vbDb9WtYQiZI78Pwa_TlEvYpJnR_S67B/view?usp=sharing)
+[Current GCA4 Export version: 'GCA-11' 12/23/2021 / Current GCA5 Export version: 'GCA5-12' 2/28/2022 / Current GCS Export version: 'GCS-5' 3/8/2021](https://drive.google.com/file/d/1vbDb9WtYQiZI78Pwa_TlEvYpJnR_S67B/view?usp=sharing)
 
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.13.5
+Release 0.13.5 2/28/2022
 
 - Updated GCA5 Exporter to fix an export issue. ~Stevil
 - Updated import code to warn if not using latest GCA5 export script.

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
   "templateVersion": 2,
@@ -54,7 +54,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.13.4.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.13.5.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Updated GCA5 Exporter to fix an export issue. ~Stevil
- Updated import code to warn if not using latest GCA5 export script.
- Removed default hit locations from template file.
- Added support for multiple movement modes, such as Ground, Air, Water, Space. (In the editor, click the edit button next to the new Move Type dropdown menu to add, delete, modify movement types).
- Support for Enhanced Move, including in the Drag Ruler.
- Support unlimited, by-the-book, range on the Standard Speed, Size, and Range Table.
- Unified the NPC/mini and NPC/mini CI sheets. Now "NPC/mini" supports both.
- Added /IF [otf] cs:{} s:{} f:{} cf:{} syntax
- Added @margin to add last margin of success to roll (useful on frightcheck tables, reaction tables)
- Added @target for /hp /fp commands
- Added support for !/ev [OTF] which will roll [OTF] against all of the player characters, a blindrolls (so only the GM sees).
- Fixed some Dice so Nice calls for /ev, /hp, /fp and random hit location
- Added Modifier Bucket magnet
- Added modifier [+@margin]
- Fixed Melee attack usage not saving during edit
- Fixed Melee/Range attack if usage/mode contained "( )"
- Added +/-@margin to attribute, skill and attack OTFs ex: \[ST+@margin] \[Sk:Brawling-@margin] \[M:Natural\*Attacks+@margin]
- Fixed Resource Tacker editor (re-enabled + buttons), and added "Add Resource Tracker" button to melee head (if no trackers)
- Updated to JB2A v0.3.8
