### PR TITLE
Fixed hit location table recognition for GCS imports

### DIFF
--- a/module/actor/actor-importer.js
+++ b/module/actor/actor-importer.js
@@ -1001,9 +1001,9 @@ export class ActorImporter {
       // and backup their exclusive info inside Actor system.itemInfo
       const isEligibleItem = item => {
         const sysKey =
-          itemType === 'equipment' ?
-            this.actor._findEqtkeyForId('itemid', item.id)
-          : this.actor._findSysKeyForId('itemid', item.id, item.actorComponentKey)
+          itemType === 'equipment'
+            ? this.actor._findEqtkeyForId('itemid', item.id)
+            : this.actor._findSysKeyForId('itemid', item.id, item.actorComponentKey)
         return (
           (!!item.system.importid && item.system.importFrom === generator && item.type === itemType) ||
           !foundry.utils.getProperty(this.actor, sysKey)?.save
@@ -1741,10 +1741,7 @@ export class ActorImporter {
 
   async importSk(i, p) {
     if (this.GCSVersion === 5) {
-      i.type =
-        i.id.startsWith('q') ? 'technique'
-        : i.id.startsWith('s') ? 'skill'
-        : 'skill_container'
+      i.type = i.id.startsWith('q') ? 'technique' : i.id.startsWith('s') ? 'skill' : 'skill_container'
     }
     let name =
       i.name + (!!i.tech_level ? `/TL${i.tech_level}` : '') + (!!i.specialization ? ` (${i.specialization})` : '') ||
@@ -1814,10 +1811,7 @@ export class ActorImporter {
   async importSp(i, p) {
     let s = new Spell()
     if (this.GCSVersion === 5) {
-      i.type =
-        i.id.startsWith('r') ? 'ritual_magic_spell'
-        : i.id.startsWith('p') ? 'spell'
-        : 'spell_container'
+      i.type = i.id.startsWith('r') ? 'ritual_magic_spell' : i.id.startsWith('p') ? 'spell' : 'spell_container'
     }
     s.name = i.name || 'Spell'
     s.originalName = i.name
@@ -2073,7 +2067,7 @@ export class ActorImporter {
     // Hit Locations MUST come from an existing bodyplan hit location table, or else ADD (and
     // potentially other features) will not work. Sometime in the future, we will look at
     // user-entered hit locations.
-    let bodyplan = hls.id // Was a body plan actually in the import?
+    let bodyplan = hls.name.toLowerCase() // Was a body plan actually in the import?
     if (bodyplan === 'snakemen') bodyplan = 'snakeman'
     let table = HitLocations.hitlocationDictionary[bodyplan] // If so, try to use it.
 
@@ -2665,9 +2659,8 @@ export class ActorImporter {
 
       // Create or Update item
       const itemData = actorComp.toItemData(this.actor, fromProgram)
-      const [item] =
-        !!existingItem ?
-          await this.actor.updateEmbeddedDocuments('Item', [{ _id: existingItem._id, system: itemData.system }])
+      const [item] = !!existingItem
+        ? await this.actor.updateEmbeddedDocuments('Item', [{ _id: existingItem._id, system: itemData.system }])
         : await this.actor.createEmbeddedDocuments('Item', [itemData])
       // Update Actor Component for new Items
       if (!!item) {


### PR DESCRIPTION
Fixes #2201 

This issue was caused by a GCS change some time ago which got rid of the `id` field for hit location tables. This was causing the lookup function to compare against a blank, get no matches, and fall back to using the Humanoid template + non-matching locations due to current ADD limitations.

Note: the issue still persists if the name of the table does not match the name in our key, and is thus non-localisable etc.