### PR TITLE
0.13.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.13.7 (compatible with Foundry 0.9.x)
+# Current Release Version 0.13.8 (compatible with Foundry 0.9.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.13.8
+Release 0.13.8 3/5/2022
 
 - Fixed GCA5-12 export for unmodified damage.
 - Increased size of generic modifier buttons in Other Modifiers section.

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
   "templateVersion": 2,
@@ -54,7 +54,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.13.7.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.13.8.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Fixed GCA5-12 export for unmodified damage.
- Increased size of generic modifier buttons in Other Modifiers section.
- Fixed various chat messages (failing substitutions).
- Added handling of user defined page ref containing URL.
- Fixed /status chat command.
- Updated Brazilian Portuguese language file.
- Change remaining calls from {{localize}} handlebar to ((i18n}} handlebar.
- Fixed reaction and conditional mods to be draggable.
