### PR TITLE
Fix random horizontal scrollbar in character sheet

### DIFF
--- a/styles/simple.css
+++ b/styles/simple.css
@@ -518,7 +518,6 @@
   padding: 5px;
   scroll-behavior: smooth;
   background: white;
-  overflow-x: scroll;
 }
 
 .gurps .sheet-header {

--- a/styles/simple.css
+++ b/styles/simple.css
@@ -518,6 +518,7 @@
   padding: 5px;
   scroll-behavior: smooth;
   background: white;
+  overflow-x: auto;
 }
 
 .gurps .sheet-header {
@@ -1271,6 +1272,7 @@ body {
 #notes {
   display: grid;
   border: var(--standardborder);
+  overflow: hidden;
 }
 
 #conditionalmods {


### PR DESCRIPTION
Currently, there is a useless scrollbar in the character sheet window. 
![image](https://github.com/user-attachments/assets/688f4f20-fa7c-4503-b4cf-ef875707c4b1)

I don't think this does anything useful. Seems like a leftover style sheet rule. I removed it, seems to have fixed the issue.