### PR TITLE
Bugfix - #2314 - Updating an actor creates a new instance of the rendered actor sheet

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1513,7 +1513,7 @@ export class GurpsActor extends Actor {
 
   _forceRender() {
     this.ignoreRender = false
-    this.render(true)
+    this.render()
   }
 
   // Drag and drop from an equipment list


### PR DESCRIPTION
This option is really only used for forcing an application to re-render afaik and shouldn't be used this casually. We should instead not be updating the actor multiple times with one change and going through data preparation every time. This is bad practice and is insanely slow, yet is very prevalent in the system as it stands. I don't think this will cause any missed renders.

This resolves #2314 which was affecting users in FoundryVTT v12 (The issue does not seem to affect v13 in the same way).