### PR TITLE
Fixed damage effect message failing to display as coming from attackingng actor

### DIFF
--- a/module/damage/applydamage.js
+++ b/module/damage/applydamage.js
@@ -792,7 +792,7 @@ export default class ApplyDamageDialog extends Application {
 
     this._renderTemplate('chat-damage-results.html', data).then(html => {
       let speaker = ChatMessage.getSpeaker(game.user)
-      if (!!attackingActor) speaker = ChatMessage.getSpeaker(attackingActor)
+      if (!!attackingActor) speaker = ChatMessage.getSpeaker({ actor: attackingActor })
       let messageData = {
         user: game.user.id,
         speaker: speaker,


### PR DESCRIPTION
The issue was caused by the actor being provided directly to the function instead of being provided as the actor argument

This resolves #2195.