### PR TITLE
Fix bl unit for high strength characters

### DIFF
--- a/module/actor/actor-importer.js
+++ b/module/actor/actor-importer.js
@@ -1537,8 +1537,9 @@ export class ActorImporter {
     }
     data.QP.value = qp
 
-    let bl_value = parseDecimalNumber(calc?.basic_lift.match(/[\d,\.]+/g)[0])
-    let bl_unit = calc?.basic_lift.replace(bl_value + ' ', '')
+    let bl_string = calc?.basic_lift.match(/[\d,\.]+/g)[0]
+    let bl_value = parseDecimalNumber(bl_string)
+    let bl_unit = calc?.basic_lift.replace(bl_string + ' ', '')
 
     let lm = {}
     lm.basiclift = (bl_value * 1).toString() + ' ' + bl_unit


### PR DESCRIPTION
GGA 0.17.16 fixed issue #2039 for the Basic Lift value, but the unit is still broken. Its not displayed on the GGA sheets, but I use it in the Cathegorized Character Sheet module.

This pull request extends the fix to also fix the unit.