### PR TITLE
fix: prevent notes field horizontal overflow in modern UI

### DIFF
--- a/styles/modern/components/_notes.scss
+++ b/styles/modern/components/_notes.scss
@@ -26,6 +26,7 @@
 
 .ms-notes-list {
   font-size: var(--ms-font-xs);
+  min-width: 0;
 }
 
 .ms-note-row {
@@ -41,6 +42,8 @@
 
 .ms-note-content {
   flex: 1;
+  min-width: 0;
+  overflow-wrap: break-word;
 
   .expandcollapseicon {
     margin-right: var(--ms-space-2);

--- a/styles/modern/components/_sections.scss
+++ b/styles/modern/components/_sections.scss
@@ -4,6 +4,7 @@
   border-radius: var(--ms-radius);
   padding: var(--ms-gap);
   margin-bottom: var(--ms-gap);
+  min-width: 0;
 }
 
 .ms-section-header {


### PR DESCRIPTION
Add min-width: 0 to section, notes list, and note content elements to allow flex/grid children to shrink below content width. Add overflow-wrap: break-word to break long text/URLs

Closes #2464