### PR TITLE
Bugfix/2276 modifier bucket overlaps hotbar when sidebar is open

### DIFF
--- a/build/cpx.js
+++ b/build/cpx.js
@@ -1,6 +1,6 @@
 import cpx from 'cpx'
 
-const staticFolders = ['assets', 'icons', 'lang', 'lib', 'scripts', 'utils', 'ui', 'exportutils', 'styles', 'templates']
+const staticFolders = ['assets', 'icons', 'lang', 'lib', 'scripts', 'utils', 'ui', 'exportutils', 'templates']
 const staticFiles = ['changelog.md', 'LICENSE.txt', 'README.md', 'system.json', 'template.json']
 const outputBase = 'dist'
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -20,5 +20,6 @@ declare global {
 
   interface SettingConfig {
     'gurps.rangeStrategy': 'Standard' | 'Simplified' | 'TenPenalties'
+    'gurps.bucket-position': 'left' | 'right'
   }
 }

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -83,6 +83,7 @@ import * as Canvas from './canvas/index.js'
 import * as Combat from './combat/index.js'
 import * as Damage from './damage/index.js'
 import * as Token from './token/index.js'
+import * as UI from './ui/index.js'
 
 export let GURPS = undefined
 
@@ -109,10 +110,11 @@ if (!globalThis.GURPS) {
     GURPS.parseDecimalNumber = parseDecimalNumber
   }
 
-  Damage.init() // Initialize the Damage module
-  Combat.init() // Initialize the Combat module
   Canvas.init() // Initialize the Canvas module
+  Combat.init() // Initialize the Combat module
+  Damage.init() // Initialize the Damage module
   Token.init() // Initialize the Token module
+  UI.init() // Initialize the UI module
 
   AddChatHooks()
   JQueryHelpers()

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1944,7 +1944,7 @@ if (!globalThis.GURPS) {
 
     // Modifier Bucket must be defined after hit locations
     GURPS.ModifierBucket = new ModifierBucket()
-    // GURPS.ModifierBucket.render(true)
+    GURPS.ModifierBucket.render(true)
 
     GURPS.initiative = new Initiative()
     GURPS.hitpoints = new HitFatPoints()
@@ -2612,10 +2612,6 @@ if (!globalThis.GURPS) {
     Hooks.call('gurpsready')
   })
 }
-
-Hooks.once('renderHotbar', (app, element, context) => {
-  GURPS.ModifierBucket.render(true)
-})
 
 const handleCombatTurn = async (combat, round) => {
   const nextCombatant = combat.nextCombatant

--- a/module/modifier-bucket/bucket-app.js
+++ b/module/modifier-bucket/bucket-app.js
@@ -828,48 +828,16 @@ export class ModifierBucket extends Application {
 
     if (game.release.generation >= 13) {
       const chatBox = document.getElementById('chat-message')
+      if (!chatBox) {
+        console.warn('#chat-message element not found, cannot adjust position')
+        return
+      }
       const chatBoxIsFloating = chatBox?.parentNode.id === 'chat-notifications' ?? false
 
       if (positionSetting === 'left') {
         const hotbar = document.querySelector('#hotbar')
         const hotbarIsOffset = hotbar.classList.contains('offset')
         const hotbarOffset = window.getComputedStyle(hotbar).getPropertyValue('--offset')
-
-        function waitUntilStill(el, { threshold = 0.1, timeout = 500 } = {}) {
-          return new Promise(resolve => {
-            if (!el) {
-              resolve()
-              return
-            }
-
-            let lastRect = el.getBoundingClientRect()
-            let startTime = performance.now()
-
-            function check(time) {
-              const newRect = el.getBoundingClientRect()
-              const dx = Math.abs(newRect.left - lastRect.left)
-              const dy = Math.abs(newRect.top - lastRect.top)
-
-              if (dx < threshold && dy < threshold) {
-                // Movement is below threshold, assume it's done
-                resolve()
-                return
-              }
-
-              lastRect = newRect
-
-              if (time - startTime > timeout) {
-                // Give up after timeout
-                resolve()
-                return
-              }
-
-              requestAnimationFrame(check)
-            }
-
-            requestAnimationFrame(check)
-          })
-        }
 
         setTimeout(() => {
           waitUntilStill(chatBox, { threshold: 0.1, timeout: 500 }).then(() => {
@@ -888,6 +856,10 @@ export class ModifierBucket extends Application {
         }, 50)
       } else {
         const uiRight = document.getElementById('ui-right-column-1')
+        if (!uiRight) {
+          console.warn('#ui-right-column-1 element not found, cannot adjust position')
+          return
+        }
         const uiRightWidth = uiRight.getBoundingClientRect().width
 
         if (chatBoxIsFloating) {
@@ -949,4 +921,40 @@ export class ModifierBucket extends Application {
       console.warn('=== HOLA ===\n That weird Modifier Bucket problem just happened! \n============')
     }
   }
+}
+
+function waitUntilStill(el, { threshold = 0.1, timeout = 500 } = {}) {
+  return new Promise(resolve => {
+    if (!el) {
+      resolve()
+      return
+    }
+
+    let lastRect = el.getBoundingClientRect()
+    let startTime = performance.now()
+
+    function check(time) {
+      const newRect = el.getBoundingClientRect()
+      const dx = Math.abs(newRect.left - lastRect.left)
+      const dy = Math.abs(newRect.top - lastRect.top)
+
+      if (dx < threshold && dy < threshold) {
+        // Movement is below threshold, assume it's done
+        resolve()
+        return
+      }
+
+      lastRect = newRect
+
+      if (time - startTime > timeout) {
+        // Give up after timeout
+        resolve()
+        return
+      }
+
+      requestAnimationFrame(check)
+    }
+
+    requestAnimationFrame(check)
+  })
 }

--- a/module/modifier-bucket/tooltip-window.js
+++ b/module/modifier-bucket/tooltip-window.js
@@ -11,10 +11,8 @@ import * as HitLocations from '../hitlocation/hitlocation.js'
 export default class ModifierBucketEditor extends Application {
   constructor(bucket, options = {}) {
     super(options)
-
-    // console.trace('+++++ Create ModifierBucketEditor +++++')
-
     this.bucket = bucket // reference to class ModifierBucket, which is the 'button' that opens this window
+
     this.inside = false
     this.tabIndex = 0
   }
@@ -80,11 +78,6 @@ export default class ModifierBucketEditor extends Application {
       .map(it => gurpslink(it))
   }
 
-  /**
-   * @override
-   * @param {*} options
-   * @returns
-   */
   getData(options) {
     const data = super.getData(options)
 
@@ -135,10 +128,6 @@ export default class ModifierBucketEditor extends Application {
     return data
   }
 
-  /**
-   * @override
-   * @param {*} html
-   */
   activateListeners(html) {
     super.activateListeners(html)
 
@@ -155,9 +144,7 @@ export default class ModifierBucketEditor extends Application {
       let width = parseFloat(html.css('width').replace('px', ''))
       // ensure that left is not negative
       let left = Math.max(bucketLeft + bucketWidth / 2 - width / 2, 10)
-      // console.log(`bucketLeft: ${bucketLeft}; width: ${width}; left: ${left}`)
       html.css('left', `${left}px`)
-      // }
     }
 
     html.removeClass('overflowy')
@@ -238,7 +225,6 @@ export default class ModifierBucketEditor extends Application {
   }
 
   _onleave(_ev) {
-    // console.log('onleave')
     this.inside = false
     this.bucket.SHOWING = false
     this.close()
@@ -247,7 +233,6 @@ export default class ModifierBucketEditor extends Application {
   _onenter(ev) {
     if (!this.options.popOut) {
       if (!this.inside) {
-        // console.log('onenter')
         this.inside = true
         $(ev.currentTarget).mouseleave(ev => this._onleave(ev))
       }
@@ -304,7 +289,6 @@ export default class ModifierBucketEditor extends Application {
     let index = element.dataset.index
     this.bucket.modifierStack.removeIndex(index)
     this.bucket.refresh()
-    //    this.render(false)
   }
 }
 
@@ -506,13 +490,6 @@ ${horiz(game.i18n.localize('GURPS.modifiers_.onTargetAiming'))}
   get OtherMods2() {
     return ''
   },
-  /**
-		  return `[+1 ${game.i18n.localize('GURPS.modifierGMSaidSo')}]
-		  [-1 ${game.i18n.localize('GURPS.modifierGMSaidSo')}]
-		  [+4 ${game.i18n.localize('GURPS.modifierGMBlessed')}]
-		  [-4 ${game.i18n.localize('GURPS.modifierGMDontTry')}]`
-		},
-		*/
 
   get TaskDifficultyModifiers() {
     return [

--- a/module/modifier-bucket/tooltip-window.js
+++ b/module/modifier-bucket/tooltip-window.js
@@ -133,18 +133,29 @@ export default class ModifierBucketEditor extends Application {
 
     // if this is a tooltip, scale and position
     let scale = game.settings.get(Settings.SYSTEM_NAME, Settings.SETTING_BUCKET_SCALE)
+    const positionSetting = game.settings.get(Settings.SYSTEM_NAME, Settings.SETTING_BUCKET_POSITION)
 
     if (!this.options.popOut) {
       html.css('font-size', `${13 * scale}px`)
 
-      let x = $('#modifierbucket')
-      let bucketLeft = x.position().left
-      let bucketWidth = 70
+      const button = document.getElementById('modifierbucket')
 
-      let width = parseFloat(html.css('width').replace('px', ''))
+      const buttonLeft = button.getBoundingClientRect().left
+      const buttonWidth = button.offsetWidth
+      const buttonHeight = button.offsetHeight
+
+      const width = parseFloat(html.css('width').replace('px', ''))
+
+      let left = 0
+      if (positionSetting === 'left') {
+        left = Math.max(buttonLeft + buttonWidth / 2 - width / 2, 10)
+      } else {
+        left = Math.max(buttonLeft + buttonWidth - width, 10)
+      }
+
       // ensure that left is not negative
-      let left = Math.max(bucketLeft + bucketWidth / 2 - width / 2, 10)
       html.css('left', `${left}px`)
+      html.css('bottom', `${buttonHeight + 30}px`)
     }
 
     html.removeClass('overflowy')

--- a/module/token/gurps-token.ts
+++ b/module/token/gurps-token.ts
@@ -1,6 +1,5 @@
 import Maneuvers from '../actor/maneuver.js'
 import { isCombatActive, isTokenInActiveCombat } from '../game-utils.js'
-import { DatabaseCreateOperation } from 'node_modules/fvtt-types/src/foundry/common/abstract/_types.mjs'
 import { TokenActions } from '../token-actions.js'
 
 // COMPATIBILITY: v12
@@ -10,7 +9,7 @@ class GurpsToken extends Token {
 
   protected override _onCreate(
     data: foundry.data.fields.SchemaField.CreateData<Token.Schema>,
-    options: foundry.abstract.Document.Database.CreateOptions<DatabaseCreateOperation>,
+    options: foundry.abstract.Document.Database.CreateOptions<foundry.abstract.types.DatabaseCreateOperation>,
     userId: string
   ): void {
     super._onCreate(data, options, userId)

--- a/module/ui/index.ts
+++ b/module/ui/index.ts
@@ -1,0 +1,7 @@
+import { GurpsSidebar } from './sidebar.js'
+
+export function init() {
+  Hooks.once('init', () => {
+    CONFIG.ui.sidebar = GurpsSidebar
+  })
+}

--- a/module/ui/sidebar.ts
+++ b/module/ui/sidebar.ts
@@ -1,0 +1,24 @@
+import * as Settings from '../../lib/miscellaneous-settings.js'
+
+class GurpsSidebar extends Sidebar {
+  // @ts-expect-error: Waiting for types to catch up
+  override toggleExpanded(expanded: boolean): void {
+    // @ts-expect-error: Waiting for types to catch up
+    super.toggleExpanded(expanded)
+
+    if (game.settings?.get(Settings.SYSTEM_NAME, Settings.SETTING_BUCKET_POSITION) !== 'right') return
+
+    const bucketElement = GURPS.ModifierBucket.element[0]
+    // @ts-expect-error: Waiting for types to catch up
+    if (this.expanded) {
+      // @ts-expect-error: Waiting for types to catch up
+      const sidebarElement = (ui.sidebar?.element as HTMLElement) ?? null
+      sidebarElement.parentNode?.insertBefore(bucketElement, sidebarElement)
+    } else {
+      const uiRightElement = document.getElementById('ui-right') ?? null
+      uiRightElement?.prepend(bucketElement)
+    }
+  }
+}
+
+export { GurpsSidebar }

--- a/module/ui/sidebar.ts
+++ b/module/ui/sidebar.ts
@@ -1,22 +1,20 @@
-import * as Settings from '../../lib/miscellaneous-settings.js'
+import { AnyObject } from 'fvtt-types/utils'
 
 class GurpsSidebar extends Sidebar {
   // @ts-expect-error: Waiting for types to catch up
   override toggleExpanded(expanded: boolean): void {
     // @ts-expect-error: Waiting for types to catch up
     super.toggleExpanded(expanded)
+    GURPS.ModifierBucket.refreshPosition()
+  }
 
-    if (game.settings?.get(Settings.SYSTEM_NAME, Settings.SETTING_BUCKET_POSITION) !== 'right') return
-
-    const bucketElement = GURPS.ModifierBucket.element[0]
+  // @ts-expect-error: Waiting for types to catch up
+  override changeTab(tab: string, group: string, options: AnyObject): void {
+    // @ts-expect-error: Waiting for types to catch up
+    super.changeTab(tab, group, options)
     // @ts-expect-error: Waiting for types to catch up
     if (this.expanded) {
-      // @ts-expect-error: Waiting for types to catch up
-      const sidebarElement = (ui.sidebar?.element as HTMLElement) ?? null
-      sidebarElement.parentNode?.insertBefore(bucketElement, sidebarElement)
-    } else {
-      const uiRightElement = document.getElementById('ui-right') ?? null
-      uiRightElement?.prepend(bucketElement)
+      GURPS.ModifierBucket.refreshPosition()
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6377,7 +6377,7 @@
     "node_modules/fvtt-types": {
       "name": "@league-of-foundry-developers/foundry-vtt-types",
       "version": "13.340.0",
-      "resolved": "git+ssh://git@github.com/League-of-Foundry-Developers/foundry-vtt-types.git#24554c19ccb797e7ed873d6b0278d5df70652981",
+      "resolved": "git+ssh://git@github.com/League-of-Foundry-Developers/foundry-vtt-types.git#0fd8368ad71ac724a8b7901eed3097c2c39a4743",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/styles/apps.css
+++ b/styles/apps.css
@@ -1655,19 +1655,18 @@ details .popup.square5x4 {
 }
 
 #bucket-container {
+  --offset: 0;
   display: flex;
   flex-direction: row;
   align-self: flex-end;
   margin-bottom: 0.5rem;
+  transition: all 0.3s ease-in-out;
+  transform: translateX(var(--offset));
+  margin-bottom: 16px;
 }
 
 #bucket-container.force-left {
-  justify-content: flex-start;
-  margin-left: 4rem;
-}
-
-#bucket-container.force-right {
-  justify-content: flex-end;
+  margin-left: 10px;
 }
 
 #bucket-app {
@@ -1971,23 +1970,9 @@ details .popup.square5x4 {
   text-align: center;
   border-radius: 10px;
   width: 63.5em;
-  bottom: 90px !important;
-  left: 430px;
   position: fixed;
   z-index: 999;
 }
-
-/* .modttt::after {
-  content: '';
-  position: absolute;
-  /* top: 100%; 
-  left: 50%;
-  margin-left: -300px;
-  border-width: 37px 300px;
-  border-style: solid;
-  border-color: grey transparent transparent transparent;
-  pointer-events: none;
-} */
 
 .modttt .modtooltip {
   padding: 0.35em;

--- a/styles/simple.css
+++ b/styles/simple.css
@@ -166,19 +166,19 @@
 }
 
 #threed6 #oned6dice {
-  /* display: none; */
-  /* position: absolute; */
-  /* top: 0; */
-  /* left: 0; */
-  /* z-index: 105; */
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 105;
 }
 
 #threed6 #threed6dicerotactive {
   display: none;
-  /* position: absolute; */
-  /* top: 0; */
-  /* left: 0; */
-  /* z-index: 105; */
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 105;
 }
 
 #threed6:hover #threed6dicerot {

--- a/system.json
+++ b/system.json
@@ -25,7 +25,7 @@
   "compatibility": {
     "minimum": "12",
     "maximum": "13",
-    "verified": "13.342"
+    "verified": "13.344"
   },
   "esmodules": ["module/gurps.js", "lib/xregexp-all.js"],
   "scripts": ["scripts/jquery.tinycolorpicker.js"],


### PR DESCRIPTION
I'm not all too happy with this solution and welcome any suggestions on improving it.

Currently, the solution relies on waiting for the floating chatbox to finish moving before it moves the bucket, which results in a visual delay which I think looks very clunky.

In theory we could probably predict the movement of the chatbox to make it a bit smoother, but this is sort of an 80/20 solution to the problem.

Confirmed to be working for both v12 and v13.
Confirmed to display acceptable results at 1440p, 1080p and 768p with both left and right bucket positions.