### PR TITLE
0.14.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.14.4 (compatible with Foundry 0.9.x)
+# Current Release Version 0.14.5 (compatible with Foundry 0.9.x)
 With support for the [Nordlondr Ovinabokin: Bestiary and Enemies module](https://foundryvtt.com/packages/nordlond-bestiary)!
 
 ### [Change Log](changelog.md)

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.14.5
+Release 0.14.5 - 7/24/2022
 
 - Fixed pi+ and pi++ parsing on Mook generator
 - Fixed pi++ OTF parsing and damage creation

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
   "templateVersion": 2,
@@ -52,7 +52,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.14.4.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.14.5.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Fixed pi+ and pi++ parsing on Mook generator
- Fixed pi++ OTF parsing and damage creation
- Fixed GCS import exception when using UTF-8
- Added Legendsmith's BAD status icons
- Fixed Cast time column for Items
- Fixed calc on ADs/DisADs so it works like GCS
- Holding CTRL shows changes in roll mode (GM roll for GMs, Blind roll for Players), w/system setting
- Fix /hp +1 @target for good?
- Damage column can now execute OTFs (ex: PDF:B405)
- OTF now handles HTTP URLs.   [http://google.com], as well as labeled ["Google!"http://google.com]
- Drag and drop PDF Journal links now open PDFoundry, and not the placeholder Journal
- Show "flavor" text below roll (issue #1426)
- Add ability to roll dice or damage multiple times from chat "/r [3d] 5" or "/r [3d cut] 5"
- Add ability to roll dice or damage multiple times from chat (using compact syntax) "/3d 5" or "/3d cut 5"
- Fixed initial vtt-notes import from GCS
- Added warning for /repeat X /anim ... when actor not linked
- Added "selected roll", /sr [otf], /psr [otf] .   "rolls" (executes) OTF against the selected actors.  /sr [per], /sr [/hp -1d-3!], /sr [/hp reset]
