### PR TITLE
Bugfix: premature return in penaltiesPerTenRanges loop

### DIFF
--- a/lib/ranges.js
+++ b/lib/ranges.js
@@ -137,8 +137,8 @@ export class GurpsRange {
         penalty: -i,
         desc: `${(i + 1) * 10} yds`,
       })
-      return penaltiesPerTenRanges
     }
+	return penaltiesPerTenRanges
 
     // Must be kept in order... checking range vs Max.   If >Max, go to next entry.
   }


### PR DESCRIPTION
This PR fixes a logic error in the `penaltiesPerTenRanges` where the `return` statement was accidentally placed inside the `for` loop.

### The Issue
Previously, the loop would execute only once and immediately return the array with a single entry (Max: 10).
```javascript
// Previous broken logic
for (let i = 0; i < 50; i++) {
  penaltiesPerTenRanges.push({ ... })
  return penaltiesPerTenRanges // <--- Bug: Returns immediately after i=0
}
```
### The Fix
I have moved the `return` statement outside the loop. The function now correctly populates the full array of ranges before returning it.

### Impact
This fixes the issue where the "Per10" range table would fail to calculate modifiers for any distance greater than 10. This caused Ruler and Target modifiers to always default to 0 (no penalty) for long ranges, as the lookup table contained only the first entry.

## Changes
- Moved `return penaltiesPerTenRanges` outside the `for` loop.