### PR TITLE
Fixed Issue #1778

### DIFF
--- a/module/utilities/gurpslink.js
+++ b/module/utilities/gurpslink.js
@@ -29,6 +29,7 @@ export function gurpslink(str, clrdmods = true, returnActions = false) {
         i = -1
         found = -1
       }
+      if (depth == -1) depth = 0 // we reset to starting condition after second ']' from OTF parse 
     }
   }
   if (returnActions === true) return actions


### PR DESCRIPTION
gurpslink function was not resetting properly for treating other OTF formulas or links and considered second and onthere OTF formulas as links, including them in a span.