### PR TITLE
Fixed SemanticVersion.toString not outputting pre-release data and build metadata

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 ### [Users Guide](https://bit.ly/2JaSlQd) for GURPS 4e Game Aid for Foundry VTT
 
+## Release 0.18.1
+
+### Bugfixes
+
+- SemanticVersion.toString does not show pre-release data or build metadata #2297
+
 ## Release 0.18.0-a 05/23/2025 (FNORD!)
 
 ### Features

--- a/lib/semver.js
+++ b/lib/semver.js
@@ -24,7 +24,7 @@ export class SemanticVersion {
   }
 
   toString() {
-    return `${this.major}.${this.minor}.${this.patch}`
+    return `${this.major}.${this.minor}.${this.patch}-${this.preRelease}${this.buildMetaData ? '+' + this.buildMetaData : ''}`
   }
 
   isHigherThan(otherVersion) {

--- a/lib/semver.js
+++ b/lib/semver.js
@@ -24,7 +24,7 @@ export class SemanticVersion {
   }
 
   toString() {
-    return `${this.major}.${this.minor}.${this.patch}-${this.preRelease}${this.buildMetaData ? '+' + this.buildMetaData : ''}`
+    return `${this.major}.${this.minor}.${this.patch}${this.preRelease ? '-' + this.preRelease : ''}${this.buildMetaData ? '+' + this.buildMetaData : ''}`
   }
 
   isHigherThan(otherVersion) {


### PR DESCRIPTION
The two properties were just not included in the toString output. Resolves #2297 