### PR TITLE
0.15.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.15.17 (compatible with FoundryVTT v10.x)
+# Current Release Version 0.15.18 (compatible with FoundryVTT v10.x)
 
 With support for the [Nordlondr Ovinabokin: Bestiary and Enemies module](https://foundryvtt.com/packages/nordlond-bestiary)!
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 ### [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 
-Release 0.15.8
+Release 0.15.8 12/31/2022
 
 - Update to JB2a 0.5.3
 - Fix editing of Will and Per attributes (thanks @JT314!)

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "gurps",
   "title": "GURPS 4e Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.15.17",
+  "version": "0.15.18",
   "authors": [
     {
       "name": "Chris Normand",
@@ -81,7 +81,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.15.17.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.15.18.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Update to JB2a 0.5.3
- Fix editing of Will and Per attributes (thanks @JT314!)
- (Hopefully) fix the display of the rollable attribute on the GCS actor sheet.
- Include src ID for attributes rolled directly from the charactersheet.
