### PR TITLE
fix: add name property to new Active Effect creation

### DIFF
--- a/module/effects/active-effect-list.js
+++ b/module/effects/active-effect-list.js
@@ -44,7 +44,8 @@ export default class GurpsActiveEffectListSheet extends Application {
       case 'create':
         await this.actor.createEmbeddedDocuments('ActiveEffect', [
           {
-            label: game.i18n.localize('GURPS.effectNew', 'New Effect'),
+            name: game.i18n.localize('GURPS.effectNew'),
+            label: game.i18n.localize('GURPS.effectNew'),
             icon: 'icons/svg/aura.svg',
             disabled: true,
           },


### PR DESCRIPTION
Foundry VTT v12+ requires the name property for Active Effect validation. Without it, users get "name: may not be undefined" error.

Closes #2447