### PR TITLE
Update ExportToFoundryVTT.vb

### DIFF
--- a/exportutils/ExportToFoundryVTT/ExportToFoundryVTT.vb
+++ b/exportutils/ExportToFoundryVTT/ExportToFoundryVTT.vb
@@ -534,7 +534,7 @@ Public Class ExportToFoundryVTT
                 fw.Paragraph("<relativelevel type=""string"">" & tmp & "</relativelevel>")
 
                 fw.Paragraph("<points type=""number"">" & CurChar.Items(i).TagItem("points") & "</points>")
-                fw.Paragraph("<text type=""string"">" & UpdateEscapeChars(RTFtoPlainText(CurChar.Items(i).TagItem("usernotes"))) & "</text>") '2022-11-17 - convert to plain text - ADS
+                fw.Paragraph("<text type=""string"">" & UpdateEscapeChars(UserVTTNotes(CurChar, i)) & "</text>") '2022-11-17 - combine user notes & vtt notes - ADS
                 fw.Paragraph("<pageref type=""string"">" & CurChar.Items(i).TagItem("page") & "</pageref>")
                 fw.Paragraph("<parentuuid>" & CurChar.Items(i).ParentKey & "</parentuuid>")
                 fw.Paragraph("<uuid>k" & CurChar.Items(i).idkey & "</uuid>")
@@ -611,7 +611,7 @@ Public Class ExportToFoundryVTT
                 fw.Paragraph("<class type=""string"">" & spellClass & "</class>")
                 fw.Paragraph("<type type=""string"">" & CurChar.Items(i).TagItem("type") & "</type>")
                 fw.Paragraph("<points type=""number"">" & CurChar.Items(i).TagItem("points") & "</points>")
-                fw.Paragraph("<text type=""string"">" & UpdateEscapeChars(RTFtoPlainText(CurChar.Items(i).TagItem("usernotes"))) & "</text>") '2022-11-17 - convert to plain text - ADS
+                fw.Paragraph("<text type=""string"">" & UpdateEscapeChars(UserVTTNotes(CurChar, i)) & "</text>") '2022-11-17 - combine user notes & vtt notes - ADS
 				
 
                 fw.Paragraph("<time type=""string"">" & CurChar.Items(i).TagItem("time") & "</time>")
@@ -942,7 +942,7 @@ Public Class ExportToFoundryVTT
                 fw.Paragraph("<weight type=""string"">" & StrToDbl(CurChar.Items(i).tagitem("weight")) /qty & "</weight>")
 
                 'print the notes (not currently shown on Fantasy Grounds character sheet)
-                fw.Paragraph("<text type=""string"">" & UpdateEscapeChars(RTFtoPlainText(CurChar.Items(i).TagItem("usernotes"))) & "</text>") '2022-11-17 - convert to plain text - ADS
+                fw.Paragraph("<text type=""string"">" & UpdateEscapeChars(UserVTTNotes(CurChar, i)) & "</text>") '2022-11-17 - combine user notes & vtt notes - ADS
                 
                 fw.Paragraph("<tl type=""string"">" & CurChar.Items(i).TagItem("techlvl") & "</tl>")
                 
@@ -1074,7 +1074,7 @@ Public Class ExportToFoundryVTT
                     fw.Paragraph("<lc type=""string"">" & CurChar.Items(i).TagItem("lc") & "</lc>")
 
                     'print the notes (not currently shown on Fantasy Grounds character sheet)
-                    fw.Paragraph("<text type=""string"">" & UpdateEscapeChars(RTFtoPlainText(CurChar.Items(i).TagItem("usernotes"))) & "</text>") '2022-11-17 - convert to plain text - ADS
+                    fw.Paragraph("<text type=""string"">" & UpdateEscapeChars(UserVTTNotes(CurChar, i)) & "</text>") '2022-11-17 - combine user notes & vtt notes - ADS
 
                     fw.Paragraph("<tl type=""string"">" & CurChar.Items(i).DamageModeTagItem(CurMode, "techlvl") & "</tl>")
 
@@ -1382,7 +1382,7 @@ Public Class ExportToFoundryVTT
                         work = work - CInt(CurChar.Items(i).TagItem("childpoints"))
                     End If
                     fw.Paragraph("<points type=""number"">" & CStr(work) & "</points>")
-                    fw.Paragraph("<text type=""string"">" & mods_text & UpdateEscapeChars(RTFtoPlainText(CurChar.Items(i).TagItem("usernotes"))) & "</text>") '2022-11-17 - convert to plain text - ADS
+                    fw.Paragraph("<text type=""string"">" & mods_text & UpdateEscapeChars(UserVTTNotes(CurChar, i)) & "</text>") '2022-11-17 - combine user notes & vtt notes - ADS
                     fw.Paragraph("</id-" & tag_index & ">")
 
                 End If
@@ -1423,7 +1423,7 @@ Public Class ExportToFoundryVTT
                             work = work - CInt(CurChar.Items(i).TagItem("childpoints"))
                         End If
                         fw.Paragraph("<points type=""number"">" & CStr(work) & "</points>")
-                        fw.Paragraph("<text type=""string"">" & mods_text & UpdateEscapeChars(RTFtoPlainText(CurChar.Items(i).TagItem("usernotes"))) & "</text>") '2022-11-17 - convert to plain text - ADS
+                        fw.Paragraph("<text type=""string"">" & mods_text & UpdateEscapeChars(UserVTTNotes(CurChar, i)) & "</text>") '2022-11-17 - combine user notes & vtt notes - ADS
                         fw.Paragraph("<pageref type=""string"">" & CurChar.Items(i).TagItem("page") & "</pageref>")
                         fw.Paragraph("<parentuuid>" & CurChar.Items(i).ParentKey & "</parentuuid>")
                         fw.Paragraph("<uuid>k" & CurChar.Items(i).idkey & "</uuid>")
@@ -1466,7 +1466,7 @@ Public Class ExportToFoundryVTT
                         work = work - CInt(CurChar.Items(i).TagItem("childpoints"))
                     End If
                     fw.Paragraph("<points type=""number"">" & CStr(work) & "</points>")
-                    fw.Paragraph("<text type=""string"">" & mods_text & UpdateEscapeChars(RTFtoPlainText(CurChar.Items(i).TagItem("usernotes"))) & "</text>") '2022-11-17 - convert to plain text - ADS
+                    fw.Paragraph("<text type=""string"">" & mods_text & UpdateEscapeChars(UserVTTNotes(CurChar, i)) & "</text>") '2022-11-17 - combine user notes & vtt notes - ADS
                     fw.Paragraph("<pageref type=""string"">" & CurChar.Items(i).TagItem("page") & "</pageref>")
                     fw.Paragraph("<parentuuid>" & CurChar.Items(i).ParentKey & "</parentuuid>")
                     fw.Paragraph("<uuid>k" & CurChar.Items(i).idkey & "</uuid>")
@@ -1526,7 +1526,7 @@ Public Class ExportToFoundryVTT
                         work = work - CInt(CurChar.Items(i).TagItem("childpoints"))
                     End If
                     fw.Paragraph("<points type=""number"">" & CStr(work) & "</points>")
-                    fw.Paragraph("<text type=""string"">" & CreateControlRoll(mods_text & UpdateEscapeChars(RTFtoPlainText(CurChar.Items(i).TagItem("usernotes")))) & "</text>") '2022-11-17 - convert to plain text - ADS
+                    fw.Paragraph("<text type=""string"">" & CreateControlRoll(mods_text & UpdateEscapeChars(UserVTTNotes(CurChar, i))) & "</text>") '2022-11-17 - combine user notes & vtt notes - ADS
                     fw.Paragraph("<pageref type=""string"">" & CurChar.Items(i).TagItem("page") & "</pageref>")
                     fw.Paragraph("<parentuuid>" & CurChar.Items(i).ParentKey & "</parentuuid>")
                     fw.Paragraph("<uuid>k" & CurChar.Items(i).idkey & "</uuid>")
@@ -1568,7 +1568,7 @@ Public Class ExportToFoundryVTT
                         work = work - CInt(CurChar.Items(i).TagItem("childpoints"))
                     End If
                     fw.Paragraph("<points type=""number"">" & CStr(work) & "</points>")
-                    fw.Paragraph("<text type=""string"">" & mods_text & UpdateEscapeChars(RTFtoPlainText(CurChar.Items(i).TagItem("usernotes"))) & "</text>") '2022-11-17 - convert to plain text - ADS
+                    fw.Paragraph("<text type=""string"">" & mods_text & UpdateEscapeChars(UserVTTNotes(CurChar, i)) & "</text>") '2022-11-17 - combine user notes & vtt notes - ADS
                     fw.Paragraph("<pageref type=""string"">" & CurChar.Items(i).TagItem("page") & "</pageref>")
                     fw.Paragraph("<parentuuid>" & CurChar.Items(i).ParentKey & "</parentuuid>")
                     fw.Paragraph("<uuid>k" & CurChar.Items(i).idkey & "</uuid>")
@@ -1873,7 +1873,7 @@ Public Class ExportToFoundryVTT
 
         ' then print, converting carriage returns to \r
         ' (I've done this in two steps in case the pairs ever come through the other way round, e.g. after editing in a different app)
-        fw.Paragraph("<description type=""string"">" & UpdateEscapeChars(RTFtoPlainText(CurChar.Description)) & "</description>") '2022-11-17 - new function is more robust
+        fw.Paragraph("<description type=""string"">" & UpdateEscapeChars(RTFtoPlainText(CurChar.Description)) & "</description>") '2022-11-17 - new function is more robust - ADS
 
     End Sub
 
@@ -1903,7 +1903,7 @@ Public Class ExportToFoundryVTT
         ' then print, converting carriage returns to \r
         ' (I've done this in two steps in case the pairs ever come through the other way round, e.g. after editing in a different app)
         fw.Paragraph("<name type=""string"">Character Note</name>")
-        fw.Paragraph("<text type=""string"">" & UpdateEscapeChars(RTFtoPlainText(CurChar.Notes)) & "</text>") '2022-11-17 - new function is more robust
+        fw.Paragraph("<text type=""string"">" & UpdateEscapeChars(RTFtoPlainText(CurChar.Notes)) & "</text>") '2022-11-17 - new function is more robust - ADS
 
         fw.Paragraph("</id-00001>")
         fw.Paragraph("</notelist>")
@@ -2112,6 +2112,29 @@ Public Class ExportToFoundryVTT
         On Error GoTo 0
         'disable error handling
 
+    End Function
+
+'****************************************
+'* Function
+'* Convenient way to get UserNotes and VTTNotes combined
+'* ~ ADS
+'****************************************
+    Function UserVTTNotes(CurChar as GCACharacter, Index As Integer) As String
+        Dim ret As String = ""
+        Dim user As String = RTFtoPlainText(CurChar.Items(Index).TagItem("usernotes")).Trim
+        Dim vtt As String = CurChar.Items(Index).TagItem("vttnotes").Trim
+
+        If user <> "" Then ret = user
+		
+        If vtt <> "" Then
+            If ret = "" Then
+                ret = vtt
+            Else
+                ret = ret & vblf & vtt
+            End If
+        End If
+
+        Return ret
     End Function
 
 End Class


### PR DESCRIPTION
This includes a new function to return a concatenated UserNotes and VTT Notes. It includes a plain-texted UserNotes first, then a line break, then VTT Notes. Only non-empty fields are included, and adds no line-break if just one field is included. The new function is now used in place of the previous calls to plain-text UserNotes. Hopefully this successfully allows users to enjoy both fields as intended.