### PR TITLE
0.15.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 If you can't access the Google doc, here is a [PDF](https://github.com/crnormand/gurps/raw/main/docs/Guide%20for%20GURPS%204e%20on%20Foundry%20VTT.pdf) of the latest version.
 
-# Current Release Version 0.15.31 (compatible with FoundryVTT v10.x)
+# Current Release Version 0.15.32 (compatible with FoundryVTT v10.x)
 
 With support for the [Nordlondr Ovinabokin: Bestiary and Enemies module](https://foundryvtt.com/packages/nordlond-bestiary)!
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 ### [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 
-Release 0.15.32
+Release 0.15.32 03/13/2023
 
 - Expose the ApplyDamageDialog via the GURPS global object ()
 - Update for JB2a 0.5.5.1

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
 	"id": "gurps",
 	"title": "GURPS 4e Game Aid (Unofficial)",
 	"description": "A game aid to help play GURPS 4e for Foundry VTT",
-	"version": "0.15.31",
+	"version": "0.15.32",
 	"authors": [
 		{
 			"name": "Chris Normand",
@@ -81,7 +81,7 @@
 	"secondaryTokenAttribute": "FP",
 	"url": "https://github.com/crnormand/gurps",
 	"manifest": "https://raw.githubusercontent.com/crnormand/gurps/release/system.json",
-	"download": "https://github.com/crnormand/gurps/archive/0.15.31.zip",
+	"download": "https://github.com/crnormand/gurps/archive/0.15.32.zip",
 	"socket": true,
 	"license": "LICENSE.txt"
 }


### PR DESCRIPTION
- Expose the ApplyDamageDialog via the GURPS global object ()
- Update for JB2a 0.5.5.1
- fixed issue where QTYs and user edits were not being saved for various GCS imported items
- fixed combat tracker reorder
