### PR TITLE
0.15.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.15.16 (compatible with FoundryVTT v10.x)
+# Current Release Version 0.15.17 (compatible with FoundryVTT v10.x)
 
 With support for the [Nordlondr Ovinabokin: Bestiary and Enemies module](https://foundryvtt.com/packages/nordlond-bestiary)!
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 ### [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 
 
+Release 0.15.17 12/15/2022
+
+- Allow attribute rolls (IQ, DX, etc.) to remember which character they came from using OtF sourceId (for GMs with multiple NPCs)
+- Add support for RcL < 1 (0.5), to support a weapon that shoots 2 rounds per attempt
+- Fix /st ... @self to work with /sr command
+- Workaround for UI blowing up (if player clicked on damage chat window to see rolls).   Rolls are now always shown for damage chat msgs
+
 Release 0.15.16 12/08/2022
 
 - Added support for list of files using /sound chat command.   /sound /dir/somefile.txt read text file (list of file names) and randomly picks one

--- a/lib/parselink.js
+++ b/lib/parselink.js
@@ -424,6 +424,7 @@ export function parselink(str, htmldesc, clrdmods = false) {
         falsetext: opt[5],
         target: target,
         melee: melee,
+        sourceId: sourceId
       }
       return {
         text: gspan(overridetxt, spantext, action, brtxt),

--- a/module/chat/chat-processors.js
+++ b/module/chat/chat-processors.js
@@ -1032,6 +1032,25 @@ class DevChatProcessor extends ChatProcessor {
         GURPS.executeOTF('/sel *\\\\/sr [/hp reset]\\\\/sr [/fp reset]\\\\/sr [/st clear]')
         break
       }
+      case 'resetstatus': {
+        for (let t of canvas.tokens.controlled) {
+          console.log(`Checking ${t.name}`)
+          const effect = t.actor.effects.contents;
+          for (let i = 0; i < effect.length; i++) {
+            let condition = effect[i].label;
+            let status = effect[i].disabled;
+            let effect_id = effect[i]._id;
+            console.log(`Removing from ${t.name} condition: [${condition}] status: [${status}] effect_id: [${effect_id}]`)
+            if (status === false) {
+                try {
+                  await _token.actor.deleteEmbeddedDocuments("ActiveEffect", [effect_id]);
+                } catch (error) {
+                  console.log(error)
+                }
+            }
+          } 
+        }  
+      }
     }
   }
 }

--- a/module/chat/status.js
+++ b/module/chat/status.js
@@ -150,6 +150,9 @@ export default class StatusChatProcessor extends ChatProcessor {
   getSelfTokens() {
     let list = canvas.tokens?.placeables.filter(it => it.owner)
     if (list && list.length === 1) return list
+    
+    list = canvas.tokens?.placeables.filter(it => it.actor == GURPS.LastActor)
+    if (list && list.length === 1) return list
 
     let msg = list && list.length === 0 ? i18n('GURPS.chatNoOwnedTokenFound') : i18n('GURPS.chatMultipleOwnedFound')
     ui.notifications.warn(msg)

--- a/module/dierolls/dieroll.js
+++ b/module/dierolls/dieroll.js
@@ -96,7 +96,7 @@ export async function doRoll({
 
     if (margin > 0 && !!optionalArgs.obj && !!optionalArgs.obj.rcl) {
       // if the attached obj (see handleRoll()) as Recoil information, do the additional math
-      let rofrcl = Math.floor(margin / parseInt(optionalArgs.obj.rcl)) + 1
+      let rofrcl = Math.floor(margin / parseFloat(optionalArgs.obj.rcl)) + 1
       if (!!optionalArgs.obj.rof) {
         let rof = optionalArgs.obj.rof
         let m = rof.match(/(\d+)[×xX\*](\d+)/) // Support shotgun RoF (3x9)

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -104,7 +104,7 @@ if (!globalThis.GURPS) {
   Settings.initializeSettings()
   GURPS.EffectModifierControl = new EffectModifierControl()
 
-  // CONFIG.debug.hooks = true;
+  //CONFIG.debug.hooks = true;
 
   // Expose Maneuvers to make them easier to use in modules
   GURPS.Maneuvers = Maneuvers

--- a/styles/apps.css
+++ b/styles/apps.css
@@ -514,7 +514,7 @@ ul#result-effects li {
 }
 
 .toggle:checked + .label-toggle + .collapsible-content {
-  max-height: 130vh;
+  max-height: 130vh; 
 }
 
 .damage-message .label-toggle {
@@ -532,9 +532,8 @@ ul#result-effects li {
 
 .damage-message .toggle:checked + .label-toggle:after {
   font: normal normal normal 12px/1;
-  /*  font-family: 'Font Awesome 5 Free'; */
   font-weight: 900;
-  content: '\f077';
+  content: '\f077'; 
   float: right;
 }
 

--- a/styles/simple.css
+++ b/styles/simple.css
@@ -2047,7 +2047,7 @@ body {
 .roll-result .roll-value,
 .roll-result .roll-detail {
   /* font-family: var(--fontawesomefamily); */
-  font-family: inherit;
+  font-family: inherit; 
 }
 
 .roll-result .roll-detail {
@@ -2055,7 +2055,7 @@ body {
 }
 
 .roll-result .roll-detail .aside {
-  font-size: inherit;
+  font-size: inherit; 
 }
 
 .roll-result .roll-detail .crit {

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "gurps",
   "title": "GURPS 4e Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.15.16",
+  "version": "0.15.17",
   "authors": [
     {
       "name": "Chris Normand",
@@ -81,7 +81,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.15.16.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.15.17.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }

--- a/templates/damage-message.hbs
+++ b/templates/damage-message.hbs
@@ -27,9 +27,9 @@
       <div class='gurps damage-message' data-transfer='{{transfer}}'>
 
         <div class='roll-message'>
-          <div class='collapsible-wrapper'>
-            <input id='collapsible-{{id}}' class='toggle offscreen-only' type='checkbox'>
-            <label for='collapsible-{{id}}' class='roll-result {{#if hasExplanation}}label-toggle{{/if}}'>
+          <div class='collapsible-wrapperXXXX'>
+            <!-- <input id='collapsible-{{id}}' class='toggle offscreen-only' type='checkbox'> -->
+            <label for='collapsible-{{id}}' class='roll-result {{#if hasExplanation}}label-toggleXXXX{{/if}}'>
               <span>{{#if target}}&nbsp;{{target}}:{{/if}} 
                 {{#if ../loaded}}
                   <i style='color:darkred' class='fas fa-user'></i>


### PR DESCRIPTION
- Allow attribute rolls (IQ, DX, etc.) to remember which character they came from using OtF sourceId (for GMs with multiple NPCs)
- Add support for RcL < 1 (0.5), to support a weapon that shoots 2 rounds per attempt
- Fix /st ... @self to work with /sr command
- Workaround for UI blowing up (if player clicked on damage chat window to see rolls).   Rolls are now always shown for damage chat msgs
