### PR TITLE
0.15.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.15.23 (compatible with FoundryVTT v10.x)
+# Current Release Version 0.15.24 (compatible with FoundryVTT v10.x)
 
 With support for the [Nordlondr Ovinabokin: Bestiary and Enemies module](https://foundryvtt.com/packages/nordlond-bestiary)!
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,10 @@
 
 Release 0.15.24
 
-- Remove the leading + from Accuracy bonus on the characte sheets. (In preparation to handle accuracy mods like "5+2"..."+5+2" just looks too weird.)
+- Remove the leading + from Accuracy bonus on the character sheets. (In preparation to handle accuracy mods like "5+2"..."+5+2" just looks too weird.)
+- Add OTF support for GM Notes module
+- Support usage note on melee/ranged weapons
+- Fixed Skill/Spell search if it contains ^
 
 Release 0.15.23 01/11/2023
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -463,6 +463,7 @@ export function makeRegexPatternFrom(text, end = true, start = true) {
   // defaults to exact match
   let pattern = text.split('*').join('.*?').replace(/\(/g, '\\(').replace(/\)/g, '\\)') // Make string into a RegEx pattern
   pattern = pattern.replace(/\[/g, '\\[').replace(/\]/g, '\\]').replace(/\+/g, '\\+')
+  pattern = pattern.replace(/\^/g, '\\^')
   let s = start ? '^' : ''
   let e = end ? '$' : ''
   return s + pattern.trim() + e

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1839,7 +1839,6 @@ export class GurpsActor extends Actor {
             m.techlevel = i.tech_level || ''
             m.cost = i.value || ''
             m.notes = i.notes || ''
-            if (!!m.notes && w.usage_notes) m.notes += '\n' + w.usage_notes
             m.pageRef(i.reference || '')
             m.mode = w.usage || ''
             m.import = w.calc?.level?.toString() || '0'
@@ -1848,7 +1847,7 @@ export class GurpsActor extends Actor {
             m.parry = w.calc?.parry || ''
             m.block = w.calc?.block || ''
             let old = this._findElementIn('melee', false, m.name, m.mode)
-            this._migrateOtfsAndNotes(old, m, i.vtt_notes)
+            this._migrateOtfsAndNotes(old, m, i.vtt_notes, w.usage_notes)
 
             GURPS.put(melee, m, m_index++)
           } else if (w.type == 'ranged_weapon') {
@@ -1859,7 +1858,6 @@ export class GurpsActor extends Actor {
             r.legalityclass = i.legality_class || '4'
             r.ammo = 0
             r.notes = i.notes || ''
-            if (!!r.notes && w.usage_notes) r.notes += '\n' + w.usage_notes
             r.pageRef(i.reference || '')
             r.mode = w.usage || ''
             r.import = w.calc?.level || '0'
@@ -1870,7 +1868,7 @@ export class GurpsActor extends Actor {
             r.rcl = w.recoil || ''
             r.range = w.calc?.range || ''
             let old = this._findElementIn('ranged', false, r.name, r.mode)
-            this._migrateOtfsAndNotes(old, r, i.vtt_notes)
+            this._migrateOtfsAndNotes(old, r, i.vtt_notes, w.usage_notes)
 
             GURPS.put(ranged, r, r_index++)
           }
@@ -2894,8 +2892,9 @@ export class GurpsActor extends Actor {
    * @param {Skill|Spell|Ranged|Melee} oldobj
    * @param {Skill|Spell|Ranged|Melee} newobj
    */
-  _migrateOtfsAndNotes(oldobj = {}, newobj, importvttnotes = '') {
+  _migrateOtfsAndNotes(oldobj = {}, newobj, importvttnotes = '', usagenotes = '') {
     if (!!importvttnotes) newobj.notes += (!!newobj.notes ? ' ' : '') + importvttnotes
+    if (!!usagenotes) newobj.notes += (!!newobj.notes ? ' ' : '') + usagenotes
     this._updateOtf('check', oldobj, newobj)
     this._updateOtf('during', oldobj, newobj)
     this._updateOtf('pass', oldobj, newobj)
@@ -2924,9 +2923,9 @@ export class GurpsActor extends Actor {
   _removeOtf(key, text) {
     if (!text) return [text, null]
     var start
-    let patstart = text.toLowerCase().indexOf(key[0] + ':[')
+    let patstart = text.toLowerCase().lastIndexOf(key[0] + ':[')
     if (patstart < 0) {
-      patstart = text.toLowerCase().indexOf(key + ':[')
+      patstart = text.toLowerCase().lastIndexOf(key + ':[')
       if (patstart < 0) return [text, null]
       else start = patstart + key.length + 2
     } else start = patstart + 3

--- a/module/chat.js
+++ b/module/chat.js
@@ -394,17 +394,6 @@ export default function addChatHooks() {
 
     Hooks.on('renderChatMessage', (_app, html, _msg) => {
       GurpsWiring.hookupAllEvents(html)
-      // html.find('[data-otf]').each((_, li) => {
-      //   li.setAttribute('draggable', 'true')
-      //   li.addEventListener('dragstart', ev => {
-      //     return ev.dataTransfer?.setData(
-      //       'text/plain',
-      //       JSON.stringify({
-      //         otf: li.getAttribute('data-otf'),
-      //       })
-      //     )
-      //   })
-      // })
     })
 
     Hooks.on(

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "gurps",
   "title": "GURPS 4e Game Aid (Unofficial)",
   "description": "A game aid to help play GURPS 4e for Foundry VTT",
-  "version": "0.15.23",
+  "version": "0.15.24",
   "authors": [
     {
       "name": "Chris Normand",
@@ -81,7 +81,7 @@
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",
   "manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-  "download": "https://github.com/crnormand/gurps/archive/0.15.23.zip",
+  "download": "https://github.com/crnormand/gurps/archive/0.15.24.zip",
   "socket": true,
   "license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Remove the leading + from Accuracy bonus on the character sheets. (In preparation to handle accuracy mods like "5+2"..."+5+2" just looks too weird.)
- Add OTF support for GM Notes module
- Support usage note on melee/ranged weapons
- Fixed Skill/Spell search if it contains ^
