### PR TITLE
Fix bug that prevented notes deletion

### DIFF
--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1566,7 +1566,7 @@ if (!globalThis.GURPS) {
       let parentpath = objpath.substring(0, i)
       let objkey = objpath.substring(i + 1)
       // Create shallow copy of object
-      let object = foundry.utils.foundry.utils.duplicate(GURPS.decode(actor, objpath))
+      let object = foundry.utils.duplicate(GURPS.decode(actor, objpath))
       let t = parentpath + '.-=' + objkey
       await actor.internalUpdate({ [t]: null }) // Delete the whole object from the parent
 


### PR DESCRIPTION
There was an error preventing me from deleting notes from a character sheet:
```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'utils')
    at Object.removeKey (gurps.js:1569:42)
    at Object.callback (actor-sheet.js:509:17)
    at #onClickItem (foundry.js:67909:11)
    at HTMLElement.dispatch (jquery.min.js:2:40035)
    at v.handle (jquery.min.js:2:38006)
```

I've noticed there was a weird duplication function call inside removeKey:
```js
foundry.utils.foundry.utils.duplicate(GURPS.decode(actor, objpath))
```

So I've removed one of the `foundry.utils` and it fixed the bug.