### PR TITLE
0.14.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.14.3 (compatible with Foundry 0.9.x)
+# Current Release Version 0.14.4 (compatible with Foundry 0.9.x)
 With support for the [Nordlondr Ovinabokin: Bestiary and Enemies module](https://foundryvtt.com/packages/nordlond-bestiary)!
 
 ### [Change Log](changelog.md)

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.14.4
+Release 0.14.4 7/7/2022
 
 - Import Portrait image from GCS file, Thanks @Neck!
 - Change UTF reader to "hopefully" support extended characters on Mac and Linux

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
   "templateVersion": 2,
@@ -52,7 +52,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.14.3.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.14.4.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Import Portrait image from GCS file, Thanks @Neck!
- Change UTF reader to "hopefully" support extended characters on Mac and Linux
- Update code to convert 'BX' PDF references to 'B' references if using the combined PDF (GCS Library update 3.15.1)
- Update JB2A to 0.4.5
- Fixed? the possible Mythic Game Master Emulator issue when using Dice so Nice.
