### PR TITLE
Fixed Editor sheet not opening when Editor button pressed

### DIFF
--- a/lib/npc-input.js
+++ b/lib/npc-input.js
@@ -246,7 +246,7 @@ export class NpcInput extends FormApplication {
       let data = { name: this.mook.name, type: 'character' }
       let a = await GurpsActor.create(data, { renderSheet: false })
       await this.populate(a)
-      await a.setFlag('core', 'sheetClass', 'GURPS.GurpsActorNpcSheet')
+      await a.setFlag('core', 'sheetClass', 'gurps.GurpsActorNpcSheet')
       a.sheet.render(true)
     }
     this.render(true)
@@ -315,11 +315,7 @@ export class NpcInput extends FormApplication {
     ts.title = m.title
     let dt = new Date().toString().split(' ').splice(1, 3).join(' ')
     ts.createdon = dt
-    if (!!m.sm)
-      ts.sizemod =
-        m.sm[0] == '-' ? m.sm
-        : m.sm[0] == '+' ? ''
-        : '+' + m.sm
+    if (!!m.sm) ts.sizemod = m.sm[0] == '-' ? m.sm : m.sm[0] == '+' ? '' : '+' + m.sm
     ts.appearance = m.desc
     ts.height = m.height
     ts.weight = m.weight

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -1719,13 +1719,13 @@ export class GurpsActorSheet extends ActorSheet {
       this.actor.getFlag('core', 'sheetClass') ||
       Object.values(CONFIG.Actor.sheetClasses['character']).filter(s => s.default)[0].id
 
-    if (original != 'GURPS.GurpsActorSheet') newSheet = 'GURPS.GurpsActorSheet'
+    if (original != 'gurps.GurpsActorSheet') newSheet = 'gurps.GurpsActorSheet'
     if (event.shiftKey)
       // Hold down the shift key for Simplified
-      newSheet = 'GURPS.GurpsActorSimplifiedSheet'
+      newSheet = 'gurps.GurpsActorSimplifiedSheet'
     if (game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.CONTROL))
       // Hold down the Ctrl key (Command on Mac) for Simplified
-      newSheet = 'GURPS.GurpsActorNpcSheet'
+      newSheet = 'gurps.GurpsActorNpcSheet'
 
     this.actor.openSheet(newSheet)
   }
@@ -1968,7 +1968,7 @@ Hooks.on('getGurpsActorEditorSheetHeaderButtons', sheet => {
             'You are editing an EMPTY Actor!<br><br>Either use the <b>Import</b> button to enter data, or delete this Actor and use the <b>/mook</b> chat command to create NPCs.<br><br>Press Ok to open the Full View.',
           label: 'Ok',
           callback: async () => {
-            sheet.actor.openSheet('GURPS.GurpsActorSheet')
+            sheet.actor.openSheet('gurps.GurpsActorSheet')
           },
           rejectClose: false,
         }),

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -652,7 +652,6 @@ export class GurpsActorSheet extends ActorSheet {
             },
           },
         ],
-       
       }).render({ force: true })
       dlg.element.querySelector('textarea').addEventListener('drop', this.dropFoundryLinks.bind(this))
 
@@ -1040,8 +1039,8 @@ export class GurpsActorSheet extends ActorSheet {
     }
     const equipmentAsItem = game.settings.get(Settings.SYSTEM_NAME, Settings.SETTING_USE_FOUNDRY_ITEMS)
     if (!item) return {}
-    return (!!equipmentAsItem && item.type !== 'equipment') || !equipmentAsItem ?
-        {
+    return (!!equipmentAsItem && item.type !== 'equipment') || !equipmentAsItem
+      ? {
           n: item.name,
           id: item.id,
         }
@@ -1656,7 +1655,7 @@ export class GurpsActorSheet extends ActorSheet {
   get title() {
     const t = this.actor.name
     const sheet = this.actor.getFlag('core', 'sheetClass')
-    return sheet === 'GURPS.GurpsActorEditorSheet' ? '**** Editing: ' + t + ' ****' : t
+    return sheet === 'gurps.GurpsActorEditorSheet' ? '**** Editing: ' + t + ' ****' : t
   }
 
   _getHeaderButtons() {
@@ -1674,7 +1673,7 @@ export class GurpsActorSheet extends ActorSheet {
    */
   getCustomHeaderButtons() {
     const sheet = this.actor.getFlag('core', 'sheetClass')
-    const isEditor = sheet === 'GURPS.GurpsActorEditorSheet'
+    const isEditor = sheet === 'gurps.GurpsActorEditorSheet'
     const altsheet = game.settings.get(settings.SYSTEM_NAME, settings.SETTING_ALT_SHEET)
 
     const isFull = sheet === undefined || sheet === 'GURPS.GurpsActorSheet'
@@ -1719,7 +1718,6 @@ export class GurpsActorSheet extends ActorSheet {
     const original =
       this.actor.getFlag('core', 'sheetClass') ||
       Object.values(CONFIG.Actor.sheetClasses['character']).filter(s => s.default)[0].id
-    console.log('original: ' + original)
 
     if (original != 'GURPS.GurpsActorSheet') newSheet = 'GURPS.GurpsActorSheet'
     if (event.shiftKey)
@@ -1734,7 +1732,7 @@ export class GurpsActorSheet extends ActorSheet {
 
   async _onOpenEditor(event) {
     event.preventDefault()
-    this.actor.openSheet('GURPS.GurpsActorEditorSheet')
+    this.actor.openSheet('gurps.GurpsActorEditorSheet')
   }
 
   async _onRightClickGurpslink(event) {
@@ -1917,8 +1915,8 @@ export class GurpsActorTabSheet extends GurpsActorSheet {
 
   /** @override */
   get template() {
-    return !game.user.isGM && this.actor.limited ?
-        'systems/gurps/templates/actor/actor-sheet-gcs-limited.hbs'
+    return !game.user.isGM && this.actor.limited
+      ? 'systems/gurps/templates/actor/actor-sheet-gcs-limited.hbs'
       : 'systems/gurps/templates/actor/actor-tab-sheet.hbs'
   }
 }

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -739,13 +739,11 @@ export class GurpsActor extends Actor {
     let posture = this._getMoveAdjustedForPosture(move, threshold)
 
     if (threshold == 1.0) this.system.conditions.move = maneuver.move < posture.move ? maneuver.text : posture.text
-    return (
-      updateMove ?
-        maneuver.move < posture.move ?
-          maneuver.move
+    return updateMove
+      ? maneuver.move < posture.move
+        ? maneuver.move
         : posture.move
       : Math.max(1, Math.floor(move * threshold))
-    )
   }
 
   _getMoveAdjustedForManeuver(move, threshold) {
@@ -758,12 +756,12 @@ export class GurpsActor extends Actor {
 
       adjustment = this._adjustMove(move, threshold, value, reason)
     }
-    return !!adjustment ? adjustment : (
-        {
+    return !!adjustment
+      ? adjustment
+      : {
           move: Math.max(1, Math.floor(move * threshold)),
           text: i18n('GURPS.moveFull'),
         }
-      )
   }
 
   _adjustMove(move, threshold, value, reason) {
@@ -830,12 +828,12 @@ export class GurpsActor extends Actor {
       adjustment = this._adjustMove(move, threshold, value, reason)
     }
 
-    return !!adjustment ? adjustment : (
-        {
+    return !!adjustment
+      ? adjustment
+      : {
           move: Math.max(1, Math.floor(move * threshold)),
           text: i18n('GURPS.moveFull'),
         }
-      )
   }
 
   _calculateRangedRanges() {
@@ -1436,9 +1434,9 @@ export class GurpsActor extends Actor {
 
       // 2. Check if Actor Component exists
       const actorCompKey =
-        data.type === 'equipment' ?
-          this._findEqtkeyForId('globalid', data.system.globalid)
-        : this._findSysKeyForId('globalid', data.system.globalid, data.actorComponentKey)
+        data.type === 'equipment'
+          ? this._findEqtkeyForId('globalid', data.system.globalid)
+          : this._findSysKeyForId('globalid', data.system.globalid, data.actorComponentKey)
       const actorComp = foundry.utils.getProperty(this, actorCompKey)
       if (!!actorComp) {
         ui.notifications?.warn(i18n('GURPS.cannotDropItemAlreadyExists'))
@@ -1505,9 +1503,9 @@ export class GurpsActor extends Actor {
 
         // 6. Process Child Items for created Item
         const actorCompKey =
-          data.type === 'equipment' ?
-            this._findEqtkeyForId('uuid', parentItem.system.eqt.uuid)
-          : this._findSysKeyForId('uuid', parentItem.system[parentItem.itemSysKey].uuid, parentItem.actorComponentKey)
+          data.type === 'equipment'
+            ? this._findEqtkeyForId('uuid', parentItem.system.eqt.uuid)
+            : this._findSysKeyForId('uuid', parentItem.system[parentItem.itemSysKey].uuid, parentItem.actorComponentKey)
         await this._addItemAdditions(parentItem, actorCompKey)
       }
     }
@@ -2584,9 +2582,9 @@ export class GurpsActor extends Actor {
 
   async _updateItemFromForm(item) {
     const sysKey =
-      item.type === 'equipment' ?
-        this._findEqtkeyForId('itemid', item.id)
-      : this._findSysKeyForId('itemid', item.id, item.actorComponentKey)
+      item.type === 'equipment'
+        ? this._findEqtkeyForId('itemid', item.id)
+        : this._findSysKeyForId('itemid', item.id, item.actorComponentKey)
 
     const actorComp = foundry.utils.getProperty(this, sysKey)
 
@@ -3563,10 +3561,7 @@ export class GurpsActor extends Actor {
 
       default:
         result = {
-          name:
-            thing ? thing
-            : chatting ? chatting.split('/[')[0]
-            : formula,
+          name: thing ? thing : chatting ? chatting.split('/[')[0] : formula,
           uuid: null,
           itemId: null,
           fromItem: null,

--- a/module/chat/chat-processors.js
+++ b/module/chat/chat-processors.js
@@ -1050,7 +1050,7 @@ class DevChatProcessor extends ChatProcessor {
       case 'open': {
         // Open the full character sheet for an Actor
         let a = game.actors.getName(m[2].trim())
-        if (a) a.openSheet('GURPS.GurpsActorSheet')
+        if (a) a.openSheet('gurps.GurpsActorSheet')
         else ui.notifications.warn("Can't find Actor named '" + m[2] + "'")
         break
       }

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -2762,7 +2762,7 @@ if (!globalThis.GURPS) {
     // This system setting must be built AFTER all of the character sheets have been registered
     let sheets = /** @type {Record<string,string>} */ ({})
     Object.values(CONFIG.Actor.sheetClasses['character']).forEach(e => {
-      if (e.id.toString().startsWith(Settings.SYSTEM_NAME) && e.id != 'GURPS.GurpsActorSheet') sheets[e.label] = e.label
+      if (e.id.toString().startsWith(Settings.SYSTEM_NAME) && e.id != 'gurps.GurpsActorSheet') sheets[e.label] = e.label
     })
     game.settings.register(Settings.SYSTEM_NAME, Settings.SETTING_ALT_SHEET, {
       name: i18n('GURPS.settingSheetDetail'),


### PR DESCRIPTION
Foundry seems to use the lowercase "gurps" when you set the sheet for an Actor, and this somehow causes the function which changes this to "Editor" to fall over. This PR just changes all instances of "GURPS" to "gurps" when a sheet class is referenced.