### PR TITLE
Fixed cross-compatibility issues between v12 and v13

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -19,7 +19,9 @@ import SplitDREditor from './splitdr-editor.js'
  * Extend the basic ActorSheet with some very simple modifications
  * @extends {foundry.appv1.sheets.ActorSheet}
  */
-export class GurpsActorSheet extends foundry.appv1.sheets.ActorSheet {
+// COMPATIBILITY: v12
+// export class GurpsActorSheet extends foundry.appv1.sheets.ActorSheet {
+export class GurpsActorSheet extends ActorSheet {
   /** @override */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {

--- a/module/actor/maneuver-button.js
+++ b/module/actor/maneuver-button.js
@@ -60,6 +60,9 @@ export default class ManeuverHUDButton {
    * @memberof ManeuverHUDButton
    */
   static async prepTokenHUD(hud, html, token) {
+    // COMPATIBILITY: v12
+    if (game.release.generation === 12) html = html[0]
+
     if (!hud.object?.combatant) return
 
     // @ts-ignore

--- a/module/canvas/index.ts
+++ b/module/canvas/index.ts
@@ -1,10 +1,15 @@
+import { RulerGURPSv12 } from './ruler-12.js'
 import { RulerGURPS } from './ruler.js'
 
 export function init() {
   Hooks.once('init', () => {
     console.log('GURPS | Initializing GURPS Canvas Module')
 
-    // @ts-expect-error: types have not yet caught up
-    CONFIG.Canvas.rulerClass = RulerGURPS
+    if (!game.release) return
+    if (game.release?.generation >= 13) {
+      CONFIG.Canvas.rulerClass = RulerGURPS
+    } else {
+      CONFIG.Canvas.rulerClass = RulerGURPSv12
+    }
   })
 }

--- a/module/canvas/ruler-12.ts
+++ b/module/canvas/ruler-12.ts
@@ -1,6 +1,7 @@
 import * as Settings from '../../lib/miscellaneous-settings.js'
 import { Length, LengthUnit } from '../data/common/index.js'
 
+// COMPATIBILITY: v12
 export class RulerGURPSv12 extends Ruler {
   override _getSegmentLabel(segment: Ruler.PartialSegmentForLabelling) {
     const totalDistance = this.totalDistance

--- a/module/canvas/ruler.ts
+++ b/module/canvas/ruler.ts
@@ -2,6 +2,7 @@ import { AnyObject } from 'fvtt-types/utils'
 import * as Settings from '../../lib/miscellaneous-settings.js'
 import { Length, LengthUnit } from '../data/common/index.js'
 
+// COMPATIBILITY: v12
 // class RulerGURPS extends foundry.canvas.interaction.Ruler {
 class RulerGURPS extends Ruler {
   // Used to determine the distance modifier to apply to the modifier bucket

--- a/module/canvas/ruler.ts
+++ b/module/canvas/ruler.ts
@@ -2,8 +2,8 @@ import { AnyObject } from 'fvtt-types/utils'
 import * as Settings from '../../lib/miscellaneous-settings.js'
 import { Length, LengthUnit } from '../data/common/index.js'
 
-// @ts-expect-error: types have not yet caught up
-class RulerGURPS extends foundry.canvas.interaction.Ruler {
+// class RulerGURPS extends foundry.canvas.interaction.Ruler {
+class RulerGURPS extends Ruler {
   // Used to determine the distance modifier to apply to the modifier bucket
   // when releasing the ruler.
   distanceModifier = 0
@@ -17,6 +17,7 @@ class RulerGURPS extends foundry.canvas.interaction.Ruler {
 
   //@ts-expect-error: types have not yet caught up
   protected _getWaypointLabelContext(waypoint: RulerWaypoint, state: any): AnyObject | void {
+    // @ts-expect-error: types have not yet caught up
     const context = super._getWaypointLabelContext(waypoint, state)
     if (context === undefined) return context
     if (waypoint.next === null) {
@@ -52,6 +53,7 @@ class RulerGURPS extends foundry.canvas.interaction.Ruler {
   // @ts-expect-error: types have not yet caught up
   override reset(): void {
     if (this.distanceModifier !== 0) GURPS.ModifierBucket.addTempRangeMod()
+    // @ts-expect-error: types have not yet caught up
     return super.reset()
   }
 }

--- a/module/effects/active-effect-config.js
+++ b/module/effects/active-effect-config.js
@@ -1,4 +1,6 @@
-export default class GurpsActiveEffectConfig extends foundry.applications.sheets.ActiveEffectConfig {
+// export default class GurpsActiveEffectConfig extends foundry.applications.sheets.ActiveEffectConfig {
+// COMPATIBILITY: v12
+export default class GurpsActiveEffectConfig extends ActiveEffectConfig {
   constructor(object = {}) {
     super(object)
   }

--- a/module/effects/active-effect.js
+++ b/module/effects/active-effect.js
@@ -180,12 +180,6 @@ export default class GurpsActiveEffect extends ActiveEffect {
     }
   }
 
-  // async _preCreate(data, options, user) {
-  //   if (user.isSelf) {
-  //     console.log('preCreate', data, options, user)
-  //   }
-  // }
-
   get endCondition() {
     return this.getFlag('gurps', 'endCondition')
   }

--- a/module/effects/active-effect.js
+++ b/module/effects/active-effect.js
@@ -180,11 +180,11 @@ export default class GurpsActiveEffect extends ActiveEffect {
     }
   }
 
-  async _preCreate(data, options, user) {
-    if (user.isSelf) {
-      console.log('preCreate', data, options, user)
-    }
-  }
+  // async _preCreate(data, options, user) {
+  //   if (user.isSelf) {
+  //     console.log('preCreate', data, options, user)
+  //   }
+  // }
 
   get endCondition() {
     return this.getFlag('gurps', 'endCondition')

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1935,14 +1935,22 @@ if (!globalThis.GURPS) {
     CONFIG.JournalEntryPage.documentClass = JournalEntryPageGURPS
 
     // add custom ActiveEffectConfig sheet class
-    foundry.applications.apps.DocumentSheetConfig.unregisterSheet(
-      ActiveEffect,
-      'core',
-      foundry.applications.sheets.ActiveEffectConfig
-    )
-    foundry.applications.apps.DocumentSheetConfig.registerSheet(ActiveEffect, 'gurps', GurpsActiveEffectConfig, {
-      makeDefault: true,
-    })
+    // COMPATIBILITY: v12
+    if (game.release.generation >= 13) {
+      foundry.applications.apps.DocumentSheetConfig.unregisterSheet(
+        ActiveEffect,
+        'core',
+        foundry.applications.sheets.ActiveEffectConfig
+      )
+      foundry.applications.apps.DocumentSheetConfig.registerSheet(ActiveEffect, 'gurps', GurpsActiveEffectConfig, {
+        makeDefault: true,
+      })
+    } else {
+      DocumentSheetConfig.unregisterSheet(ActiveEffect, 'core', ActiveEffectConfig)
+      DocumentSheetConfig.registerSheet(ActiveEffect, 'gurps', GurpsActiveEffectConfig, {
+        makeDefault: true,
+      })
+    }
 
     // preload drag-and-drop image
     {
@@ -1959,55 +1967,103 @@ if (!globalThis.GURPS) {
     }
 
     // Register sheet application classes
-    foundry.documents.collections.Actors.unregisterSheet('core', foundry.appv1.sheets.ActorSheet)
-    foundry.documents.collections.Actors.registerSheet('gurps', GurpsActorCombatSheet, {
-      label: 'Combat',
-      makeDefault: false,
-    })
-    foundry.documents.collections.Actors.registerSheet('gurps', GurpsActorEditorSheet, {
-      label: 'Editor',
-      makeDefault: false,
-    })
-    foundry.documents.collections.Actors.registerSheet('gurps', GurpsActorSimplifiedSheet, {
-      label: 'Simple',
-      makeDefault: false,
-    })
-    foundry.documents.collections.Actors.registerSheet('gurps', GurpsActorNpcSheet, {
-      label: 'NPC/mini',
-      makeDefault: false,
-    })
-    foundry.documents.collections.Actors.registerSheet('gurps', GurpsInventorySheet, {
-      label: 'Inventory Only',
-      makeDefault: false,
-    })
-    foundry.documents.collections.Actors.registerSheet('gurps', GurpsActorTabSheet, {
-      label: 'Tabbed Sheet',
-      makeDefault: false,
-    })
-    foundry.documents.collections.Actors.registerSheet('gurps', GurpsActorSheetReduced, {
-      label: 'Reduced Mode',
-      makeDefault: false,
-    })
-    foundry.documents.collections.Actors.registerSheet('gurps', GurpsActorSheet, {
-      // Add this sheet last
-      label: 'Full (GCS)',
-      makeDefault: true,
-    })
+    if (game.release.generation >= 13) {
+      Actors.unregisterSheet('core', foundry.appv1.sheets.ActorSheet)
+      Actors.registerSheet('gurps', GurpsActorCombatSheet, {
+        label: 'Combat',
+        makeDefault: false,
+      })
+      Actors.registerSheet('gurps', GurpsActorEditorSheet, {
+        label: 'Editor',
+        makeDefault: false,
+      })
+      Actors.registerSheet('gurps', GurpsActorSimplifiedSheet, {
+        label: 'Simple',
+        makeDefault: false,
+      })
+      Actors.registerSheet('gurps', GurpsActorNpcSheet, {
+        label: 'NPC/mini',
+        makeDefault: false,
+      })
+      Actors.registerSheet('gurps', GurpsInventorySheet, {
+        label: 'Inventory Only',
+        makeDefault: false,
+      })
+      Actors.registerSheet('gurps', GurpsActorTabSheet, {
+        label: 'Tabbed Sheet',
+        makeDefault: false,
+      })
+      Actors.registerSheet('gurps', GurpsActorSheetReduced, {
+        label: 'Reduced Mode',
+        makeDefault: false,
+      })
+      Actors.registerSheet('gurps', GurpsActorSheet, {
+        // Add this sheet last
+        label: 'Full (GCS)',
+        makeDefault: true,
+      })
 
-    foundry.documents.collections.Items.unregisterSheet('core', foundry.appv1.sheets.ItemSheet)
-    foundry.documents.collections.Items.registerSheet('gurps', GurpsItemSheet, { makeDefault: true })
+      Items.unregisterSheet('core', foundry.appv1.sheets.ItemSheet)
+      Items.registerSheet('gurps', GurpsItemSheet, { makeDefault: true })
 
-    foundry.applications.apps.DocumentSheetConfig.unregisterSheet(
-      JournalEntryPage,
-      'core',
-      foundry.applications.sheets.journal.JournalEntryPagePDFSheet
-    )
+      foundry.applications.apps.DocumentSheetConfig.unregisterSheet(
+        JournalEntryPage,
+        'core',
+        foundry.applications.sheets.journal.JournalEntryPagePDFSheet
+      )
 
-    foundry.applications.apps.DocumentSheetConfig.registerSheet(JournalEntryPage, 'gurps', PDFEditorSheet, {
-      types: ['pdf'],
-      makeDefault: true,
-      label: 'GURPS PDF Editor Sheet',
-    })
+      foundry.applications.apps.DocumentSheetConfig.registerSheet(JournalEntryPage, 'gurps', PDFEditorSheet, {
+        types: ['pdf'],
+        makeDefault: true,
+        label: 'GURPS PDF Editor Sheet',
+      })
+    } else {
+      Actors.unregisterSheet('core', ActorSheet)
+      Actors.registerSheet('gurps', GurpsActorCombatSheet, {
+        label: 'Combat',
+        makeDefault: false,
+      })
+      Actors.registerSheet('gurps', GurpsActorEditorSheet, {
+        label: 'Editor',
+        makeDefault: false,
+      })
+      Actors.registerSheet('gurps', GurpsActorSimplifiedSheet, {
+        label: 'Simple',
+        makeDefault: false,
+      })
+      Actors.registerSheet('gurps', GurpsActorNpcSheet, {
+        label: 'NPC/mini',
+        makeDefault: false,
+      })
+      Actors.registerSheet('gurps', GurpsInventorySheet, {
+        label: 'Inventory Only',
+        makeDefault: false,
+      })
+      Actors.registerSheet('gurps', GurpsActorTabSheet, {
+        label: 'Tabbed Sheet',
+        makeDefault: false,
+      })
+      Actors.registerSheet('gurps', GurpsActorSheetReduced, {
+        label: 'Reduced Mode',
+        makeDefault: false,
+      })
+      Actors.registerSheet('gurps', GurpsActorSheet, {
+        // Add this sheet last
+        label: 'Full (GCS)',
+        makeDefault: true,
+      })
+
+      Items.unregisterSheet('core', ItemSheet)
+      Items.registerSheet('gurps', GurpsItemSheet, { makeDefault: true })
+
+      DocumentSheetConfig.unregisterSheet(JournalEntryPage, 'core', JournalPDFPageSheet)
+
+      DocumentSheetConfig.registerSheet(JournalEntryPage, 'gurps', PDFEditorSheet, {
+        types: ['pdf'],
+        makeDefault: true,
+        label: 'GURPS PDF Editor Sheet',
+      })
+    }
 
     // Warning, the very first table will take a refresh before the dice to show up in the dialog.  Sorry, can't seem to get around that
     // @ts-ignore
@@ -2435,14 +2491,25 @@ if (!globalThis.GURPS) {
 
     // define Handlebars partials for ADD:
     const __dirname = 'systems/gurps/templates'
-    foundry.applications.handlebars.loadTemplates([
-      __dirname + '/apply-damage/effect-blunttrauma.hbs',
-      __dirname + '/apply-damage/effect-crippling.hbs',
-      __dirname + '/apply-damage/effect-headvitalshit.hbs',
-      __dirname + '/apply-damage/effect-knockback.hbs',
-      __dirname + '/apply-damage/effect-majorwound.hbs',
-      __dirname + '/apply-damage/effect-shock.hbs',
-    ])
+    if (game.release.generation >= 13) {
+      foundry.applications.handlebars.loadTemplates([
+        __dirname + '/apply-damage/effect-blunttrauma.hbs',
+        __dirname + '/apply-damage/effect-crippling.hbs',
+        __dirname + '/apply-damage/effect-headvitalshit.hbs',
+        __dirname + '/apply-damage/effect-knockback.hbs',
+        __dirname + '/apply-damage/effect-majorwound.hbs',
+        __dirname + '/apply-damage/effect-shock.hbs',
+      ])
+    } else {
+      loadTemplates([
+        __dirname + '/apply-damage/effect-blunttrauma.hbs',
+        __dirname + '/apply-damage/effect-crippling.hbs',
+        __dirname + '/apply-damage/effect-headvitalshit.hbs',
+        __dirname + '/apply-damage/effect-knockback.hbs',
+        __dirname + '/apply-damage/effect-majorwound.hbs',
+        __dirname + '/apply-damage/effect-shock.hbs',
+      ])
+    }
 
     GURPS.setInitiativeFormula()
 

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1967,6 +1967,7 @@ if (!globalThis.GURPS) {
     }
 
     // Register sheet application classes
+    // COMPATIBILITY: v12
     if (game.release.generation >= 13) {
       Actors.unregisterSheet('core', foundry.appv1.sheets.ActorSheet)
       Actors.registerSheet('gurps', GurpsActorCombatSheet, {
@@ -2491,6 +2492,7 @@ if (!globalThis.GURPS) {
 
     // define Handlebars partials for ADD:
     const __dirname = 'systems/gurps/templates'
+    // COMPATIBILITY: v12
     if (game.release.generation >= 13) {
       foundry.applications.handlebars.loadTemplates([
         __dirname + '/apply-damage/effect-blunttrauma.hbs',

--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -4,7 +4,9 @@ import * as Settings from '../lib/miscellaneous-settings.js'
 import { recurselist } from '../lib/utilities.js'
 import { Advantage, Melee, Ranged, Skill, Spell } from './actor/actor-components.js'
 
-export class GurpsItemSheet extends foundry.appv1.sheets.ItemSheet {
+// export class GurpsItemSheet extends foundry.appv1.sheets.ItemSheet {
+// COMPATIBILITY: v12
+export class GurpsItemSheet extends ItemSheet {
   /** @override */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {

--- a/module/item.js
+++ b/module/item.js
@@ -167,8 +167,7 @@ export class GurpsItem extends Item {
    * We need to filter MeleeAtk and RangedAtk from the list of Items
    * because they are subtypes of the other types.
    *
-   * @returns {string[]}
-   * @constructor
+   * @returns {BaseItem.SubType[]}
    */
   static get TYPES() {
     return Object.keys(game.model[this.metadata.name]).filter(k => !k.includes('Atk'))

--- a/module/modifier-bucket/bucket-app.js
+++ b/module/modifier-bucket/bucket-app.js
@@ -385,7 +385,9 @@ class ModifierStack {
  * This class owns the modifierStack, while the ModifierBucketEditor
  * modifies it.
  */
-export class ModifierBucket extends foundry.appv1.api.Application {
+// export class ModifierBucket extends foundry.appv1.api.Application {
+// COMPATIBILITY: v12
+export class ModifierBucket extends Application {
   constructor(options = {}) {
     super(options)
 
@@ -837,7 +839,9 @@ export class ModifierBucket extends foundry.appv1.api.Application {
   _injectHTML($html) {
     const position = game.settings.get(Settings.SYSTEM_NAME, Settings.SETTING_BUCKET_POSITION)
 
-    const bucketExists = !!ui.hotbar.element.querySelector('#modifierbucket')
+    const hotbarElement = game.release.generation === 12 ? ui.hotbar.element[0] : ui.hotbar.element
+
+    const bucketExists = !!hotbarElement.querySelector('#modifierbucket')
     if (!bucketExists) {
       if (position === 'left') ui.hotbar.element.prepend($html[0])
       else ui.hotbar.element.append($html[0])

--- a/module/modifier-bucket/bucket-app.js
+++ b/module/modifier-bucket/bucket-app.js
@@ -839,6 +839,7 @@ export class ModifierBucket extends Application {
   _injectHTML($html) {
     const position = game.settings.get(Settings.SYSTEM_NAME, Settings.SETTING_BUCKET_POSITION)
 
+    // COMPATIBILITY: v12
     const hotbarElement = game.release.generation === 12 ? ui.hotbar.element[0] : ui.hotbar.element
 
     const bucketExists = !!hotbarElement.querySelector('#modifierbucket')

--- a/module/pdf/edit.js
+++ b/module/pdf/edit.js
@@ -1,4 +1,6 @@
-export class PDFEditorSheet extends foundry.applications.sheets.journal.JournalEntryPagePDFSheet {
+// export class PDFEditorSheet extends foundry.applications.sheets.journal.JournalEntryPagePDFSheet {
+// COMPATIBILITY: v12
+export class PDFEditorSheet extends JournalPDFPageSheet {
   constructor(object, options = { pageNumber: 1 }) {
     super(object, options)
   }

--- a/module/token-hud.js
+++ b/module/token-hud.js
@@ -2,7 +2,9 @@ import Maneuvers from './actor/maneuver.js'
 import * as Settings from '../lib/miscellaneous-settings.js'
 
 // Our override of the TokenHUD; it removes the maneuver tokens from the list of status effects
-export default class GURPSTokenHUD extends foundry.applications.hud.TokenHUD {
+// export default class GURPSTokenHUD extends foundry.applications.hud.TokenHUD {
+// COMPATIBILITY: v12
+export default class GURPSTokenHUD extends TokenHUD {
   /**
    * @param {Application.RenderOptions | undefined} [options]
    */

--- a/module/token.js
+++ b/module/token.js
@@ -23,7 +23,7 @@ Hooks.once('ready', async function () {
   overrideRefresh = game.settings.get(SYSTEM_NAME, 'token-override-refresh-icon')
 })
 
-// waiting for v13 types to catch up
+// COMPATIBILITY: v12
 // export default class GurpsToken extends foundry.canvas.placeables.Token {
 export default class GurpsToken extends Token {
   static ready() {

--- a/module/token.js
+++ b/module/token.js
@@ -23,7 +23,9 @@ Hooks.once('ready', async function () {
   overrideRefresh = game.settings.get(SYSTEM_NAME, 'token-override-refresh-icon')
 })
 
-export default class GurpsToken extends foundry.canvas.placeables.Token {
+// waiting for v13 types to catch up
+// export default class GurpsToken extends foundry.canvas.placeables.Token {
+export default class GurpsToken extends Token {
   static ready() {
     Hooks.on('createToken', GurpsToken._createToken)
   }

--- a/module/utilities/contextmenu.js
+++ b/module/utilities/contextmenu.js
@@ -1,5 +1,7 @@
 // Context Menu
-export default class GgaContextMenu extends foundry.applications.ux.ContextMenu {
+// COMPATIBILITY: v12
+// export default class GgaContextMenu extends foundry.applications.ux.ContextMenu {
+export default class GgaContextMenu extends ContextMenu {
   constructor(container, element, selector, title, menuItems, events = { eventName: 'contextmenu' }) {
     super(element, selector, menuItems, events)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3061,22 +3061,22 @@
       }
     },
     "node_modules/@peggyjs/from-mem": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@peggyjs/from-mem/-/from-mem-1.3.5.tgz",
-      "integrity": "sha512-oRyzXE7nirAn+5yYjCdWQHg3EG2XXcYRoYNOK8Quqnmm+9FyK/2YWVunwudlYl++M3xY+gIAdf0vAYS+p0nKfQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@peggyjs/from-mem/-/from-mem-2.0.0.tgz",
+      "integrity": "sha512-f+pL/s2DiT+2dxwheSoJT0P/KJy/s0klzE+ZqRdXHlkeyFk/DpKtyjLZIiA79kx56g3oEPA8Zu9EzEKzAwuvhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "semver": "7.6.3"
+        "semver": "7.7.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@peggyjs/from-mem/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4901,9 +4901,9 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6307,7 +6307,7 @@
     "node_modules/fvtt-types": {
       "name": "@league-of-foundry-developers/foundry-vtt-types",
       "version": "13.340.0",
-      "resolved": "git+ssh://git@github.com/League-of-Foundry-Developers/foundry-vtt-types.git#13ceca2bfa267a9e4113f6ce5430dfaaf1e95bc4",
+      "resolved": "git+ssh://git@github.com/League-of-Foundry-Developers/foundry-vtt-types.git#24554c19ccb797e7ed873d6b0278d5df70652981",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6328,8 +6328,8 @@
         "handlebars": "^4.7.8",
         "handlebars-intl": "^1.1.2",
         "jquery": "^3.7.1",
-        "mime-types": "^2.1.35",
-        "peggy": "^4.2.0",
+        "mime-types": "^3.0.1",
+        "peggy": "^5.0.0",
         "pixi.js": "^7.4.2",
         "prosemirror-collab": "^1.3.1",
         "prosemirror-commands": "^1.6.2",
@@ -6354,6 +6354,29 @@
       },
       "peerDependencies": {
         "typescript": "^5.4"
+      }
+    },
+    "node_modules/fvtt-types/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fvtt-types/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/gensync": {
@@ -8990,21 +9013,21 @@
       }
     },
     "node_modules/peggy": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/peggy/-/peggy-4.2.0.tgz",
-      "integrity": "sha512-ZjzyJYY8NqW8JOZr2PbS/J0UH/hnfGALxSDsBUVQg5Y/I+ZaPuGeBJ7EclUX2RvWjhlsi4pnuL1C/K/3u+cDeg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/peggy/-/peggy-5.0.2.tgz",
+      "integrity": "sha512-s7cQVFZ845bskMM60L3pjWv/6QkC0dZeWd/qrj9g7vvjjS/gkHLTA4Bzs6dxIBezDPdD+WUjoEKgiH7OJA3JAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@peggyjs/from-mem": "1.3.5",
-        "commander": "^12.1.0",
-        "source-map-generator": "0.8.0"
+        "@peggyjs/from-mem": "2.0.0",
+        "commander": "^13.1.0",
+        "source-map-generator": "2.0.0"
       },
       "bin": {
         "peggy": "bin/peggy.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/picocolors": {
@@ -10845,13 +10868,13 @@
       }
     },
     "node_modules/source-map-generator": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/source-map-generator/-/source-map-generator-0.8.0.tgz",
-      "integrity": "sha512-psgxdGMwl5MZM9S3FWee4EgsEaIjahYV5AzGnwUvPhWeITz/j6rKpysQHlQ4USdxvINlb8lKfWGIXwfkrgtqkA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/source-map-generator/-/source-map-generator-2.0.0.tgz",
+      "integrity": "sha512-4KomB7QsJti7dFBAVF6SXHzuCNQauk4gE2CummcqPzl+eJqXz1CkkiBdVXXW3g8VGh23bxcdEVACOzrxpIqnUg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">= 10"
+        "node": ">=20"
       }
     },
     "node_modules/source-map-js": {

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -7,7 +7,3 @@ body.theme-dark {
   --color-modifier-negative: #ff7b7b;
   --color-modifier-positive: #00ff00;
 }
-
-h4.message-sender {
-  color: red !important;
-}

--- a/system.json
+++ b/system.json
@@ -23,8 +23,9 @@
     }
   ],
   "compatibility": {
-    "minimum": "13",
-    "verified": "13.341"
+    "minimum": "12",
+    "maximum": "13",
+    "verified": "13.342"
   },
   "esmodules": ["module/gurps.js", "lib/xregexp-all.js"],
   "scripts": ["scripts/jquery.tinycolorpicker.js"],


### PR DESCRIPTION
This should account for most if not all issues of unrecognised namespaces as well as changes between whether JQuery<HTML> or HTML are used in some contexts.

It means that a lot of deprecation warnings show up in v13 once again, but this won't really affect users so I think it's the easiest and most effective way of ensuring v12 compatibility remains at least for some time.