### PR TITLE
Resolve gridDistance & gridUnits deprecation warning

### DIFF
--- a/system.json
+++ b/system.json
@@ -69,8 +69,10 @@
       "flags": {}
     }
   ],
-  "gridDistance": 1,
-  "gridUnits": "yd",
+  "grid": {
+    "distance": 1,
+    "units": "yd"
+  },
   "primaryTokenAttribute": "HP",
   "secondaryTokenAttribute": "FP",
   "url": "https://github.com/crnormand/gurps",


### PR DESCRIPTION
gridDistance and gridUnits were deprecated in favour for grid.distance and grid.units. In Foundry V12 this throws a warning. I've migrated the values according to the new specification.