### PR TITLE
Added GCS Portrait Import

### DIFF
--- a/lib/miscellaneous-settings.js
+++ b/lib/miscellaneous-settings.js
@@ -60,6 +60,8 @@ export const SETTING_MANEUVER_UPDATES_MOVE = 'maneuver-updates-move'
 export const SETTING_SHOW_CHAT_FOR_REELING_TIRED = 'show-chat-reeling-tired'
 export const SETTING_USE_QUINTESSENCE = 'use-quintessence'
 export const SETTING_DEFAULT_ADD_ACTION = 'default-add-action'
+export const SETTING_PORTRAIT_PATH = 'portrait-path'
+export const SETTING_OVERWRITE_PORTRAITS = 'overwrite-portraitsk'
 
 export const VERSION_096 = SemanticVersion.fromString('0.9.6')
 export const VERSION_097 = SemanticVersion.fromString('0.9.7')
@@ -625,6 +627,30 @@ export function initializeSettings() {
       type: String,
       default: 'Fright Check',
       onChange: value => console.log(`Fright Check table name : ${value}`),
+    })
+
+    game.settings.register(SYSTEM_NAME, SETTING_PORTRAIT_PATH, {
+      name: 'Portrait Path',
+      hint: 'Choose where character portraits are stored (in the global Foundry User Data directory, or the local world directory).',
+      scope: 'world',
+      config: true,
+      type: String,
+      default: 'global',
+      choices: {
+        global: 'Global ([Foundry User Data]/Data/images/portaits/',
+        local: 'Local ([Foundry User Data]/Data/worlds/[World]/images/portaits/)'
+      },
+      onChange: value => console.log(`Portrait Path : ${value}`),
+    })
+
+    game.settings.register(SYSTEM_NAME, SETTING_OVERWRITE_PORTRAITS, {
+      name: 'Overwrite Portraits',
+      hint: 'Choose whether character portraits are overwritten on import',
+      scope: 'world',
+      config: true,
+      type: Boolean,
+      default: true,
+      onChange: value => console.log(`Overwrite Portraits : ${value}`),
     })
   })
 }

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1247,7 +1247,6 @@ export class GurpsActor extends Actor {
           currentDir += path.split("/")[i] + "/";
           await FilePicker.createDirectory("data", currentDir);
         } catch (err) {
-          console.error(err);
           continue;
         }
       }

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1250,7 +1250,7 @@ export class GurpsActor extends Actor {
           continue;
         }
       }
-        const filename = `${p.name}_${this.id}_portrait.png`;
+        const filename = `${p.name}_${this.id}_portrait.png`.replace(" ", "_");
         const url = `data:image/png;base64,${p.portrait}`;
         await fetch(url)
           .then((res) => res.blob())
@@ -1258,7 +1258,7 @@ export class GurpsActor extends Actor {
             const file = new File([blob], filename);
             FilePicker.upload("data", path, file, {}, { notify: false });
           });
-          r.img = path + "/" + filename;
+          r.img = (path + "/" + filename).replace(" ", "_");
       }
       return r;
     }


### PR DESCRIPTION
When importing characters from GCS, if the `.gcs` file includes a portrait, GGA will save the portrait to a specified directory, and set the character's `img` value to it.
Importing portraits can be toggled on or off through the System Settings.
The directory can also be changed. Currently, there are two options:
- "global" saves all portraits to `[FoundryVTT User Data Directory]/Data/images/portraits/`
- "local" saves all portraits to `[FoundryVTT User Data Directory]/Data/worlds/[World]/images/portraits/`

As always, any requests for changes are welcome, if you guys would like to add this feature to GGA.