### PR TITLE
0.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.15.0 (compatible with FoundryVTT v10.x)
+# Current Release Version 0.15.1 (compatible with FoundryVTT v10.x)
 
 With support for the [Nordlondr Ovinabokin: Bestiary and Enemies module](https://foundryvtt.com/packages/nordlond-bestiary)!
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.15.1 9/13/2022
+Release 0.15.1 9/14/2022
 
 - Fixed call to missing obsolete migration methods.
 - Updated Users Doc PDF

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "gurps",
   "title": "GURPS 4e Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "authors": [
     {
       "name": "Chris Normand",
@@ -75,7 +75,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.15.0.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.15.1.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Fixed call to missing obsolete migration methods.
- Updated Users Doc PDF
- Support JournalEntryPage drag&drop
- Fixed targeted rolls made by a specific actor will remember that actor (especially when clicking 'follow on' damage after hit)
