### PR TITLE
fix(actor): prevent permission error when GM switches sheet view with token on map

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -129,6 +129,14 @@ export class GurpsActor extends Actor {
     }
   }
 
+  /** @override */
+  _onUpdate(changed, options, userId) {
+    if (changed.flags?.core?.sheetClass !== undefined && game.user.id !== userId) {
+      delete changed.flags.core.sheetClass
+    }
+    super._onUpdate(changed, options, userId)
+  }
+
   prepareData() {
     super.prepareData()
     // By default, it does this:


### PR DESCRIPTION
when GM changes sheet view (Full View -> Editor), setFlag('core', 'sheetClass') broadcasts to all clients. Foundry's `_onUpdate` detects this flag change and calls `_onSheetChange` which tries to create/render the new sheet on every client - including players who lack permission.

The fix removes sheetClass from the change data for non-initiating clients so Foundry never triggers _onSheetChange on their machines

closes #2481