### PR TITLE
Temporarily disabled modifier bucket transition animation

### DIFF
--- a/styles/apps.css
+++ b/styles/apps.css
@@ -1660,7 +1660,9 @@ details .popup.square5x4 {
   flex-direction: row;
   align-self: flex-end;
   margin-bottom: 0.5rem;
-  transition: all 200ms ease;
+  /* Transition temporarily disabled to prevent jolting when the actor updates. This will be */
+  /* re-enabled when the actor data is not updated multiple times per single change. */
+  /* transition: all 200ms ease; */
   transform: translateX(var(--offset));
   margin-bottom: 16px;
 }
@@ -2575,7 +2577,6 @@ details .popup.square5x4 {
 }
 
 li.combatant.active {
-
   display: flex;
   flex-wrap: wrap;
 }


### PR DESCRIPTION
This was causing issues due to the transition animation causing a visual jolt every time the bucket is updated (which was every time an actor is updated, which is very often). It means slightly less visual flair for now, but it's just a patch fix as the real solution is to re-think how often we update the bucket data (which almost certainly also means AppV2 migration).