### PR TITLE
Fixed Body Hits not capping torso/groin damage

### DIFF
--- a/module/damage/damagecalculator.js
+++ b/module/damage/damagecalculator.js
@@ -1121,14 +1121,15 @@ class DamageCalculator {
    * Actual number of HP to apply is the amount of injury, or the effective blunt trauma.
    * Set a limit of the max needed to cripple the location. markline
    */
-  get pointsToApply() {
+   get pointsToApply() {
+    this._useBodyHits = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_BODY_HITS)
     let pointsToApply = this.unmodifiedPointsToApply
     if (this._parent.useLocationModifiers) {
-      if ([hitlocation.EXTREMITY, hitlocation.LIMB].includes(this._parent.hitLocationRole)) {
+        if ([hitlocation.EXTREMITY, hitlocation.LIMB].includes(this._parent.hitLocationRole)) {
         return Math.min(pointsToApply, Math.floor(this._parent.locationMaxHP))
       } else if (
         [hitlocation.GROIN, hitlocation.CHEST].includes(this._parent.hitLocationRole) &&
-        this._useBodyHits &&
+        this._useBodyHits === true &&
         (['imp', ...piercing].includes(this._parent.damageType) || this._isTightBeamBurning)
       ) {
         return Math.min(pointsToApply, Math.floor(this._parent.locationMaxHP))


### PR DESCRIPTION
I noticed that torso and groin damage was not being capped when use body hits was enabled and found that the _usebodyhits variable was undefined in the pointstoapply function in damagecalculator therfore the if statement that capped damage would never trigger, i fixed it by defining _usebodyhits at the start of pointstoapply.