### PR TITLE
0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.13.19 (compatible with Foundry 0.9.x)
+# Current Release Version 0.14.00 (compatible with Foundry 0.9.x)
+With support for the [Nordlondr Ovinabokin: Bestiary and Enemies module](https://foundryvtt.com/packages/nordlond-bestiary)!
 
 ### [Change Log](changelog.md)
 The list was getting just too long, so it has been moved to a separate file.   Click above to see what has changed.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.13.20
+Release 0.14.0 5/18/2022
 
 - Partial fix for Modifier Bucket when Minimal UI module is active.
 - Fix for Damage followon button for Nordlond Bestiary.

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.13.19",
+  "version": "0.14.0",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
   "templateVersion": 2,
@@ -52,7 +52,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.13.19.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.14.0.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Partial fix for Modifier Bucket when Minimal UI module is active.
- Fix for Damage followon button for Nordlond Bestiary.
- Add initial support for 'kb' (knockback only) damage type.
- Support override text for PDF links.
- Fixed PDF references for Gaming Ballistic and Nordlond Bestiary
