### PR TITLE
Fix modifiers not added on item drag-and-drop

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1534,6 +1534,11 @@ export class GurpsActor extends Actor {
         actorComp.duringotf = data.system[data.itemSysKey].duringotf
         actorComp.passotf = data.system[data.itemSysKey].passotf
         actorComp.failotf = data.system[data.itemSysKey].failotf
+        actorComp.bonuses = data.system.bonuses || ''
+        actorComp.itemModifiers = data.system.itemModifiers || ''
+        actorComp.modifierTags = data.system.modifierTags || ''
+        actorComp.addToQuickRoll =
+          data.system.addToQuickRoll !== undefined ? data.system.addToQuickRoll : actorComp.addToQuickRoll
 
         // 4. Create Parent Item
         const importer = new ActorImporter(this)


### PR DESCRIPTION
Fix bug where dragging items did not add bonuses, itemModifiers, modifierTags, or addToQuickRoll.
They are now added correctly after drag-and-drop.
