### PR TITLE
0.13.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.13.13 (compatible with Foundry 0.9.x)
+# Current Release Version 0.13.14 (compatible with Foundry 0.9.x)
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.13.14
+Release 0.13.14 4/12/2022
 
 - Make all @margin entries case insensitive
 - Add /if check for @margin, @isCritSuccess, @isCritFailure (@margin >/>=/</<=/=/== X)

--- a/system.json
+++ b/system.json
@@ -52,7 +52,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.13.13.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.13.14.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Make all @margin entries case insensitive
- Add /if check for @margin, @isCritSuccess, @isCritFailure (@margin >/>=/</<=/=/== X)
- Fixed, when clicking OTF Journal link, only show for current user (not all owners, including GM).
- Added range modifier support for grid units (ex: meters, millimeters, kilometers, inches, centimeters, feet, yards, miles, parcecs, light years, etc.) Thanks @Kalos!
- Allow \*Per 1fp (vs. \*Cost 1fp)
- Updated JB2A to v0.4.x
- Add support for split DR.
- Support linked damage: all comma-separated damage will be rolled with one click. E.g. `2d cut,1d+1 burn`.
- Support an optional title for a Note.
- Added a "damage accumulator" for powers like spells which do a variable amount of damage. Adding '+' in front of damage makes it accumulate.
- Added damage right-click option to combine multiple rolls into one; e.g. combining five `1d-1 burn` rolls yields one roll of `5d-5 burn`.
- Added @kbrownridge's Quintessence code
