### PR TITLE
fix-add-damagetype

### DIFF
--- a/lib/moustachewax.js
+++ b/lib/moustachewax.js
@@ -387,6 +387,17 @@ export default function () {
     return false
   })
 
+  /**
+   * Attempt to translate the given key. If the translation is not found, return the fallback value.
+   */
+  Handlebars.registerHelper('i18nFallback', function (key, fallback) {
+    let translation = game.i18n.localize(key)
+    if (translation === key) {
+      return fallback
+    }
+    return translation
+  })
+
   Handlebars.registerHelper('filter', function (objects, key) {
     // objects - array of object to filter
     // key - property to filter on

--- a/templates/apply-damage/apply-damage-dialog.hbs
+++ b/templates/apply-damage/apply-damage-dialog.hbs
@@ -158,11 +158,11 @@
 
                   {{#each CALC.effectiveWoundModifiers}}
                     <div><label><input type='radio' name='woundmodifier' {{checked (eq ../CALC.damageType
-											@key)}} value='{{@key}}'>&nbsp;{{localize (concat "GURPS.damageType" this.label)
+											@key)}} value='{{@key}}'>&nbsp;{{i18nFallback (concat "GURPS.damageType" this.label)
 										this.label}}</label>
                     </div>
                     <div>
-                      {{localize (concat "GURPS.damageAbbrev" @key) @key}}
+                      {{i18nFallback (concat "GURPS.damageAbbrev" @key) @key}}
                     </div>
                     <div name='{{@key}}' {{#if this.changed}}class='{{this.changed}}' {{/if}}>
                       ×{{fractionalize


### PR DESCRIPTION
This pull request introduces an internationalization (i18n) enhancement by adding a new Handlebars helper function, `i18nFallback`, and updating templates to use it. This ensures that if a translation key is missing, a fallback value is displayed instead of the untranslated key.

### Internationalization Enhancements:

* **New Handlebars Helper for i18n**:
  - Added the `i18nFallback` helper in `lib/moustachewax.js`. This helper attempts to translate a given key and returns a fallback value if the translation is not found. (`[lib/moustachewax.jsR390-R400](diffhunk://#diff-f74268839a68c62ce23de535c1f3422ff4e8956d5213874bf9097f723913a97bR390-R400)`)

* **Template Updates**:
  - Updated `templates/apply-damage/apply-damage-dialog.hbs` to replace the `localize` helper with the new `i18nFallback` helper for damage type and abbreviation translations. This ensures fallback values are used when translations are missing. (`[templates/apply-damage/apply-damage-dialog.hbsL161-R165](diffhunk://#diff-ec581df660c355b01f77068a62905dbc97db969bb1d4383e0ae44d7f0693ea89L161-R165)`)