### PR TITLE
Fixed modifier bucket being vertically offset unnecessarily

### DIFF
--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1994,43 +1994,43 @@ if (!globalThis.GURPS) {
     // Register sheet application classes
     // COMPATIBILITY: v12
     if (game.release.generation >= 13) {
-      Actors.unregisterSheet('core', foundry.appv1.sheets.ActorSheet)
-      Actors.registerSheet('gurps', GurpsActorCombatSheet, {
+      foundry.documents.collections.Actors.unregisterSheet('core', foundry.appv1.sheets.ActorSheet)
+      foundry.documents.collections.Actors.registerSheet('gurps', GurpsActorCombatSheet, {
         label: 'Combat',
         makeDefault: false,
       })
-      Actors.registerSheet('gurps', GurpsActorEditorSheet, {
+      foundry.documents.collections.Actors.registerSheet('gurps', GurpsActorEditorSheet, {
         label: 'Editor',
         makeDefault: false,
       })
-      Actors.registerSheet('gurps', GurpsActorSimplifiedSheet, {
+      foundry.documents.collections.Actors.registerSheet('gurps', GurpsActorSimplifiedSheet, {
         label: 'Simple',
         makeDefault: false,
       })
-      Actors.registerSheet('gurps', GurpsActorNpcSheet, {
+      foundry.documents.collections.Actors.registerSheet('gurps', GurpsActorNpcSheet, {
         label: 'NPC/mini',
         makeDefault: false,
       })
-      Actors.registerSheet('gurps', GurpsInventorySheet, {
+      foundry.documents.collections.Actors.registerSheet('gurps', GurpsInventorySheet, {
         label: 'Inventory Only',
         makeDefault: false,
       })
-      Actors.registerSheet('gurps', GurpsActorTabSheet, {
+      foundry.documents.collections.Actors.registerSheet('gurps', GurpsActorTabSheet, {
         label: 'Tabbed Sheet',
         makeDefault: false,
       })
-      Actors.registerSheet('gurps', GurpsActorSheetReduced, {
+      foundry.documents.collections.Actors.registerSheet('gurps', GurpsActorSheetReduced, {
         label: 'Reduced Mode',
         makeDefault: false,
       })
-      Actors.registerSheet('gurps', GurpsActorSheet, {
+      foundry.documents.collections.Actors.registerSheet('gurps', GurpsActorSheet, {
         // Add this sheet last
         label: 'Full (GCS)',
         makeDefault: true,
       })
 
-      Items.unregisterSheet('core', foundry.appv1.sheets.ItemSheet)
-      Items.registerSheet('gurps', GurpsItemSheet, { makeDefault: true })
+      foundry.documents.collections.Items.unregisterSheet('core', foundry.appv1.sheets.ItemSheet)
+      foundry.documents.collections.Items.registerSheet('gurps', GurpsItemSheet, { makeDefault: true })
 
       foundry.applications.apps.DocumentSheetConfig.unregisterSheet(
         JournalEntryPage,

--- a/module/modifier-bucket/bucket-app.js
+++ b/module/modifier-bucket/bucket-app.js
@@ -827,37 +827,26 @@ export class ModifierBucket extends Application {
     const positionSetting = game.settings.get(Settings.SYSTEM_NAME, Settings.SETTING_BUCKET_POSITION)
 
     if (game.release.generation >= 13) {
-      const chatBox = document.getElementById('chat-message')
-      if (!chatBox) {
-        console.warn('#chat-message element not found, cannot adjust position')
-        return
-      }
-      const chatBoxIsFloating = chatBox?.parentNode.id === 'chat-notifications' ?? false
-
       if (positionSetting === 'left') {
         const hotbar = document.querySelector('#hotbar')
-        const hotbarIsOffset = hotbar.classList.contains('offset')
-        const hotbarOffset = window.getComputedStyle(hotbar).getPropertyValue('--offset')
+        const hotbarOffset = parseFloat(hotbar.style.getPropertyValue('--offset')) || '0px'
+        const buttonWidth = element[0].offsetWidth || 0
+        const currentButtonOffset = parseFloat(element[0].style.getPropertyValue('--offset')) || 0
+        // hotbarOffset is always negative but buttonWidth is positive so need to subtract
+        const totalOffset = hotbarOffset === currentButtonOffset ? currentButtonOffset : hotbarOffset - buttonWidth
 
-        setTimeout(() => {
-          waitUntilStill(chatBox, { threshold: 0.1, timeout: 500 }).then(() => {
-            const chatBoxOverlap =
-              element[0].getBoundingClientRect().right > (chatBox?.getBoundingClientRect().left ?? 0)
-            const chatBoxIsOverlapping = chatBoxIsFloating && chatBoxOverlap
-
-            element[0].style.setProperty('--offset', hotbarOffset)
-            if (hotbarIsOffset || chatBoxIsOverlapping) {
-              const chatBoxBottom = window.innerHeight - chatBox?.getBoundingClientRect().top
-              element[0].style.marginBottom = `${chatBoxBottom + 16}px`
-            } else {
-              element[0].style.marginBottom = '16px'
-            }
-          })
-        }, 50)
+        hotbar.style.setProperty('--offset', `${totalOffset}px`)
+        element[0].style.setProperty('--offset', `${totalOffset}px`)
       } else {
+        const chatBox = document.getElementById('chat-message')
+        // Can't adjust position if there is no #chat-message element
+        if (!chatBox) return
+
+        const chatBoxIsFloating = chatBox?.parentNode.id === 'chat-notifications' ?? false
+
         const uiRight = document.getElementById('ui-right-column-1')
         if (!uiRight) {
-          console.warn('#ui-right-column-1 element not found, cannot adjust position')
+          // Can't adjust position if there is no #ui-right element
           return
         }
         const uiRightWidth = uiRight.getBoundingClientRect().width
@@ -918,7 +907,7 @@ export class ModifierBucket extends Application {
       }
       this._element = $html
     } else {
-      console.warn('=== HOLA ===\n That weird Modifier Bucket problem just happened! \n============')
+      console.warn('GURPS | ModifierBucket: _injectHTML called, but bucket already exists.')
     }
   }
 }

--- a/styles/apps.css
+++ b/styles/apps.css
@@ -1660,7 +1660,7 @@ details .popup.square5x4 {
   flex-direction: row;
   align-self: flex-end;
   margin-bottom: 0.5rem;
-  transition: all 0.3s ease-in-out;
+  transition: all 200ms ease;
   transform: translateX(var(--offset));
   margin-bottom: 16px;
 }


### PR DESCRIPTION
The modifier bucket was being vertically offset unnecessarily when it was pinned to the left in scenarios where there was no room between the floating chatbox and the hotbar. I changed this to offset the hotbar a bit more instead. This should now be fine at all Foundry-supported resolutions.

This commit also includes some v13 namespace changes to snuff some of the deprecation warnings, but these aren't ever executed in v12 and below so should be no issue.