### PR TITLE
Fix editing PER and WILL for users in Foundry

### DIFF
--- a/templates/actor/sections/secondary-attributes.hbs
+++ b/templates/actor/sections/secondary-attributes.hbs
@@ -17,10 +17,10 @@
     {{#if isEditing}}
       <div class='field'>
         <input
-          name='system.attributes.WILL.value'
+          name='system.attributes.WILL.import'
           class='gcs-input'
           type='number'
-          value='{{system.attributes.WILL.value}}'
+          value='{{system.attributes.WILL.import}}'
         />
       </div>
     {{else}}
@@ -52,10 +52,10 @@
     {{#if isEditing}}
       <div class='field'>
         <input
-          name='system.attributes.PER.value'
+          name='system.attributes.PER.import'
           class='gcs-input'
           type='number'
-          value='{{system.attributes.PER.value}}'
+          value='{{system.attributes.PER.import}}'
         />
       </div>
     {{else}}


### PR DESCRIPTION
Changed the .hbs to be consistent with the basic-templates.hbs for ".value" vs ".import", allowing these secondary stats to be modified in Foundry.