### PR TITLE
0.14.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.14.9 (compatible with Foundry 0.9.x)
+# Current Release Version 0.14.10 (compatible with Foundry 0.9.x)
 With support for the [Nordlondr Ovinabokin: Bestiary and Enemies module](https://foundryvtt.com/packages/nordlond-bestiary)!
 
 ### [Change Log](changelog.md)

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.14.10
+Release 0.14.10 - 9/07/2022
 
 - Fixed Skill search if skill has no name
 - Catch bad maneuver data during import

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "gurps",
   "title": "GURPS 4th Ed. Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.14.9",
+  "version": "0.14.10",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
   "templateVersion": 2,
@@ -52,7 +52,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.14.9.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.14.10.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Fixed Skill search if skill has no name
- Catch bad maneuver data during import
- Don't throw exception when a bad token is in combat
- Protect char sheet positioning if bad position
- Fixed PDF references like "b40-43"
- Fixed, reinstalled individual dice results on targetted rolls.
- Enhanced /show to accept -a (sort alphabetically), -pc and -npc flags
- Fixed import of usage notes for melee and ranged weapons
- Fixed /anim file selection algorithm (to detgermine best fit).   NOTE: You may need to adjust your current targeted /anim commands to get the right "look".
- Added 'Show?' button to tooltip
- Holding CTRL/CMD and clicking a "send to" will add, not replace player's bucket
- Update to JB2A 0.4.9
- Fixed parsing for 1/2 damage, ex: [2Dx0.5 cut]
- Fixed other eqt cost in header bar
- Fixed damage chat message "attacker" (which may be different than 'selected')
