### PR TITLE
Support override text for PDF links

### DIFF
--- a/lib/parselink.js
+++ b/lib/parselink.js
@@ -438,7 +438,7 @@ export function parselink(str, htmldesc, clrdmods = false) {
   let pdf = str.replace(/^PDF: */g, '')
   if (pdf != str) {
     return {
-      text: "<span class='pdflink'>" + pdf + '</span>',
+      text: "<span class='pdflink' data-pdf='" + pdf + "'>" + (overridetxt || pdf) + '</span>',
       action: {
         orig: str,
         type: 'pdf',

--- a/module/pdf-refs.js
+++ b/module/pdf-refs.js
@@ -62,7 +62,8 @@ export const SJGProductMappings = {
 export function handleOnPdf(event) {
   event.preventDefault()
   event.stopPropagation()
-  handlePdf(event.currentTarget.innerText)
+  let pdf = event.currentTarget.dataset?.pdf || event.currentTarget.innerText
+  handlePdf(pdf)
 }
 
 /**


### PR DESCRIPTION
For example:
`(['See Area and Spreading Attacks, Exploits, pp. 44–45'PDF:DFE44])`
produces:

![image](https://user-images.githubusercontent.com/8931036/168949225-6e8503c5-61cf-435e-976e-5b61fd62baca.png)
