### PR TITLE
Use `ruler._addWaypoint` instead of modifying waypoints directly

### DIFF
--- a/module/actor/effect-modifier-popout.js
+++ b/module/actor/effect-modifier-popout.js
@@ -82,7 +82,7 @@ export class EffectModifierPopout extends Application {
     // const ruler = new Ruler() as Ruler & { totalDistance: number }
     const ruler = new RulerGURPS(game.user)
     ruler._state = Ruler.STATES.MEASURING
-    ruler.waypoints = [{ x: token1.x, y: token1.y }]
+    ruler._addWaypoint({ x: token1.x, y: token1.y }, { snap: false })
     ruler.measure({ x: token2.x, y: token2.y }, { gridSpaces: true })
     const horizontalDistance = ruler.totalDistance
     const verticalDistance = Math.abs(token1.document.elevation - token2.document.elevation)


### PR DESCRIPTION
For better compatibility with Ruler updates and modules that may modify the Ruler, use the `_addWaypoint` method instead of directly modifying waypoints.

Note that `calculateRange` may be incorrect for tokens with differing elevations. Default Foundry v12 does not handle this situation although mods like Elevation Ruler can. Note also that `canvas.grid.measurePath` might be the better approach instead of constructing an entire Ruler for one measurement.

Closes #1948.