### PR TITLE
Fixed equipment library items being duplicated after world is reloaded

### DIFF
--- a/module/item-import.js
+++ b/module/item-import.js
@@ -206,7 +206,11 @@ export class ItemImporter {
         }
       }
     itemData.data.bonuses = bonus_list.join('\n')
-    let oi = pack.find(p => p.data.data.eqt.uuid === itemData.data.eqt.uuid)
+    const cachedItems = [];
+    for (let i of pack.index) {
+      cachedItems.push(await pack.getDocument(i._id));
+    }
+    let oi = await cachedItems.find(p => p.data.data.eqt.uuid === itemData.data.eqt.uuid)
     if (!!oi) {
       let oldData = duplicate(oi.data.data)
       let newData = duplicate(itemData.data)


### PR DESCRIPTION
Program now caches items from the requested compendium, which was previously not done, which would fail to find and subsequently replace any duplicate items