### PR TITLE
0.15.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.15.12 (compatible with FoundryVTT v10.x)
+# Current Release Version 0.15.13 (compatible with FoundryVTT v10.x)
 
 With support for the [Nordlondr Ovinabokin: Bestiary and Enemies module](https://foundryvtt.com/packages/nordlond-bestiary)!
 

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "gurps",
   "title": "GURPS 4e Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.15.12",
+  "version": "0.15.13",
   "authors": [
     {
       "name": "Chris Normand",
@@ -81,7 +81,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.15.12.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.15.13.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Added support for Warpgate module (in animations).   HIGHLY RECOMMENDED!
- Shortened "Roll Damage" to "Damage" in successful hit msg
- Show error if PDF book code not found
- Allow case insensitive OTF for PDF
- Foundry item rename now correctly renames ranged attacks
- Fixed error in en lang selection warning
- Rounded down Strength based ranges to nearest integer
- Updated to JB2A 0.5.2
