### PR TITLE
0.15.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.15.10 (compatible with FoundryVTT v10.x)
+# Current Release Version 0.15.11 (compatible with FoundryVTT v10.x)
 
 With support for the [Nordlondr Ovinabokin: Bestiary and Enemies module](https://foundryvtt.com/packages/nordlond-bestiary)!
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-Release 0.15.11 
+Release 0.15.11 11/10/2022
 
 - Change Github release.yml to include 'utils'
 - Fixed more Item issues caused by the v9->v10 upgrade.   Items will now split and combine by name.

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "gurps",
   "title": "GURPS 4e Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.15.10",
+  "version": "0.15.11",
   "authors": [
     {
       "name": "Chris Normand",
@@ -76,7 +76,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.15.10.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.15.11.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Change Github release.yml to include 'utils'
- Fixed more Item issues caused by the v9->v10 upgrade.   Items will now split and combine by name.
