### PR TITLE
Fixed Modifier Bucket disappearing when hotbar is re-rendered

### DIFF
--- a/module/gurps.js
+++ b/module/gurps.js
@@ -2591,7 +2591,7 @@ if (!globalThis.GURPS) {
   })
 }
 
-Hooks.on('renderHotbar', (app, element, context) => {
+Hooks.once('renderHotbar', (app, element, context) => {
   GURPS.ModifierBucket.render(true)
 })
 

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -2591,7 +2591,7 @@ if (!globalThis.GURPS) {
   })
 }
 
-Hooks.once('renderHotbar', (_application, element, _applicationOptions, _renderContext) => {
+Hooks.on('renderHotbar', (app, element, context) => {
   GURPS.ModifierBucket.render(true)
 })
 

--- a/module/modifier-bucket/bucket-app.js
+++ b/module/modifier-bucket/bucket-app.js
@@ -832,23 +832,26 @@ export class ModifierBucket extends Application {
     }
     return content
   }
-  /**
 
-     * @override
-     */
+  /**
+   * @override
+   */
   _injectHTML($html) {
     const position = game.settings.get(Settings.SYSTEM_NAME, Settings.SETTING_BUCKET_POSITION)
 
-    // COMPATIBILITY: v12
-    const hotbarElement = game.release.generation === 12 ? ui.hotbar.element[0] : ui.hotbar.element
-
-    const bucketExists = !!hotbarElement.querySelector('#modifierbucket')
+    const bucketExists = !!document.querySelector('#modifierbucket')
     if (!bucketExists) {
-      if (position === 'left') ui.hotbar.element.prepend($html[0])
-      else ui.hotbar.element.append($html[0])
+      if (game.release.generation >= 13) {
+        if (position === 'left') document.querySelector('#ui-bottom').append($html[0])
+        else document.querySelector('#ui-right').prepend($html[0])
+      } else {
+        document.querySelector('#ui-bottom > div').append($html[0])
+
+        if (position === 'left') document.querySelector('#ui-bottom > div').style.justifyContent = 'flex-start'
+      }
+      this._element = $html
     } else {
       console.warn('=== HOLA ===\n That weird Modifier Bucket problem just happened! \n============')
     }
-    this._element = $html
   }
 }

--- a/styles/apps.css
+++ b/styles/apps.css
@@ -1640,9 +1640,6 @@ details .popup.square5x4 {
 /* ========================= */
 /* Modifier Bucket           */
 /* ========================= */
-#hotbar {
-  align-self: end;
-}
 
 @media (max-width: 1120px) {
   #hotbar {
@@ -1651,21 +1648,22 @@ details .popup.square5x4 {
   }
 }
 
-#ui-bottom > div {
-  justify-content: unset;
+#ui-bottom {
+  flex-direction: row;
+  align-items: end;
+  justify-content: center;
 }
 
 #bucket-container {
   display: flex;
   flex-direction: row;
-  width: 100%;
   align-self: flex-end;
-  /* margin-left: 60px;
-  margin-right: 25px; */
+  margin-bottom: 0.5rem;
 }
 
 #bucket-container.force-left {
   justify-content: flex-start;
+  margin-left: 4rem;
 }
 
 #bucket-container.force-right {
@@ -1679,7 +1677,6 @@ details .popup.square5x4 {
   grid-template-rows: auto auto;
   gap: 3px;
   width: 130px;
-  /* margin-bottom: 10px; */
 }
 
 .modifierbucket #modifierbucket {


### PR DESCRIPTION
The issue was caused by the Modifier Bucket being changed to a child of the hotbar element due to a previous PR. I added different handling depending on whether we are running v12 or v13.