### PR TITLE
Fix contained items not being equipped and unequipped with the container item

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -1593,8 +1593,8 @@ export class GurpsActorSheet extends ActorSheet {
     let key = element.dataset.key
     let eqt = foundry.utils.duplicate(GURPS.decode(this.actor, key))
     eqt.equipped = !eqt.equipped
-    await this.actor.internalUpdate({ [key]: eqt })
     await this.actor.updateItemAdditionsBasedOn(eqt, key)
+    await this.actor.internalUpdate({ [key]: eqt })
     let p = this.actor.getEquippedParry()
     let b = this.actor.getEquippedBlock()
     await this.actor.internalUpdate({


### PR DESCRIPTION
When equipping and unequipping items in the character sheet their contained items don't update. This doesn't make sense and makes items like holsters, sheaths, backpacks and bags more cumbersome to use.

The changing equip status of child items requires a recursive through the contained items and is part of the `updateItemAdditionsBasedOn` logic already only for carried status I took a liberty to expand it for the equipped status as well.

I also had to change the order of operations in `_onClickEquip` because `internalUpdate` should be called only when all the `eqt.equipped` values were changed.

I also did a bit of refactoring of the code documentation.