### PR TITLE
0.13.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.13.11 (compatible with Foundry 0.9.x)
+# Current Release Version 0.13.12 (compatible with Foundry 0.9.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.13.12
+Release 0.13.12 3/9/2022
 
 - Allow Skill Names to be enclosed in single quotes
 - Import GCS VTT-Notes for Advantages and Equipment

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
   "templateVersion": 2,
@@ -54,7 +54,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.13.11.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.13.12.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Allow Skill Names to be enclosed in single quotes
- Import GCS VTT-Notes for Advantages and Equipment
- Fixed import spell class from .gcs
- Fixed display in melee/range if item in both equipped and other equipment list
- Fixed /fc chat command
- Added 'thing' description when using +/-@margin as a modifier
- Add GM drag and drop combat initiative order (for Peter ;-)
- Fixed Item bonuses/melee/ranged not respecting 'unequipped' flag.
- Added system setting for default ADD action (apply, apply quietly, target).
