### PR TITLE
Beta 4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,8 +35,14 @@
 - Bugfix: 17.17-beta2: Button in Chat message for Major Wound broken #2087
 - Bugfix: 17.16 OtF Macro arguments do not support quoted strings #2089
 - Bugfix: 17.17-b3-patched GURPS.executeOTF still unbalanced with more than one command in a clause #2093
-
-Release 0.17.16 11/29/2024
+- Bugifx: 17.17-beta2 Roll Confirmation #2030, multiple issues #2082
+- Bugfix: 17.17-beta2: Parry penalty is applied multiple times (once for every attack mode) #2085
+- Bugfix: 17.17-b3 Confirmation Dialog did not consider Bucket special modifiers #2096
+- Bugfix: 17.17-b3: Tracking attacks and parrys not longer works #2099
+- Bugfix: Beta 3 - ADD doesn't note crippling any more #2101
+- Bugfix: 17.17-b3 Parsing error for non tagged modifiers in Modifier Bucket #2102
+- Bugfix: 17.17-b3 Damage roll ignores armor divisor #2103
+- Release 0.17.16 11/29/2024
 
 - Feature: Multiple actor import. Import multiple GCS and GCA files with one command. #1994
 - Bugfix: Errors occurring when users drop damage onto mooks/NPCs #2024

--- a/lang/de.json
+++ b/lang/de.json
@@ -1132,5 +1132,13 @@
   "GURPS.forbidMaxAttacksReached": "Du hast bereits alle Angriffe in dieser Runde verwendet.",
   "GURPS.consumeAction": "Consommer l'Action",
   "GURPS.willConsumeAction": "Wird eine Aktion verbrauchen.",
-  "GURPS.isFreeAction": "Ist eine freie Aktion."
+  "GURPS.isFreeAction": "Ist eine freie Aktion.",
+  "GURPS.noActionsAvailable": "Keine Aktionen verfügbar.",
+  "GURPS.settingUseMaxActions": "Maximale Aktionen überprüfen",
+  "GURPS.settingHintUseMaxActions": "Aktivieren, um das System für jeden Token zu überprüfen, ob der Spieler mehr Aktionen als erlaubt pro Runde verwendet. Alle Kämpfer = System überprüft nur die Tokens im Kampf-Tracker; Alle Tokens = System überprüft alle Tokens in der Szene.",
+  "GURPS.disable": "Deaktivieren",
+  "GURPS.allCombatants": "Alle Tokens im Kampf",
+  "GURPS.allTokens": "Alle Tokens in der Szene",
+  "GURPS.settingAddCumulativeParryPenalties": "Kumulative Parier-Strafen automatisch hinzufügen",
+  "GURPS.settingHintAddCumulativeParryPenalties": "Wenn aktiviert, fügt das System automatisch kumulative Parier-Strafen zum Wurf für die ausgewählten Tokens für die Max Actions Check hinzu."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1450,5 +1450,13 @@
   "GURPS.forbidMaxAttacksReached": "You already use all attacks this turn.",
   "GURPS.consumeAction": "Consume Action",
   "GURPS.willConsumeAction": "Will consume an action.",
-  "GURPS.isFreeAction": "Is a Free Action"
+  "GURPS.isFreeAction": "Is a Free Action",
+  "GURPS.noActionsAvailable": "No actions available.",
+  "GURPS.settingUseMaxActions": "Use Max Actions Check",
+  "GURPS.settingHintUseMaxActions": "Enable to let system check, for each selected token, if player is using more actions than allowed per turn. All Combatants = system will check only the tokens in combat tracker; All Tokens = system will check for all tokens in the scene.",
+  "GURPS.disable": "Disable",
+  "GURPS.allCombatants": "All Tokens in Combat",
+  "GURPS.allTokens": "All Tokens in Scene",
+  "GURPS.settingAddCumulativeParryPenalties": "Automatically Add Cumulative Parry Penalties",
+  "GURPS.settingHintAddCumulativeParryPenalties": "If checked, system will automatically add cumulative parry penalties to the roll for the tokens selected for Max Actions Check."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1302,5 +1302,13 @@
   "GURPS.forbidMaxAttacksReached": "Vous avez déjà utilisé toutes les attaques de ce tour.",
   "GURPS.consumeAction": "Consommer l'Action",
   "GURPS.willConsumeAction": "Consommera une action.",
-  "GURPS.isFreeAction": "Est une action gratuite."
+  "GURPS.isFreeAction": "Est une action gratuite.",
+  "GURPS.noActionsAvailable": "Aucune action disponible.",
+  "GURPS.settingUseMaxActions": "Vérification des actions maximales",
+  "GURPS.settingHintUseMaxActions": "Activez pour permettre au système de vérifier, pour chaque jeton, si le joueur utilise plus d'actions que permis par tour. Tous les combattants = le système vérifiera uniquement les jetons dans le traqueur de combat; Tous les jetons = le système vérifiera tous les jetons dans la scène.",
+  "GURPS.disable": "Désactiver",
+  "GURPS.allCombatants": "Tous les jetons en combat",
+  "GURPS.allTokens": "Tous les jetons dans la scène",
+  "GURPS.settingAddCumulativeParryPenalties": "Ajouter automatiquement les pénalités de parade cumulatives",
+  "GURPS.settingHintAddCumulativeParryPenalties": "Si activé, le système ajoutera automatiquement les pénalités de parade cumulatives au jet pour les jetons sélectionnés pour la vérification des actions maximales."
 }

--- a/lang/pt_br.json
+++ b/lang/pt_br.json
@@ -1366,5 +1366,13 @@
   "GURPS.forbidMaxAttacksReached": "Você já usou todos os ataques deste turno.",
   "GURPS.consumeAction": "Consumir Ação",
   "GURPS.willConsumeAction": "Consumirá uma ação.",
-  "GURPS.isFreeAction": "É uma ação livre."
+  "GURPS.isFreeAction": "É uma ação livre.",
+  "GURPS.noActionsAvailable": "Nenhuma ação disponível.",
+  "GURPS.settingUseMaxActions": "Verificação de Ações Máximas",
+  "GURPS.settingHintUseMaxActions": "Ative para permitir que o sistema verifique, para cada token selecionado, se o jogador está usando mais ações do que permitido por turno. Todos os Combatentes = o sistema verificará apenas os tokens no rastreador de combate; Todos os Tokens = o sistema verificará todos os tokens na cena.",
+  "GURPS.disable": "Desativar",
+  "GURPS.allCombatants": "Todos os Tokens em Combate",
+  "GURPS.allTokens": "Todos os Tokens na Cena",
+  "GURPS.settingAddCumulativeParryPenalties": "Adicionar Penalidades de Aparar Cumulativas Automaticamente",
+  "GURPS.settingHintAddCumulativeParryPenalties": "Se ativado, o sistema adicionará automaticamente penalidades de aparar cumulativas ao teste para os tokens selecionados para a Verificação de Ações Máximas."
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -691,5 +691,13 @@
   "GURPS.forbidMaxAttacksReached": "Вы уже использовали все атаки в этом ходу.",
   "GURPS.consumeAction": "Consommer l'Action",
   "GURPS.willConsumeAction": "Потребует действия.",
-  "GURPS.isFreeAction": "Это свободное действие."
+  "GURPS.isFreeAction": "Это свободное действие.",
+  "GURPS.noActionsAvailable": "Нет доступных действий.",
+  "GURPS.settingUseMaxActions": "Проверка максимальных действий",
+  "GURPS.settingHintUseMaxActions": "Включите, чтобы система проверяла, использует ли игрок больше действий, чем разрешено за ход, для каждого токена. Все бойцы = система будет проверять только токены в трекере боя; Все токены = система будет проверять все токены на сцене.",
+  "GURPS.disable": "Отключить",
+  "GURPS.allCombatants": "Все токены в бою",
+  "GURPS.allTokens": "Все токены на сцене",
+  "GURPS.settingAddCumulativeParryPenalties": "Автоматически добавлять кумулятивные штрафы за парирование",
+  "GURPS.settingHintAddCumulativeParryPenalties": "Если включено, система автоматически добавит кумулятивные штрафы за парирование к броску для выбранных токенов для проверки максимальных действий."
 }

--- a/lib/miscellaneous-settings.js
+++ b/lib/miscellaneous-settings.js
@@ -84,9 +84,11 @@ export const SETTING_ALLOW_ROLL_BASED_ON_MANEUVER = 'allow-roll-based-on-maneuve
 export const SETTING_ALLOW_TARGETED_ROLLS = 'allow-targeted-rolls'
 export const SETTING_USE_TAGGED_MODIFIERS = 'use-tagged-modifiers'
 export const SETTING_MODIFY_DICE_PLUS_ADDS = 'modify-dice-plus-adds'
+export const SETTING_USE_MAX_ACTIONS = 'use-max-actions'
 export const SETTING_ALLOW_AFTER_MAX_ACTIONS = 'allow-after-max-actions'
 export const SETTING_ADD_SHOCK_AT_TURN = 'add-shock-at-turn'
 export const SETTING_ALLOW_ROLLS_BEFORE_COMBAT_START = 'allow-rolls-before-combat-start'
+export const SETTING_ADD_CUMULATIVE_PARRY_PENALTIES = 'add-cumulative-parry-penalties'
 
 export const VERSION_096 = SemanticVersion.fromString('0.9.6')
 export const VERSION_097 = SemanticVersion.fromString('0.9.7')
@@ -901,21 +903,6 @@ export function initializeSettings() {
       onChange: value => console.log(`Allow Rolls without Target : ${value}`),
     })
 
-    game.settings.register(SYSTEM_NAME, SETTING_ALLOW_AFTER_MAX_ACTIONS, {
-      name: i18n('GURPS.settingAllowAfterMaxActions'),
-      hint: i18n('GURPS.settingHintAllowAfterMaxActions'),
-      scope: 'world',
-      config: true,
-      type: String,
-      choices: {
-        Allow: i18n('GURPS.allow'),
-        Warn: i18n('GURPS.warn'),
-        Forbid: i18n('GURPS.forbid'),
-      },
-      default: 'Allow',
-      onChange: value => console.log(`Allow Action after Max Actions : ${value}`),
-    })
-
     game.settings.register(SYSTEM_NAME, SETTING_ALLOW_ROLLS_BEFORE_COMBAT_START, {
       name: i18n('GURPS.settingAllowRollsBeforeCombatStart'),
       hint: i18n('GURPS.settingHintAllowRollsBeforeCombatStart'),
@@ -929,6 +916,46 @@ export function initializeSettings() {
       },
       default: 'Warn',
       onChange: value => console.log(`Allow Rolls before Combat is initiated : ${value}`),
+    })
+
+    game.settings.register(SYSTEM_NAME, SETTING_USE_MAX_ACTIONS, {
+      name: i18n('GURPS.settingUseMaxActions'),
+      hint: i18n('GURPS.settingHintUseMaxActions'),
+      scope: 'world',
+      config: true,
+      type: String,
+      choices: {
+        Disable: i18n('GURPS.disable'),
+        AllCombatant: i18n('GURPS.allCombatants'),
+        AllTokens: i18n('GURPS.allTokens'),
+      },
+      default: 'allCombatant',
+      onChange: value => console.log(`Use Max Actions per Token : ${value}`),
+    })
+
+    game.settings.register(SYSTEM_NAME, SETTING_ALLOW_AFTER_MAX_ACTIONS, {
+      name: i18n('GURPS.settingAllowAfterMaxActions'),
+      hint: i18n('GURPS.settingHintAllowAfterMaxActions'),
+      scope: 'world',
+      config: true,
+      type: String,
+      choices: {
+        Allow: i18n('GURPS.allow'),
+        Warn: i18n('GURPS.warn'),
+        Forbid: i18n('GURPS.forbid'),
+      },
+      default: 'Warn',
+      onChange: value => console.log(`Allow Action after Max Actions : ${value}`),
+    })
+
+    game.settings.register(SYSTEM_NAME, SETTING_ADD_CUMULATIVE_PARRY_PENALTIES, {
+      name: i18n('GURPS.settingAddCumulativeParryPenalties'),
+      hint: i18n('GURPS.settingHintAddCumulativeParryPenalties'),
+      scope: 'world',
+      config: true,
+      type: Boolean,
+      default: true,
+      onChange: value => console.log(`Automatically add cumulative parry penalties : ${value}`),
     })
 
     game.settings.register(SYSTEM_NAME, SETTING_USE_TAGGED_MODIFIERS, {

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -3252,6 +3252,9 @@ export class GurpsActor extends Actor {
    * @returns {boolean}
    */
   canConsumeAction(action, actorComp = {}) {
+    // TODO: Still need to check if all rolls without
+    //   action did not consume action
+    if (!action) return false
     const isAttack = action.type === 'attack'
     const isDefense = action.attribute === 'dodge' || action.type === 'weapon-parry' || action.type === 'weapon-block'
     const isDodge = action.attribute === 'dodge'

--- a/module/chat/if.js
+++ b/module/chat/if.js
@@ -68,6 +68,10 @@ export class IfChatProcessor extends ChatProcessor {
         let event = this.msgs().event
         event.chatmsgData = this.msgs().data
         let pass = await GURPS.performAction(action.action, GURPS.LastActor, event)
+        if (!!GURPS.LastActor.stopActions) {
+          console.log('Stop actions after dialog canceled')
+          return
+        }
         if (invert) pass = !pass
         if (pass) {
           if (!!results.cs && GURPS.lastTargetedRoll?.isCritSuccess) {

--- a/module/damage/applydamage.js
+++ b/module/damage/applydamage.js
@@ -342,11 +342,13 @@ export default class ApplyDamageDialog extends Application {
     html.find('#result-effects button').click(async ev => this._handleEffectButtonClick(ev))
 
     html
-      .find('#add-shock-next button, #add-major button, #add-knockback button, #add-vitals button')
+      .find(
+        '#add-shock-next button, #add-major button, #add-crippling button, #add-knockback button, #add-vitals button'
+      )
       .on('click', ev => this._handleEffectAddEffectButtonClick(ev))
 
     html
-      .find('#test-major button, #test-knockback button, #test-vitals button')
+      .find('#test-major button, #test-knockback button, #test-vitals button, #test-crippling button')
       .on('click', ev => this._handleTestSaveEffectButtonClick(ev))
 
     html.find('#apply-injury-split').on('click', ev => {
@@ -499,6 +501,7 @@ export default class ApplyDamageDialog extends Application {
     switch (effect.type) {
       case 'headvitalshit':
       case 'majorwound':
+      case 'crippling':
         const htCheck =
           effect.modifier === 0 ? 'HT' : effect.modifier < 0 ? `HT+${-effect.modifier}` : `HT-${effect.modifier}`
         otf = `/r [!${htCheck}]`
@@ -586,6 +589,7 @@ export default class ApplyDamageDialog extends Application {
         break
       case 'headvitalshit':
       case 'majorwound':
+      case 'crippling':
         await toggleEffect(effect.effectName, span)
         break
       case 'knockback':

--- a/module/damage/damagecalculator.js
+++ b/module/damage/damagecalculator.js
@@ -349,6 +349,7 @@ export class CompositeDamageCalculator {
         switch (effect.type) {
           case 'headvitalshit':
           case 'majorwound':
+          case 'crippling':
             const stunIsReady = defenderToken.actor.effects.find(e => e.statuses.find(s => s === 'stun'))
             const proneIsReady = defenderToken.actor.effects.find(e => e.statuses.find(s => s === 'prone'))
             return {
@@ -389,6 +390,8 @@ export class CompositeDamageCalculator {
                 },
               ],
             }
+          default:
+            return effect
         }
       }
     })

--- a/module/modifier-bucket/bucket-app.js
+++ b/module/modifier-bucket/bucket-app.js
@@ -172,6 +172,7 @@ class ModifierStack {
     this.plus = false
     this.minus = false
     this.maxTotal = undefined
+    this.usingRapidStrike = false
 
     // do we automatically empty the bucket when a roll is made?
     this.AUTO_EMPTY = true
@@ -202,6 +203,10 @@ class ModifierStack {
     this.plus = this.currentSum > 0 || this.modifierList.length > 0 // cheating here... it shouldn't be named "plus", but "green"
     this.minus = this.currentSum < 0
     game.user?.setFlag('gurps', 'modifierstack', this) // Set the shared flags, so the GM can look at it sometime later. Not used in the local calculations
+
+    // Check if Rapid Strike is on list.
+    let rs = this.modifierList.find(m => m.desc.includes(i18n('gurps.modifiers.rapidStrike')))
+    this.usingRapidStrike = !!rs
 
     // Update the Confirmation Dialog if opened
     const taggedSettings = game.settings.get(Settings.SYSTEM_NAME, Settings.SETTING_USE_TAGGED_MODIFIERS)
@@ -314,6 +319,7 @@ class ModifierStack {
   reset(otherstacklist = []) {
     this.modifierList = otherstacklist
     this.maxTotal = undefined
+    this.usingRapidStrike = false
     this.sum()
   }
 

--- a/module/modifier-bucket/tooltip-window.js
+++ b/module/modifier-bucket/tooltip-window.js
@@ -71,10 +71,11 @@ export default class ModifierBucketEditor extends Application {
 
   convertModifiers(list) {
     return list
+      .filter(it => it.trim() !== '')
       .map(it => {
         const regex = it.includes('@man:') ? /^(.*?)(?=[#@])/ : /^(.*?)(?=[#@(])/
         const desc = it.match(regex)?.[1]
-        return `[${i18n(desc.trim())}]`
+        return desc ? `[${i18n(desc.trim())}]` : `[${i18n(it).trim()}]`
       })
       .map(it => gurpslink(it))
   }

--- a/templates/apply-damage/effect-crippling.html
+++ b/templates/apply-damage/effect-crippling.html
@@ -10,7 +10,15 @@
       </aside>
       {{/if}}
     </div>
-
+    <div id="test-crippling" class="with-send-button">
+      <button name="test-major" data-effect="{{jsonStringify this}}"><span class="fa fa-dice" title="{{testTitle}}"></span></button>
+    </div>
+    {{#each buttons as |button|}}
+      <div id="add-crippling" class="with-send-button">
+        <button name="add-major" data-effect="{{jsonStringify this}}"><span class="fa {{spanClass}} {{effectName}}"
+                                                                             data-actor={{actorId}} title="{{effectTitle}}"></span></button>
+      </div>
+    {{/each}}
     <div class="with-send-button">
       <button name="send-wound" data-struct="{{jsonStringify this}}"><span class="fa fa-comment-alt"></span></button>
     </div>


### PR DESCRIPTION
## Fixes
* Fix Max Actions Check issues and errors
* Stop actions when using OTF with conditionals (/if) and confirmation dialog roll is cancelled 
* Fix multiple parry modifiers on the same roll
* Add support to Move and Max and Rapid Strike bucket modifiers 
* Fix missing crippling options in ADD 
* Fix parsing for non tagged modifiers in Modifier Bucket
* Fix missing optional data for damage OTF (like armor divisor)

## Changes
* **Max Actions Check**: settings now is `enabled for combatant tokens` and `warn` player
* **Max Actions Check**: to cancel current token action count, change token maneuver (a menu option will be implement, but not for 0.17.17) 

## New Settings
* `SETTING_USE_MAX_ACTIONS `:  Enable/Disable **Max Actions Check** feature. You can choose the check actions for **All Combatant Tokens** (tokens inside combat tracker), or **All Tokens** in scene. Default is: `All Tokens in Combat`.
*  `SETTING_ADD_CUMULATIVE_PARRY_PENALTIES `: Enable or disable **Automatically add Parry Modifiers on Bucket**. If enabled, system will add only for the same tokens configured in Max Actions settings. Default: `true`

![image](https://github.com/user-attachments/assets/c70fe756-5d47-469b-8f0c-707a505a0ce3)

## Closes
* Close #2082
* Close #2085
* Close #2096
* Close #2099
* Close #2101
* Close #2102
* Close #2103