### PR TITLE
Correct NaN error using _getSegmentLabel with Elevation Ruler module

### DIFF
--- a/lib/ranges.js
+++ b/lib/ranges.js
@@ -38,7 +38,8 @@ import { i18n, i18n_f } from './utilities.js'
  */
 
 export class RulerGURPS extends Ruler {
-  _getSegmentLabel(segment, totalDistance) {
+  _getSegmentLabel(segment, totalDistance) { 
+    totalDistance ??= this.totalDistance;
     const units = canvas.scene.grid.units
     let dist = (d, u) => {
       return `${Math.round(d * 100) / 100} ${u}`


### PR DESCRIPTION
In Foundry v12, `Ruler#_getSegmentLabel` does not have a `totalDistance` parameter. So for modules like my Elevation Ruler module that use `_getSegmentLabel`, totalDistance should be given a default value instead of assuming it will get passed through as a parameter. 

See https://github.com/caewok/fvtt-elevation-ruler/issues/214

Thanks!