### PR TITLE
Fixed 2 Effect Modifier Control issues

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 ### [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 
+## Release 0.18.1
+
+### Bugfixes
+
+- Effect Modifier Control does not show in the canvas controls #2296
+- Effect Modifier Pop-out shows some modifiers twice #2296
+
 ## Release 0.18.0-a 05/23/2025 (FNORD!)
 
 ### Features

--- a/module/actor/effect-modifier-control.js
+++ b/module/actor/effect-modifier-control.js
@@ -62,10 +62,10 @@ export class EffectModifierControl {
 
   _createEffectModifierButton(controls) {
     if (this.shouldUseEffectModifierPopup()) {
-      let tokenButton = controls.tokens
+      // COMPATIBILITY: v12
+      let tokenButton = game.release.generation >= 13 ? controls.tokens : controls.find(c => c.name === 'token')
       if (tokenButton) {
-        let self = this
-        tokenButton.tools[EffectModifierControl.EffectModName] = {
+        const newButton = {
           name: EffectModifierControl.EffectModName,
           title: game.i18n.localize('GURPS.tokenToolsTitle'),
           icon: 'fas fa-list-alt',
@@ -73,9 +73,16 @@ export class EffectModifierControl {
           active: this.showPopup,
           visible: true,
           onChange: value => {
-            console.log(value)
-            self.showPopup = value
+            GURPS.EffectModifierControl.showPopup = value
           },
+          onClick: value => {
+            GURPS.EffectModifierControl.showPopup = value
+          },
+        }
+        if (game.release.generation >= 13) {
+          tokenButton.tools[EffectModifierControl.EffectModName] = newButton
+        } else {
+          tokenButton.tools.push(newButton)
         }
       }
     }

--- a/templates/actor/effect-modifier-popout.hbs
+++ b/templates/actor/effect-modifier-popout.hbs
@@ -7,17 +7,7 @@
           <td class='me-at {{{this.itemType}}}'><span>{{{this.itemName}}}</span></td>
           <td class='me-tag'>
             {{#each tags}}
-      {{#each selfmodifiers}}
-        <tr class='me-line'>
-          <td class='me-link' data-item-id='{{this.itemId}}' data-type='{{this.itemType}}'>{{{this.link}}}</td>
-          <td class='me-at {{{this.itemType}}}'><span>{{{this.itemName}}}</span></td>
-          <td class='me-tag'>
-            {{#each tags}}
               <span>{{this}}</span>
-            {{/each}}
-          </td>
-        </tr>
-      {{/each}}
             {{/each}}
           </td>
         </tr>
@@ -29,12 +19,9 @@
     <ul class='modifier-list'>
       {{#each targetmodifiers}}
         <li class='me-link sm'>{{{this.link}}}
-        <li class='me-link sm'>{{{this.link}}}
           {{#each tags}}
             <span class='me-other-tags'>{{{this}}}</span>
-            <span class='me-other-tags'>{{{this}}}</span>
           {{/each}}
-        </li>
         </li>
       {{/each}}
     </ul>
@@ -46,10 +33,6 @@
     >{{localize 'GURPS.targetModifiers'}}&ensp;{{name}}</div>
     <ul class='modifier-list'>
       {{#each targetmodifiers}}
-        <li class='me-link sm'>{{{this.link}}}
-          {{#each tags}}
-            <span class='me-other-tags'>{{{this}}}</span>
-          {{/each}}
         <li class='me-link sm'>{{{this.link}}}
           {{#each tags}}
             <span class='me-other-tags'>{{{this}}}</span>


### PR DESCRIPTION
0.18.0 introduced a bug where the Effect Modifier Control button was not showing in the left toolbar. This was due to the methods of referencing the buttons in the relevant object changing. I added a version check to change how adding the button is handled.

Another bug seemingly introduced in 0.18.0 caused some modifiers to appear twice in the Effect Modifier Pop-out window. This seems to be due to some accidentally duplicated lines in the template for this application.

Resolves #2296 