### PR TITLE
Fix editing Total Character Points for users in Foundry

### DIFF
--- a/templates/actor/sections/points.hbs
+++ b/templates/actor/sections/points.hbs
@@ -1,7 +1,7 @@
 <div id='points'>
   <div class='header'>{{system.totalpoints.total}} {{i18n 'GURPS.points'}}</div>
   <div class='fieldblock'>
-    {{#if isEditingA}}
+    {{#if isEditing}}
       <div class='label'>{{i18n 'GURPS.pointsTotal'}}</div>
       <div class='field noedit'><input
           name='system.totalpoints.total'


### PR DESCRIPTION
I found a typo that blocked users from editing Total Points inside Foundry VTT. I made this change in my own Foundry instance and it seems to work beautifully, saving the new point total and everything.