### PR TITLE
Fixed Token Ruler not being registered in FoundryVTT v13

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -56,6 +56,7 @@ export class Migration {
   }
 
   async migrateBadDamageChatMessages() {
+    // if (this.migrationVersion.isHigherThan(this.currentVersion)) {
     const chatMessages = game.messages.contents.filter(message =>
       message.content.includes('<div class="damage-chat-message">')
     )
@@ -68,5 +69,6 @@ export class Migration {
         console.log(`Already migrated: ${message.id}:`, message.flags)
       }
     }
+    // }
   }
 }

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -56,7 +56,6 @@ export class Migration {
   }
 
   async migrateBadDamageChatMessages() {
-    // if (this.migrationVersion.isHigherThan(this.currentVersion)) {
     const chatMessages = game.messages.contents.filter(message =>
       message.content.includes('<div class="damage-chat-message">')
     )
@@ -69,6 +68,5 @@ export class Migration {
         console.log(`Already migrated: ${message.id}:`, message.flags)
       }
     }
-    // }
   }
 }

--- a/module/canvas/ruler.ts
+++ b/module/canvas/ruler.ts
@@ -4,7 +4,6 @@ import { Length, LengthUnit } from '../data/common/index.js'
 
 function registerRuler() {
   if (game.release?.generation ?? 12 >= 13) {
-    // @ts-expect-error: Waiting for types to catch up
     class GurpsRuler extends foundry.canvas.interaction.Ruler {
       // Used to determine the distance modifier to apply to the modifier bucket
       // when releasing the ruler.
@@ -19,6 +18,7 @@ function registerRuler() {
 
       //@ts-expect-error: types have not yet caught up
       protected _getWaypointLabelContext(waypoint: RulerWaypoint, state: any): AnyObject | void {
+        //@ts-expect-error: types have not yet caught up
         const context = super._getWaypointLabelContext(waypoint, state)
         if (context === undefined) return context
         if (waypoint.next === null) {
@@ -54,11 +54,11 @@ function registerRuler() {
       // @ts-expect-error: types have not yet caught up
       override reset(): void {
         if (this.distanceModifier !== 0) GURPS.ModifierBucket.addTempRangeMod()
+        // @ts-expect-error: types have not yet caught up
         return super.reset()
       }
     }
 
-    // @ts-expect-error: Waiting for types to catch up
     CONFIG.Canvas.rulerClass = GurpsRuler
   }
 }

--- a/module/token/index.ts
+++ b/module/token/index.ts
@@ -2,6 +2,7 @@ import { GurpsModule } from 'module/gurps-module.js'
 import { GurpsToken } from './gurps-token.js'
 import { GurpsTokenHUD } from './token-hud-12.js'
 import { registerTokenHUD } from './token-hud.js'
+import { registerTokenRuler } from './token-ruler.js'
 
 export * from './gurps-token.js'
 export * from './quick-roll-settings.js'
@@ -15,6 +16,7 @@ function init(): void {
     if (game.release?.generation >= 13) {
       // COMPATIBILITY: v12
       registerTokenHUD()
+      registerTokenRuler()
     } else {
       CONFIG.Token.hudClass = GurpsTokenHUD
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3178,8 +3178,7 @@
     },
     "node_modules/@pixi/core": {
       "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.4.3.tgz",
-      "integrity": "sha512-5YDs11faWgVVTL8VZtLU05/Fl47vaP5Tnsbf+y/WRR0VSW3KhRRGTBU1J3Gdc2xEWbJhUK07KGP7eSZpvtPVgA==",
+      "resolved": "git+ssh://git@github.com/foundry-vtt-types/pixi-core.git#b2554df0b43183980830a08d92a960ede78ad25e",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3190,8 +3189,8 @@
         "@pixi/math": "7.4.3",
         "@pixi/runner": "7.4.3",
         "@pixi/settings": "7.4.3",
-        "@pixi/ticker": "7.4.3",
-        "@pixi/utils": "7.4.3"
+        "@pixi/ticker": "github:foundry-vtt-types/pixi-ticker#main",
+        "@pixi/utils": "github:foundry-vtt-types/pixi-utils#main"
       },
       "funding": {
         "type": "opencollective",
@@ -3414,13 +3413,12 @@
     },
     "node_modules/@pixi/particle-emitter": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-emitter/-/particle-emitter-5.0.8.tgz",
-      "integrity": "sha512-OzuZ4+esQo+zJ0u3htuNHHMAE8Ixmr3nz3tEfrTGZHje1vnGyie3ANQj9F0V4OM47oi9jd70njVCmeb7bTkS9A==",
+      "resolved": "git+ssh://git@github.com/foundry-vtt-types/pixi-particle-emitter.git#9bd3cb53826b2c7d4c407db183f4dd93edd50aae",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@pixi/constants": ">=6.0.4 <8.0.0",
-        "@pixi/core": ">=6.0.4 <8.0.0",
+        "@pixi/core": "github:foundry-vtt-types/pixi-core#main",
         "@pixi/display": ">=6.0.4 <8.0.0",
         "@pixi/math": ">=6.0.4 <8.0.0",
         "@pixi/sprite": ">=6.0.4 <8.0.0",
@@ -3561,21 +3559,19 @@
     },
     "node_modules/@pixi/ticker": {
       "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.4.3.tgz",
-      "integrity": "sha512-tHsAD0iOUb6QSGGw+c8cyRBvxsq/NlfzIFBZLEHhWZ+Bx4a0MmXup6I/yJDGmyPCYE+ctCcAfY13wKAzdiVFgQ==",
+      "resolved": "git+ssh://git@github.com/foundry-vtt-types/pixi-ticker.git#6a2756560f67a81fafbb1914b56d8974b6f34085",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@pixi/extensions": "7.4.3",
         "@pixi/settings": "7.4.3",
-        "@pixi/utils": "7.4.3"
+        "@pixi/utils": "github:foundry-vtt-types/pixi-utils#main"
       }
     },
     "node_modules/@pixi/utils": {
       "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.4.3.tgz",
-      "integrity": "sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA==",
+      "resolved": "git+ssh://git@github.com/foundry-vtt-types/pixi-utils.git#8274a744f353ec7a7d9313748ceab22455df8837",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3583,19 +3579,11 @@
         "@pixi/color": "7.4.3",
         "@pixi/constants": "7.4.3",
         "@pixi/settings": "7.4.3",
-        "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.4",
+        "@types/earcut": "^3.0.0",
+        "earcut": "^3.0.1",
         "eventemitter3": "^4.0.0",
         "url": "^0.11.0"
       }
-    },
-    "node_modules/@pixi/utils/node_modules/earcut": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -5354,6 +5342,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/earcut": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.1.tgz",
+      "integrity": "sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -6417,7 +6413,7 @@
     "node_modules/fvtt-types": {
       "name": "@league-of-foundry-developers/foundry-vtt-types",
       "version": "13.345.0",
-      "resolved": "git+ssh://git@github.com/League-of-Foundry-Developers/foundry-vtt-types.git#bdcadd801cff0193351449525e9878f62504d014",
+      "resolved": "git+ssh://git@github.com/League-of-Foundry-Developers/foundry-vtt-types.git#8aa628c9162470a45440b28f6ace34a8b3152c54",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6427,7 +6423,7 @@
         "@codemirror/lang-markdown": "^6.3.2",
         "@pixi/basis": "github:foundry-vtt-types/pixi-basis#main",
         "@pixi/graphics-smooth": "^1.1.1",
-        "@pixi/particle-emitter": "^5.0.8",
+        "@pixi/particle-emitter": "github:foundry-vtt-types/pixi-particle-emitter#main",
         "@types/jquery": "^3.5.32",
         "@types/showdown": "~2.0.6",
         "@types/simple-peer": "~9.11.1",


### PR DESCRIPTION
farmeroz on discord pointed this out, looks like that line was accidentally removed for some reason.

This PR also updates some dependencies and changes the calculation the Token Ruler uses to respect the current canvas grid units (it does unit conversion to yards since basic move is necessarily in yards at this point). Not sure if this is a good idea yet, but it shouldn't affect anyone negatively as far as I can tell.