### PR TITLE
bug/2113-1717-b4-effect-modifier-bug-with-range-penalty-and-missile-s…

### DIFF
--- a/module/actor/effect-modifier-popout.js
+++ b/module/actor/effect-modifier-popout.js
@@ -31,7 +31,7 @@ export const calculateRange = (token1, token2) => {
 export const getRangedModifier = (source, target) => {
   const taggedModifiersSetting = game.settings.get(Settings.SYSTEM_NAME, Settings.SETTING_USE_TAGGED_MODIFIERS)
   const rangedTag = taggedModifiersSetting.allRangedRolls.split(',')[0]
-  const spellTag = taggedModifiersSetting.allSpellRolls.split(',')[0]
+  const spellTag = '' // taggedModifiersSetting.allSpellRolls.split(',')[0]
   const baseTags = `#${rangedTag} #${spellTag}`
   let rangeModifier
   let mod = calculateRange(source, target)


### PR DESCRIPTION
…pells-or-melee-spells

I've removed the #spell tag from ranged attacks; it is not appropriate. #spell should be used only for modifiers to casting spells; Melee and Ranged attacks should not include this tag.