### PR TITLE
fix: prevent crash when rolling from actor sheet with canvas disabled

### DIFF
--- a/module/dierolls/dieroll.js
+++ b/module/dierolls/dieroll.js
@@ -1,5 +1,6 @@
 import * as Settings from '../../lib/miscellaneous-settings.js'
 import { TokenActions } from '../token-actions.js'
+import { getTokenForActor } from '../utilities/token.js'
 
 export const rollData = target => {
   let targetColor, rollChance
@@ -115,7 +116,7 @@ export async function doRoll({
     if (actorTokens.length === 1) {
       token = actorTokens[0]
     } else {
-      token = actor?.getActiveTokens()?.[0] || canvas.tokens.controlled[0]
+      token = getTokenForActor(actor)
     }
     result = await actor.canRoll(action, token, chatthing, optionalArgs.obj)
   }

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -36,6 +36,7 @@ import { GurpsItemSheet } from './item-sheet.js'
 import { GurpsItem } from './item.js'
 import GurpsJournalEntry from './journal.js'
 import { ModifierBucket } from './modifier-bucket/bucket-app.js'
+import { getTokenForActor } from './utilities/token.js'
 
 /**
  * Added to color the rollable parts of the character sheet.
@@ -576,7 +577,7 @@ if (!globalThis.GURPS) {
       }
 
       let canRoll = { result: true }
-      const token = actor?.getActiveTokens()?.[0] || canvas.tokens.controlled[0]
+      const token = getTokenForActor(actor)
       if (actor) canRoll = await actor.canRoll(action, token)
       if (!canRoll.canRoll) {
         if (canRoll.targetMessage) {
@@ -670,7 +671,7 @@ if (!globalThis.GURPS) {
       }
 
       let canRoll = { result: true }
-      const token = actor?.getActiveTokens()?.[0] || canvas.tokens.controlled[0]
+      const token = getTokenForActor(actor)
       if (actor) canRoll = await actor.canRoll(action, token)
       if (!canRoll.canRoll) {
         if (canRoll.targetMessage) {

--- a/module/utilities/token.js
+++ b/module/utilities/token.js
@@ -1,0 +1,2 @@
+export const getTokenForActor = actor =>
+  actor?.getActiveTokens()?.[0] ?? canvas.tokens?.controlled?.[0]


### PR DESCRIPTION
  Extract token retrieval logic into getTokenForActor() helper to ensure
  safe access to canvas.tokens when canvas is disabled.

  Closes #2449