### PR TITLE
Pseudo-Document Refactor

### DIFF
--- a/src/module/actor/gurps-actor.ts
+++ b/src/module/actor/gurps-actor.ts
@@ -1,4 +1,6 @@
-import { fields } from '@gurps-types/foundry/data-fields.js'
+import { Document, fields } from '@gurps-types/foundry/index.js'
+import { CollectionField } from '@module/data/fields/collection-field.js'
+import { type ItemMetadata } from '@module/item/data/base.js'
 import { EquipmentV1 } from '@module/item/legacy/equipment-adapter.js'
 import * as Settings from '@module/util/miscellaneous-settings.js'
 import { multiplyDice } from '@util/damage-utils.js'
@@ -27,6 +29,7 @@ import { TokenActions } from '../token-actions.js'
 
 import { Advantage, Equipment, HitLocationEntry, Melee, Named, Ranged, Skill, Spell } from './actor-components.js'
 import { ActorImporter } from './actor-importer.js'
+import { type ActorMetadata } from './data/base.js'
 import { DamageActionSchema } from './data/character-components.js'
 import { HitLocationEntryV2 } from './data/hit-location-entry.js'
 import { collectDeletions } from './deletion.js'
@@ -80,6 +83,8 @@ interface EquipmentDropData {
 }
 
 class GurpsActorV2<SubType extends Actor.SubType> extends Actor<SubType> implements ActorV1Interface {
+  declare pseudoCollections: Record<string, ModelCollection>
+
   // Narrowed view of this.system for characterV2 logic.
   private get modelV2() {
     return this.system as Actor.SystemOfType<ActorType.Character>
@@ -109,6 +114,29 @@ class GurpsActorV2<SubType extends Actor.SubType> extends Actor<SubType> impleme
   isOfType<SubType extends Actor.SubType>(...types: SubType[]): this is Actor.OfType<SubType>
   isOfType(...types: string[]): boolean {
     return types.includes(this.type as Actor.SubType)
+  }
+
+  /* ---------------------------------------- */
+
+  protected override _configure(options = {}) {
+    super._configure(options)
+
+    const collections: Record<string, ModelCollection> = {}
+    const model = CONFIG[this.documentName].dataModels[this._source.type]
+    const embedded = (model as unknown as gurps.MetadataOwner)?.metadata?.embedded ?? {}
+
+    for (const [documentName, fieldPath] of Object.entries(embedded)) {
+      const data = foundry.utils.getProperty(this._source, fieldPath) as AnyObject
+      const field = model.schema.getField(fieldPath.slice('system.'.length)) as CollectionField
+
+      collections[documentName] = new (field.constructor as typeof CollectionField).implementation(
+        documentName as any,
+        this,
+        data
+      )
+    }
+
+    Object.defineProperty(this, 'pseudoCollections', { value: Object.seal(collections), writable: false })
   }
 
   /* ---------------------------------------- */
@@ -170,7 +198,13 @@ class GurpsActorV2<SubType extends Actor.SubType> extends Actor<SubType> impleme
     if (!isDevMode) {
       options ||= {}
       const allTypes = Actor.TYPES
-      const excludeTypes = ['base', 'character', 'enemy', 'gcsCharacter', 'gcsLoot']
+      const excludeTypes = [
+        'base',
+        ActorType.LegacyCharacter,
+        ActorType.LegacyEnemy,
+        ActorType.GcsCharacter,
+        ActorType.GcsLoot,
+      ]
 
       // Disable non-production Actor types if developer mode is off.
       // @ts-expect-error: Improper types
@@ -182,21 +216,38 @@ class GurpsActorV2<SubType extends Actor.SubType> extends Actor<SubType> impleme
 
   /* ---------------------------------------- */
 
-  override getEmbeddedDocument<EmbeddedName extends gurps.Pseudo.EmbeddedCollectionName<'Actor'>>(
+  override getEmbeddedDocument<EmbeddedName extends gurps.Pseudo.EmbeddedCollectionName<'Actor' | 'Item'>>(
     embeddedName: EmbeddedName,
     id: string,
-    options?: foundry.abstract.Document.GetEmbeddedDocumentOptions
-  ): gurps.Pseudo.EmbeddedDocument<'Actor', EmbeddedName> {
+    options?: Document.GetEmbeddedDocumentOptions
+  ): gurps.Pseudo.EmbeddedDocument<'Actor' | 'Item', EmbeddedName> {
     const { invalid = false, strict = true } = options ?? {}
 
-    if (this.isNewActorType) {
-      const systemEmbeds = (this.system?.constructor as any).metadata.embedded ?? {}
+    const metadata = (this.system?.constructor as any).metadata as ActorMetadata
 
-      if (embeddedName in systemEmbeds) {
-        const path = systemEmbeds[embeddedName]
-        const document = foundry.utils.getProperty(this, path) as any
+    const systemEmbeds = metadata.embedded ?? {}
 
-        return (document.get(id, { invalid, strict }) ?? undefined) as any
+    if (embeddedName in systemEmbeds) {
+      return this.getEmbeddedCollection(embeddedName as keyof PseudoDocumentConfig.Embeds['Actor']).get(id, {
+        invalid,
+        strict,
+      }) as any
+    }
+
+    const holderItem: Item.Implementation | null =
+      (this.system[metadata.embeddedHolderField as keyof typeof this.system] as Item.Implementation) ?? null
+
+    if (holderItem) {
+      const itemMetadata = (holderItem.system?.constructor as any).metadata as ItemMetadata
+
+      if (itemMetadata.embedded && embeddedName in itemMetadata.embedded) {
+        const holderResult = holderItem.getEmbeddedDocument(
+          embeddedName as gurps.Pseudo.EmbeddedCollectionName<'Item'>,
+          id,
+          { invalid, strict }
+        )
+
+        if (holderResult) return holderResult
       }
     }
 
@@ -205,19 +256,85 @@ class GurpsActorV2<SubType extends Actor.SubType> extends Actor<SubType> impleme
 
   /* ---------------------------------------- */
 
-  /**
-   * Obtain the embedded collection of a given pseudo-document type.
-   */
-  getEmbeddedPseudoDocumentCollection(embeddedName: string): ModelCollection<PseudoDocument> {
-    const collectionPath = (this.system?.constructor as any).metadata.embedded?.[embeddedName]
+  override getEmbeddedCollection<EmbeddedName extends Actor.Embedded.CollectionName>(
+    embeddedName: EmbeddedName
+  ): Actor.Embedded.CollectionFor<EmbeddedName>
+  override getEmbeddedCollection<EmbeddedName extends keyof PseudoDocumentConfig.Embeds['Actor']>(
+    embeddedName: EmbeddedName
+  ): ModelCollection<PseudoDocumentConfig.Embeds['Actor'][EmbeddedName]>
+  override getEmbeddedCollection(embeddedName: string): unknown {
+    return (
+      this.pseudoCollections[embeddedName] ?? super.getEmbeddedCollection(embeddedName as Actor.Embedded.CollectionName)
+    )
+  }
 
-    if (!collectionPath) {
-      throw new Error(
-        `${embeddedName} is not a valid embedded Pseudo-Document within the [${'type' in this ? this.type : 'base'}] ${this.documentName} subtype!`
-      )
+  /* ---------------------------------------- */
+
+  override async createEmbeddedDocuments<EmbeddedName extends Actor.Embedded.Name>(
+    embeddedName: EmbeddedName,
+    data: Document.CreateDataForName<EmbeddedName>[] | undefined,
+    operation?: Document.Database.CreateOperationForName<EmbeddedName>
+  ): Promise<Array<Document.StoredForName<EmbeddedName>>>
+  override async createEmbeddedDocuments<EmbeddedName extends keyof PseudoDocumentConfig.Embeds['Actor']>(
+    embeddedName: EmbeddedName,
+    data: gurps.Pseudo.EmbeddedCreateData<'Actor', EmbeddedName>[] | undefined,
+    operation?: Partial<gurps.Pseudo.CreateOperation>
+  ): Promise<Array<PseudoDocumentConfig.Embeds['Actor'][EmbeddedName]>>
+  override async createEmbeddedDocuments(
+    embeddedName: string,
+    data?: unknown[],
+    operation?: object
+  ): Promise<unknown[]> {
+    const metadata = (this.system?.constructor as any).metadata as ActorMetadata
+
+    if (metadata.embedded && embeddedName in metadata.embedded) {
+      const cls = GURPS.CONFIG.PseudoDocument.Types[embeddedName as keyof typeof GURPS.CONFIG.PseudoDocument.Types]
+
+      return cls.createDocuments(data as any[], { parent: this, ...operation })
+    } else if (metadata.embeddedHolderField) {
+      const holderItem: Item.Implementation | null =
+        (this.system[metadata.embeddedHolderField as keyof typeof this.system] as Item.Implementation) ?? null
+
+      if (holderItem) {
+        const itemMetadata = (holderItem.system?.constructor as any).metadata as ItemMetadata
+
+        if (itemMetadata.embedded && embeddedName in itemMetadata.embedded) {
+          const cls = GURPS.CONFIG.PseudoDocument.Types[embeddedName as keyof typeof GURPS.CONFIG.PseudoDocument.Types]
+
+          return cls.createDocuments(data as any[], { ...operation, parent: holderItem })
+        }
+      }
     }
 
-    return foundry.utils.getProperty(this, collectionPath) as ModelCollection<PseudoDocument>
+    return super.createEmbeddedDocuments(embeddedName as Actor.Embedded.Name, data as never, operation as never)
+  }
+
+  /* ---------------------------------------- */
+
+  override async deleteEmbeddedDocuments<EmbeddedName extends Actor.Embedded.Name>(
+    embeddedName: EmbeddedName,
+    ids: Array<string>,
+    operation?: Document.Database.DeleteOperationForName<EmbeddedName>
+  ): Promise<Array<Document.StoredForName<EmbeddedName>>>
+  override async deleteEmbeddedDocuments<EmbeddedName extends keyof PseudoDocumentConfig.Embeds['Actor']>(
+    embeddedName: EmbeddedName,
+    ids: Array<string>,
+    operation?: Partial<PseudoDocument.DeleteOperation>
+  ): Promise<Array<PseudoDocumentConfig.Embeds['Actor'][EmbeddedName]>>
+  override async deleteEmbeddedDocuments(
+    embeddedName: string,
+    ids: Array<string>,
+    operation?: object
+  ): Promise<unknown[]> {
+    const systemEmbeds = (this.system?.constructor as any).metadata.embedded ?? {}
+
+    if (embeddedName in systemEmbeds) {
+      const cls = GURPS.CONFIG.PseudoDocument.Types[embeddedName as keyof typeof GURPS.CONFIG.PseudoDocument.Types]
+
+      return cls.deleteDocuments(ids, { parent: this, ...operation })
+    }
+
+    return super.deleteEmbeddedDocuments(embeddedName as Actor.Embedded.Name, ids as never, operation as never)
   }
 
   /* ---------------------------------------- */
@@ -570,7 +687,7 @@ class GurpsActorV2<SubType extends Actor.SubType> extends Actor<SubType> impleme
     const embedded = this.modelV2?.metadata?.embedded ?? {}
 
     for (const documentName of Object.keys(embedded)) {
-      for (const pseudoDocument of this.getEmbeddedPseudoDocumentCollection(documentName)) fn(pseudoDocument)
+      for (const pseudoDocument of this.getEmbeddedCollection(documentName as any)) fn(pseudoDocument)
     }
   }
 

--- a/src/module/actor/sheets/base-actor-sheet.ts
+++ b/src/module/actor/sheets/base-actor-sheet.ts
@@ -1,7 +1,10 @@
+import { Document } from '@gurps-types/foundry/index.js'
 import { ImportSettings } from '@module/importer/index.js'
+import { ItemType } from '@module/item/types.js'
+import { PseudoDocument } from '@module/pseudo-document/pseudo-document.js'
 import { constructHTMLButton } from '@module/util/dom.js'
 import { getUser } from '@module/util/guards.js'
-import { DeepPartial } from 'fvtt-types/utils'
+import { AnyMutableObject, DeepPartial } from 'fvtt-types/utils'
 
 import { ActorImporter } from '../actor-importer.js'
 import { ActorType } from '../types.js'
@@ -176,6 +179,12 @@ const GurpsBaseActorSheet = <
       actions: {
         importActor: GurpsBaseActorSheet.#onImportActor,
         toggleMode: GurpsBaseActorSheet.#onToggleMode,
+        createEmbedded: GurpsBaseActorSheet.#onCreateEmbedded,
+        editEmbedded: GurpsBaseActorSheet.#onEditEmbedded,
+        deleteEmbedded: GurpsBaseActorSheet.#onDeleteEmbedded,
+        toggleContainer: GurpsBaseActorSheet.#onToggleContainer,
+        addModifier: GurpsBaseActorSheet.#onAddModifier,
+        rollOtf: GurpsBaseActorSheet.#onRollOtf,
       },
       dragDrop: [{ dragSelector: '[draggable]', dropSelector: null }],
     }
@@ -222,6 +231,173 @@ const GurpsBaseActorSheet = <
       await this.render({
         mode: this.isPlayMode ? GurpsBaseActorSheet.MODES.EDIT : GurpsBaseActorSheet.MODES.PLAY,
       } as RenderOptions)
+    }
+
+    /* ---------------------------------------- */
+
+    static async #onCreateEmbedded(
+      this: GurpsBaseActorSheet,
+      event: PointerEvent | null,
+      target: HTMLElement
+    ): Promise<void> {
+      event?.preventDefault()
+
+      const documentName = target.closest<HTMLElement>('[data-document-name]')?.dataset.documentName
+
+      if (!documentName) {
+        console.error('Could not find document name for embedded document to edit.')
+
+        return
+      }
+
+      const createData: AnyMutableObject = { _id: foundry.utils.randomID() }
+
+      const type = target.closest<HTMLElement>('[data-type]')?.dataset.type
+
+      if (type) createData.type = type
+
+      if (documentName === 'Item') {
+        const defaultName = foundry.documents.Item.defaultName({
+          type: type as foundry.documents.Item.SubType,
+          parent: this.actor,
+        })
+
+        createData.name = defaultName
+      }
+
+      if (type === ItemType.Equipment) {
+        const carried = target.closest<HTMLElement>('[data-carried]')?.dataset.carried === 'true'
+
+        createData.system = { carried }
+      }
+
+      await this.actor.createEmbeddedDocuments(documentName as any, [createData], { parent: this.actor })
+    }
+
+    /* ---------------------------------------- */
+
+    protected async _getEmbedded(target: HTMLElement): Promise<Document.Any | PseudoDocument.Any | null> {
+      const uuid = target.closest<HTMLElement>('[data-uuid]')?.dataset.uuid
+
+      if (!uuid) {
+        console.error('Could not find UUID for embedded document to edit.')
+
+        return null
+      }
+
+      let doc: Document.Any | PseudoDocument.Any | null = null
+
+      if (uuid.startsWith('.')) {
+        doc = await fromUuid(uuid, { relative: this.actor })
+      } else {
+        doc = await fromUuid(uuid)
+      }
+
+      if (!doc) {
+        console.error(`Could not find document for UUID ${uuid}.`)
+
+        return null
+      }
+
+      return doc
+    }
+
+    /* ---------------------------------------- */
+
+    static async #onEditEmbedded(
+      this: GurpsBaseActorSheet,
+      event: PointerEvent | null,
+      target: HTMLElement
+    ): Promise<void> {
+      event?.preventDefault()
+
+      const doc = await this._getEmbedded(target)
+
+      if (!doc) return
+
+      const sheet = 'sheet' in doc ? doc.sheet : null
+
+      if (!sheet) {
+        console.error('Could not find sheet for document with UUID ${uuid}.')
+
+        return
+      }
+
+      if (sheet instanceof foundry.appv1.api.Application) {
+        sheet.render(true)
+      } else {
+        await sheet.render({ force: true })
+      }
+    }
+
+    /* ---------------------------------------- */
+
+    static async #onDeleteEmbedded(
+      this: GurpsBaseActorSheet,
+      event: PointerEvent | null,
+      target: HTMLElement
+    ): Promise<void> {
+      event?.preventDefault()
+
+      const doc = await this._getEmbedded(target)
+
+      if (!doc) return
+
+      if ('deleteDialog' in doc && typeof doc.deleteDialog === 'function') {
+        await doc.deleteDialog?.()
+      } else {
+        console.error('Could not find delete method for document with UUID ${uuid}.')
+
+        return
+      }
+    }
+
+    /* ---------------------------------------- */
+
+    static async #onToggleContainer(
+      this: GurpsBaseActorSheet,
+      event: PointerEvent,
+      target: HTMLElement
+    ): Promise<void> {
+      event.preventDefault()
+      const doc = await this._getEmbedded(target)
+
+      if (!doc) return
+
+      if ('toggleOpen' in doc && typeof doc.toggleOpen === 'function') {
+        await doc?.toggleOpen?.()
+      } else {
+        console.error(
+          'Tried to toggle open state of a pseudo-document or document, but the document does not have a toggleOpen function'
+        )
+
+        return
+      }
+    }
+
+    /* ---------------------------------------- */
+
+    static async #onAddModifier(this: GurpsBaseActorSheet, event: PointerEvent, target: HTMLElement): Promise<void> {
+      event.preventDefault()
+
+      const value = target.dataset.value ?? '0'
+      const comment = target.dataset.comment ?? ''
+
+      GURPS.ModifierBucket.addModifier(value, comment)
+    }
+
+    /* ---------------------------------------- */
+
+    static async #onRollOtf(this: GurpsBaseActorSheet, event: PointerEvent, target: HTMLElement): Promise<void> {
+      event.preventDefault()
+
+      const value = target.dataset.value ?? ''
+
+      const parsed = GURPS.parselink(value)
+
+      if (!parsed.action) return
+
+      GURPS.performAction(parsed.action, this.actor, event)
     }
 
     /* ---------------------------------------- */

--- a/src/module/actor/sheets/base-actor-sheet.ts
+++ b/src/module/actor/sheets/base-actor-sheet.ts
@@ -318,7 +318,7 @@ const GurpsBaseActorSheet = <
       const sheet = 'sheet' in doc ? doc.sheet : null
 
       if (!sheet) {
-        console.error('Could not find sheet for document with UUID ${uuid}.')
+        console.error(`Could not find sheet for document with UUID ${doc.uuid}.`)
 
         return
       }
@@ -346,7 +346,7 @@ const GurpsBaseActorSheet = <
       if ('deleteDialog' in doc && typeof doc.deleteDialog === 'function') {
         await doc.deleteDialog?.()
       } else {
-        console.error('Could not find delete method for document with UUID ${uuid}.')
+        console.error(`Could not find delete method for document with UUID ${doc.uuid}.`)
 
         return
       }

--- a/src/module/actor/sheets/gcs-sheet.ts
+++ b/src/module/actor/sheets/gcs-sheet.ts
@@ -732,7 +732,7 @@ class GurpsActorGcsSheet extends GurpsBaseActorSheet<
             doc = parent.getEmbeddedDocument('Action', target.dataset.actionId ?? '') ?? null
           } else if (documentName) {
             doc =
-              this.actor.getEmbeddedPseudoDocumentCollection(documentName)?.get(target.dataset.actionId ?? '') ?? null
+              (this.actor.getEmbeddedCollection(documentName as any)?.get(target.dataset.actionId ?? '') ?? null) as PseudoDocument | null
           }
 
           if (!doc) {
@@ -835,7 +835,7 @@ class GurpsActorGcsSheet extends GurpsBaseActorSheet<
 
     if (!documentName || !actionId) return
 
-    const action = this.actor.getEmbeddedPseudoDocumentCollection(documentName)?.get(actionId)
+    const action = this.actor.getEmbeddedCollection(documentName as any)?.get(actionId)
 
     if (!action) return
 

--- a/src/module/actor/sheets/gcs-sheet.ts
+++ b/src/module/actor/sheets/gcs-sheet.ts
@@ -731,8 +731,8 @@ class GurpsActorGcsSheet extends GurpsBaseActorSheet<
 
             doc = parent.getEmbeddedDocument('Action', target.dataset.actionId ?? '') ?? null
           } else if (documentName) {
-            doc =
-              (this.actor.getEmbeddedCollection(documentName as any)?.get(target.dataset.actionId ?? '') ?? null) as PseudoDocument | null
+            doc = (this.actor.getEmbeddedCollection(documentName as any)?.get(target.dataset.actionId ?? '') ??
+              null) as PseudoDocument | null
           }
 
           if (!doc) {

--- a/src/module/data/fields/collection-field.ts
+++ b/src/module/data/fields/collection-field.ts
@@ -1,8 +1,8 @@
-import { fields } from '@gurps-types/foundry/index.js'
-import { AnyObject } from 'fvtt-types/utils'
+import { DataModel, fields } from '@gurps-types/foundry/index.js'
+import { PseudoDocument } from '@module/pseudo-document/pseudo-document.js'
+import { TypedPseudoDocument } from '@module/pseudo-document/typed-pseudo-document.js'
+import { AnyMutableObject, AnyObject } from 'fvtt-types/utils'
 
-import { PseudoDocument } from '../../pseudo-document/pseudo-document.js'
-import { TypedPseudoDocument } from '../../pseudo-document/typed-pseudo-document.js'
 import { ModelCollection } from '../model-collection.js'
 
 class LazyTypedSchemaField<
@@ -13,9 +13,12 @@ class LazyTypedSchemaField<
   const PersistedType = fields.TypedSchemaField.PersistedType<Types, Options>,
 > extends fields.TypedSchemaField<Types, Options, AssignmentType, InitializedType, PersistedType> {
   protected override _validateSpecial(value: AssignmentType): boolean | void {
-    if (!value || (value as any).type in this.types) return super._validateSpecial(value)
+    // @ts-expect-error: Treating value as any here
+    const invalidType = typeof value.type === 'string' && !(value.type in this.types)
 
-    return true
+    if (invalidType) return true
+
+    return super._validateSpecial(value)
   }
 }
 
@@ -26,17 +29,20 @@ namespace CollectionField {
 
   /* ---------------------------------------- */
 
-  export type Types<M extends TypedPseudoDocument.AnyConstructor> = [TypedPseudoDocument.DocumentNameOf<M>] extends [
-    infer DocumentName extends gurps.Pseudo.WithTypes,
-  ]
-    ? {
-        [K in keyof PseudoDocumentConfig.Types[DocumentName]]: PseudoDocumentConfig.Types[DocumentName][K] extends gurps.Pseudo.ConfigEntry<
-          infer Doc
-        >
-          ? fields.EmbeddedDataField<Doc>
-          : never
-      }
-    : fields.TypedSchemaField.Types
+  export type Types = fields.TypedSchemaField.Types
+
+  // NOTE: This is technically possible but the types get very unwieldy and it's not clear if it's worth it. Revisit if we find a use case for it.
+  // export type Types<M extends TypedPseudoDocument.ConcreteConstructor> = [
+  //   TypedPseudoDocument.DocumentNameOf<M>,
+  // ] extends [infer DocumentName extends gurps.Pseudo.WithTypes]
+  //   ? {
+  //       [K in keyof PseudoDocumentConfig.Types[DocumentName]]: PseudoDocumentConfig.Types[DocumentName][K] extends gurps.Pseudo.ConfigEntry<
+  //         infer Doc
+  //       >
+  //         ? fields.EmbeddedDataField<Doc>
+  //         : never
+  //     }
+  //   : fields.TypedSchemaField.Types
 
   /* ---------------------------------------- */
 
@@ -46,16 +52,28 @@ namespace CollectionField {
 
   /* ---------------------------------------- */
 
-  export type Element<M extends Model> = M extends TypedPseudoDocument.AnyConstructor
-    ? LazyTypedSchemaField<Types<M>>
+  export type Element<M extends Model> = M extends TypedPseudoDocument.ConcreteConstructor
+    ? LazyTypedSchemaField<Types>
     : fields.EmbeddedDataField<M>
+
+  // NOTE: This is technically possible but the types get very unwieldy and it's not clear if it's worth it. Revisit if we find a use case for it.
+  // export type Element<M extends Model> = M extends TypedPseudoDocument.ConcreteConstructor
+  //   ? LazyTypedSchemaField<Types<M>>
+  //   : fields.EmbeddedDataField<M>
 
   /* ---------------------------------------- */
 
   export type AssignmentType<
     M extends Model,
     Options extends CollectionField.Options<AnyObject>,
-  > = fields.TypedObjectField.AssignmentType<Element<M>, Options>
+    // NOTE: For TypedPseudoDocument-backed collections, the concrete per-type schemas are resolved
+    // dynamically at runtime via GURPS.CONFIG.PseudoDocument.SubTypes, so the static type cannot
+    // enumerate individual schema shapes. `LazyTypedSchemaField<Types>` (the Element for these
+    // models) ends up with AssignmentType `never` because `ConcreteKeys` of a pure index-signature
+    // type is `never`. We therefore fall back to `Record<string, AnyObject>` for this branch.
+  > = M extends TypedPseudoDocument.AnyConstructor
+    ? fields.DataField.DerivedAssignmentType<{ [K in fields.TypedObjectField.ValidKey<Options>]: AnyObject }, Options>
+    : fields.TypedObjectField.AssignmentType<Element<M>, Options>
 
   /* ---------------------------------------- */
 
@@ -73,7 +91,7 @@ namespace CollectionField {
 }
 
 class CollectionField<
-  const Model extends CollectionField.Model,
+  const Model extends CollectionField.Model = typeof PseudoDocument,
   const Element extends CollectionField.Element<Model> = CollectionField.Element<Model>,
   const Options extends CollectionField.Options<AnyObject> = CollectionField.DefaultOptions,
   const AssignmentType = CollectionField.AssignmentType<Model, Options>,
@@ -89,29 +107,96 @@ class CollectionField<
       : (new fields.EmbeddedDataField(model) as unknown as Element)
 
     super(field, options, context)
+    this.#documentClass = model
+  }
+
+  /* ---------------------------------------- */
+
+  /**
+   * The Collection implementation to use when initializing the collection.
+   */
+  static get implementation(): typeof ModelCollection {
+    return ModelCollection
+  }
+
+  /* ---------------------------------------- */
+
+  /**
+   * The pseudo-document class.
+   */
+  #documentClass: Model
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The pseudo-document class.
+   */
+  get documentClass(): Model {
+    return this.#documentClass
   }
 
   /* ---------------------------------------- */
 
   override initialize(
-    value: PersistedType,
+    _value: PersistedType,
     model: PseudoDocument.Any,
     options?: fields.DataField.InitializeOptions
   ): InitializedType | (() => InitializedType | null) {
-    const init = super.initialize(value, model, options)
-    const collection = new ModelCollection()
+    const name = this.documentClass.metadata.documentName
+    const collection = model.parent.pseudoCollections[name]
 
-    // @ts-expect-error: types haven't quite caught up
-    for (const [id, model] of Object.entries(init)) {
-      if (model instanceof PseudoDocument) {
-        collection.set(id, model)
-      } else {
-        // @ts-expect-error: types haven't quite caught up
-        collection.setInvalid(model)
-      }
+    collection.initialize(model, options)
+
+    return collection
+  }
+
+  /* ---------------------------------------- */
+
+  override toObject(value: InitializedType): PersistedType {
+    if (!value) return value as unknown as PersistedType
+
+    // @ts-expect-error: Not properly typed in this method
+    return (value as Array<Element>).map(val => this.element.toObject(val)) as PersistedType
+  }
+
+  /* ---------------------------------------- */
+
+  override _updateCommit(
+    source: AnyMutableObject,
+    key: string,
+    value: AnyMutableObject,
+    diff: AnyMutableObject,
+    options?: DataModel.UpdateOptions
+  ): void {
+    const src = source[key] as AnyMutableObject | undefined
+
+    // Special Cases: * -> undefined, * -> null, undefined -> *, null -> *
+    if (!src || !value) {
+      source[key] = value
+
+      return
     }
 
-    return collection as InitializedType
+    // Reconstruct the source array, retaining object references
+    // eslint-disable-next-line prefer-const
+    for (let [id, doc] of Object.entries(diff)) {
+      if (foundry.utils.isDeletionKey(id)) {
+        if (id.startsWith('-')) {
+          // @ts-expect-error: this is difficult to type
+          delete source[key][id.slice(2)]
+          continue
+        }
+
+        id = id.slice(2)
+      }
+
+      const prior = src[id]
+
+      if (prior) {
+        this.element._updateCommit(src, id, value[id], doc, options)
+        src[id] = prior
+      } else src[id] = doc
+    }
   }
 }
 

--- a/src/module/data/mixins/prereqs.ts
+++ b/src/module/data/mixins/prereqs.ts
@@ -1,4 +1,4 @@
-import { BasePrereq, PrereqList, PrereqType } from '@module/prereqs/index.js'
+import { BasePrereq, Prereq, PrereqList, PrereqType } from '@module/prereqs/index.js'
 
 import { NumericComparison } from '../criteria/number-criteria.js'
 import { CollectionField } from '../fields/collection-field.js'
@@ -8,7 +8,7 @@ const prereqsSchema = () => {
   const _id = foundry.utils.randomID()
 
   return {
-    _prereqs: new CollectionField(BasePrereq, {
+    _prereqs: new CollectionField(BasePrereq as Prereq.AnyConstructor, {
       initial: () => {
         return {
           [_id]: {

--- a/src/module/data/model-collection.ts
+++ b/src/module/data/model-collection.ts
@@ -1,16 +1,67 @@
 import { DataModel } from '@gurps-types/foundry/index.js'
+import { BaseAction } from '@module/action/base-action.js'
+import { HitLocationEntryV2 } from '@module/actor/data/hit-location-entry.js'
+import { MoveModeV2 } from '@module/actor/data/move-mode.js'
+import { NoteV2 } from '@module/actor/data/note.js'
+import { BaseFeature } from '@module/features/base-feature.js'
+import { ConditionalModifier, ReactionModifier } from '@module/item/data/conditional-modifier.js'
+import { BasePrereq } from '@module/prereqs/base-prereq.js'
+import { TypedPseudoDocument } from '@module/pseudo-document/typed-pseudo-document.js'
+import { TrackerInstance } from '@module/resource-tracker/resource-tracker.js'
+import { AnyMutableObject, AnyObject } from 'fvtt-types/utils'
 
-import { PseudoDocument } from '../pseudo-document/pseudo-document.js'
+import { type PseudoDocument } from '../pseudo-document/pseudo-document.js'
 
-class ModelCollection<Model extends DataModel.Any = DataModel.Any> extends foundry.utils.Collection<Model> {
+class ModelCollection<Model extends PseudoDocument.Any = PseudoDocument.Any> extends foundry.utils.Collection<Model> {
+  declare parent: DataModel.Any
+  protected _initialized = false
+
+  /* ---------------------------------------- */
+
+  constructor(documentName: gurps.Pseudo.Name, document: gurps.Pseudo.ParentDocument, data: AnyObject) {
+    super()
+    // @ts-expect-error: The types here are very difficult to express, and the properties are only used internally, so
+    // we can ignore the type errors.
+    const name = CONFIG[document.documentName].dataModels[document._source.type].metadata.embedded[documentName]
+
+    Object.defineProperties(this, {
+      name: { value: name, writable: false },
+      _source: { value: data, writable: false },
+      documentClass: { value: ModelCollection.documentClasses[documentName], writable: false },
+    })
+  }
+
   /* ---------------------------------------- */
   /*  Properties                              */
   /* ---------------------------------------- */
 
   /**
-   * Pre-organized arrays of data models by type.
+   * Pseudo-document base model.
    */
-  #types = new Map<string, Set<string>>()
+  declare documentClass: typeof PseudoDocument | typeof TypedPseudoDocument
+
+  /* ---------------------------------------- */
+
+  /**
+   * The base classes of the pseudo-documents that can be stored in a model such as this.
+   * Each class must implement `documentConfig` to map to the subtype.
+   */
+  static documentClasses: Record<string, PseudoDocument.ConcreteConstructor> = {
+    Action: BaseAction,
+    Prereq: BasePrereq,
+    Feature: BaseFeature,
+    HitLocation: HitLocationEntryV2,
+    ResourceTracker: TrackerInstance,
+    MoveMode: MoveModeV2,
+    Note: NoteV2,
+    ConditionalModifier: ConditionalModifier,
+    ReactionModifier: ReactionModifier,
+  }
+
+  /**
+   * A cache of this collection's contents grouped by subtype.
+   */
+  #documentsByType: Record<string, Model[]> | null = null
 
   /* ---------------------------------------- */
 
@@ -18,81 +69,243 @@ class ModelCollection<Model extends DataModel.Any = DataModel.Any> extends found
    * The data models that originate from this parent document.
    */
   get sourceContents(): Model[] {
-    return this.filter(model => (model as unknown as PseudoDocument).isSource)
+    return this.filter(model => model.isSource)
   }
 
   /* ---------------------------------------- */
 
   /**
-   * A set of the un-initialized pseudo-documents.
-   * Stored safely for debugging purposes.
+   * The set of invalid document ids.
    */
-  #invalid: Set<object> = new Set()
+  invalidDocumentIds: Set<string> = new Set()
 
-  /* ---------------------------------------- */
-  /*  Methods                                 */
-  /* ---------------------------------------- */
+  /* -------------------------------------------------- */
 
   /**
-   * Fetch an array of data models of a certain type.
+   * Underlying source data of each embedded pseudo-document. The
+   * collection is responsible for performing mutations to this data.
    */
-  getByType(type: string): Model[] {
-    return Array.from(this.#types.get(type) ?? []).map(key => this.get(key)) as Model[]
+  declare _source: Record<string, object>
+
+  /* -------------------------------------------------- */
+  /*  Instance Methods                                  */
+  /* -------------------------------------------------- */
+
+  get documentConfig(): Readonly<Record<string, typeof TypedPseudoDocument>> {
+    return foundry.utils.isSubclass(this.documentClass, TypedPseudoDocument)
+      ? (this.documentClass.documentConfig as unknown as Record<string, typeof TypedPseudoDocument>)
+      : {}
+  }
+
+  /**
+   * The subtypes sorted by type.
+   */
+  get documentsByType(): Record<string, Model[]> {
+    if (this.#documentsByType) return this.#documentsByType
+
+    const types: Record<string, Model[]> = Object.fromEntries(
+      Object.keys(this.documentConfig ?? {}).map(type => [type, []])
+    )
+
+    for (const doc of this.values() as unknown as Model[])
+      types[(doc as unknown as TypedPseudoDocument)._source.type ?? 'base']?.push(doc)
+
+    return (this.#documentsByType = types)
   }
 
   /* ---------------------------------------- */
 
-  override set(key: string, value: Model) {
-    const type = 'type' in value && typeof value.type === 'string' ? value.type : 'base'
+  /**
+   * A sorted array of the model instances.
+   */
+  get sortedContents(): Model[] {
+    return this.contents.sort((left, right) => left.sort - right.sort)
+  }
 
-    if (!this.#types.has(type)) this.#types.set(type, new Set())
-    this.#types.get(type)!.add(key)
+  /* ---------------------------------------- */
+
+  override set(key: string, value: Model, { modifySource = true } = {}) {
+    // Perform the modifications to the source when adding a new entry.
+    if (modifySource) this._source[key] = value._source
+    if (super.get(key) !== value) this.#documentsByType = null
 
     return super.set(key, value)
   }
 
-  /* ---------------------------------------- */
+  /* -------------------------------------------------- */
+
+  override delete(key: string, { modifySource = true } = {}) {
+    // Handle modifications to the source data when deleting an entry.
+    if (modifySource) delete this._source[key]
+    const result = super.delete(key)
+
+    if (result) this.#documentsByType = null
+
+    return result
+  }
+
+  /* -------------------------------------------------- */
 
   /**
-   * Store invalid pseudo-documents.
+   * Retrieve an invalid document.
+   * @param id   The id of the invalid pseudo-document.
+   * @param [options={}]
+   * @param [options.strict=true]   Throw an error if the id does not exist.
+   * @throws If the id does not exist.
    */
-  setInvalid(value: object) {
-    this.#invalid.add(value)
-  }
-
-  /* ---------------------------------------- */
-
-  override delete(key: string) {
-    const value = this.get(key)
-
-    if (value) {
-      const typeKey = 'type' in value && typeof value.type === 'string' ? value.type : 'base'
-
-      if (typeKey) this.#types.get(typeKey)?.delete(key)
+  getInvalid(id: string, { strict = true }: { strict?: boolean } = {}): Model | void {
+    if (!this.invalidDocumentIds.has(id) && strict) {
+      throw new Error(`The '${id}' does not exist in the invalid collection.`)
     }
 
-    return super.delete(key)
+    if (!this.invalidDocumentIds.has(id)) return
+
+    const data = this._source[id] as AnyObject
+    const Cls = this.documentConfig[data.type as string] ?? this.documentClass
+
+    return (Cls as typeof PseudoDocument).fromSource(foundry.utils.deepClone(data) as never, {
+      parent: this.parent,
+    }) as Model
   }
 
-  /* ---------------------------------------- */
+  /* -------------------------------------------------- */
 
   /**
    * Test the given predicate against every entry in the Collection.
+   * @param  predicate   The predicate.
    */
-  every(predicate: (arg0: any, arg1: number, arg2: ModelCollection) => boolean): boolean {
-    return this.reduce(
-      (pass, value, index) => pass && predicate(value, index, this as unknown as ModelCollection),
-      true
-    )
+  every(predicate: (arg0: any, arg1: number, arg2: ModelCollection<Model>) => boolean): boolean {
+    return this.reduce((pass, value, index) => pass && predicate(value, index, this), true)
   }
 
-  /* ---------------------------------------- */
+  /* -------------------------------------------------- */
 
   /**
    * Convert the ModelCollection to an array of simple objects.
+   * @returns The extracted array of primitive objects.
    */
   toObject(): object[] {
     return this.map(doc => doc.toObject(true))
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Initialize the model collection. Existing entries are retained, but new source data is used.
+   * @param  model    The parent data model that holds this collection.
+   * @param  [options={}]
+   */
+  initialize(model: DataModel.Any, options = {}) {
+    this.parent = model
+    this._initialized = false
+    this.#documentsByType = null
+
+    const initIds = new Set()
+
+    for (const obj of Object.values(this._source)) {
+      const doc = this.#initializeDocument(obj as AnyMutableObject, options)
+
+      if (doc) initIds.add(doc.id)
+    }
+
+    if (this.size !== initIds.size) {
+      for (const key of this.keys()) if (!initIds.has(key)) this.delete(key, { modifySource: false })
+    }
+
+    this._initialized = true
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Initialize a pseudo-document and store it in this collection.
+   * If it exists, reinitialize with new data, otherwise create a new instance.
+   * @param {object} data   Source data.
+   * @param {object} [options]
+   * @returns {Model|null}
+   */
+  #initializeDocument(data: AnyMutableObject, options: AnyMutableObject): Model | null {
+    let doc = this.get(data._id as string)
+
+    if (doc) {
+      // The document exists, reinitialize with new source data.
+      // @ts-expect-error: we know the source is mutable, but the type doesn't reflect that
+      doc._initialize(options)
+
+      return doc
+    }
+
+    if (!data._id) {
+      data._id = foundry.utils.randomID()
+      console.warn(`PseudoDocument was constructed without an _id. Replaced with id '${data._id}'.`)
+    }
+
+    try {
+      // Create a new instance.
+      doc = this.#createDocument(data, options)
+      super.set(doc.id, doc)
+    } catch (err) {
+      console.error(`Failed to initialize document with id '${data._id}':`, err)
+
+      this.#handleInvalidDocument(data._id as string, err as foundry.data.validation.DataModelValidationError, options)
+
+      return null
+    }
+
+    return doc
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Create a new instance of the pseudo-document.
+   * @param data   Pseudo-document data.
+   * @param [context={}]
+   */
+  #createDocument(data: AnyMutableObject, context: AnyMutableObject = {}): Model {
+    let Cls = this.documentClass
+
+    if (foundry.utils.isSubclass(this.documentClass, TypedPseudoDocument)) {
+      Cls = (this.documentClass as typeof TypedPseudoDocument).TYPES?.[data.type as string]
+
+      if (!Cls)
+        throw new Error(`Type '${data.type}' is not a valid subtype for a ${this.documentClass.metadata.documentName}.`)
+    }
+
+    return new (Cls as typeof PseudoDocument)(data as any, { ...context, parent: this.parent }) as unknown as Model
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Emulate the core handling of invalid documents by throwing warnings, storing the id in the `invalidDocumentIds` set.
+   * @param id   The id of the model.
+   * @param err    The error message.
+   * @param [options={}]
+   * @param [options.strict=true]   Throw an error.
+   */
+  #handleInvalidDocument(
+    id: string,
+    err: foundry.data.validation.DataModelValidationError,
+    { strict = true }: { strict?: boolean } = {}
+  ) {
+    const documentName = this.documentClass.metadata.documentName
+    // may need to adjust if we ever double nest pseudo documents
+    const parentDocument = this.parent.parent
+
+    this.invalidDocumentIds.add(id)
+
+    // Wrap the error with more information
+    const uuid = foundry.utils.buildUuid({ id, documentName: documentName as any, parent: parentDocument })
+    const msg = `Failed to initialize ${documentName} [${uuid}]:\n${err.message}`
+    const error = new Error(msg, { cause: err })
+
+    if (strict) console.error(error)
+    else console.warn(error)
+
+    if (strict) {
+      Hooks?.onError(`${this.constructor.name}#_initializeDocument`, error, { id, documentName })
+    }
   }
 }
 

--- a/src/module/item/gurps-item.ts
+++ b/src/module/item/gurps-item.ts
@@ -1,8 +1,9 @@
 import { Document } from '@gurps-types/foundry/index.js'
 import { CollectionField } from '@module/data/fields/collection-field.js'
 import { deleteDialogWithContents } from '@module/util/delete-dialog.js'
-import { AnyMutableObject, AnyObject, InexactPartial } from 'fvtt-types/utils'
+import { AnyObject, InexactPartial } from 'fvtt-types/utils'
 
+import { recurselist } from '@util/utilities.js'
 import { MeleeAttackModel, RangedAttackModel } from '../action/index.js'
 import { IContainable, isContainable } from '../data/mixins/containable.js'
 import { ModelCollection } from '../data/model-collection.js'

--- a/src/module/item/gurps-item.ts
+++ b/src/module/item/gurps-item.ts
@@ -1,11 +1,14 @@
-import { recurselist } from '@util/utilities.js'
+import { Document } from '@gurps-types/foundry/index.js'
+import { CollectionField } from '@module/data/fields/collection-field.js'
+import { deleteDialogWithContents } from '@module/util/delete-dialog.js'
+import { AnyMutableObject, AnyObject, InexactPartial } from 'fvtt-types/utils'
 
 import { MeleeAttackModel, RangedAttackModel } from '../action/index.js'
 import { IContainable, isContainable } from '../data/mixins/containable.js'
 import { ModelCollection } from '../data/model-collection.js'
 import { PseudoDocument } from '../pseudo-document/pseudo-document.js'
 
-import { BaseItemModel } from './data/base.js'
+import { BaseItemModel, ItemMetadata } from './data/base.js'
 import { EquipmentModel } from './data/equipment.js'
 import { ItemV1Interface, ItemV1Model } from './legacy/itemv1-interface.js'
 import { ItemType } from './types.js'
@@ -14,6 +17,8 @@ class GurpsItemV2<SubType extends Item.SubType = Item.SubType>
   extends foundry.documents.Item<SubType>
   implements ItemV1Interface, IContainable<GurpsItemV2>
 {
+  declare pseudoCollections: Record<string, ModelCollection>
+
   /* ---------------------------------------- */
 
   // Narrowed view of this.system for GurpsItemV2 logic.
@@ -38,6 +43,29 @@ class GurpsItemV2<SubType extends Item.SubType = Item.SubType>
   isOfType<SubType extends Item.SubType>(...types: SubType[]): this is Item.OfType<SubType>
   isOfType(...types: string[]): boolean {
     return types.includes(this.type as Item.SubType)
+  }
+
+  /* ---------------------------------------- */
+
+  protected override _configure(options = {}) {
+    super._configure(options)
+
+    const collections: Record<string, ModelCollection> = {}
+    const model = CONFIG[this.documentName].dataModels[this._source.type]
+    const embedded = (model as unknown as gurps.MetadataOwner)?.metadata?.embedded ?? {}
+
+    for (const [documentName, fieldPath] of Object.entries(embedded)) {
+      const data = foundry.utils.getProperty(this._source, fieldPath) as AnyObject
+      const field = model.schema.getField(fieldPath.slice('system.'.length)) as CollectionField
+
+      collections[documentName] = new (field.constructor as typeof CollectionField).implementation(
+        documentName as any,
+        this,
+        data
+      )
+    }
+
+    Object.defineProperty(this, 'pseudoCollections', { value: Object.seal(collections), writable: false })
   }
 
   /* ---------------------------------------- */
@@ -134,16 +162,32 @@ class GurpsItemV2<SubType extends Item.SubType = Item.SubType>
   ): gurps.Pseudo.EmbeddedDocument<'Item', EmbeddedName> {
     const { invalid = false, strict = true } = options ?? {}
 
-    const systemEmbeds = (this.system?.constructor as any).metadata.embedded ?? {}
+    const metadata = (this.system?.constructor as any).metadata as ItemMetadata
+
+    const systemEmbeds = metadata.embedded ?? {}
 
     if (embeddedName in systemEmbeds) {
-      const path = systemEmbeds[embeddedName]
-      const document = foundry.utils.getProperty(this, path) as any
-
-      return (document.get(id, { invalid, strict }) ?? undefined) as any
+      return this.getEmbeddedCollection(embeddedName as keyof PseudoDocumentConfig.Embeds['Item']).get(id, {
+        invalid,
+        strict,
+      }) as any
     }
 
     return super.getEmbeddedDocument(embeddedName as Item.Embedded.CollectionName, id, { invalid, strict }) as any
+  }
+
+  /* ---------------------------------------- */
+
+  override getEmbeddedCollection<EmbeddedName extends Item.Embedded.CollectionName>(
+    embeddedName: EmbeddedName
+  ): Item.Embedded.CollectionFor<EmbeddedName>
+  override getEmbeddedCollection<EmbeddedName extends keyof PseudoDocumentConfig.Embeds['Item']>(
+    embeddedName: EmbeddedName
+  ): ModelCollection<PseudoDocumentConfig.Embeds['Item'][EmbeddedName]>
+  override getEmbeddedCollection(embeddedName: string): unknown {
+    return (
+      this.pseudoCollections[embeddedName] ?? super.getEmbeddedCollection(embeddedName as Item.Embedded.CollectionName)
+    )
   }
 
   /* ---------------------------------------- */
@@ -160,16 +204,16 @@ class GurpsItemV2<SubType extends Item.SubType = Item.SubType>
       const allTypes = Item.TYPES
       const excludeTypes = [
         'base',
-        'equipment',
-        'feature',
-        'skill',
-        'spell',
-        'gcsTrait',
-        'gcsSkill',
-        'gcsSpell',
-        'gcsEquipment',
-        'gcsTraitModifier',
-        'gcsEquipmentModifier',
+        ItemType.LegacyEquipment,
+        ItemType.LegacyTrait,
+        ItemType.LegacySkill,
+        ItemType.LegacySpell,
+        ItemType.GcsTrait,
+        ItemType.GcsSkill,
+        ItemType.GcsSpell,
+        ItemType.GcsEquipment,
+        ItemType.GcsTraitModifier,
+        ItemType.GcsEquipmentModifier,
       ]
 
       // Disable non-production Item types if developer mode is off.
@@ -208,38 +252,13 @@ class GurpsItemV2<SubType extends Item.SubType = Item.SubType>
 
   /* ---------------------------------------- */
 
-  override async deleteDialog(options = {}): Promise<this | false | null | undefined> {
-    // Display custom delete dialog when deleting a container with contents
-    const count = this.allContents.length
-
-    if (count) {
-      const response = await foundry.applications.api.Dialog.confirm({
-        window: {
-          title: `${game.i18n?.format('DOCUMENT.Delete', { type: game.i18n.localize('DOCUMENT.Item') })}: ${this.name}`,
-        },
-        content:
-          `<p>${game.i18n?.format('GURPS.item.deleteMessage', { name: this.name })}</p>` +
-          `<label>` +
-          `<input type="checkbox" name="deleteContents">` +
-          `${game.i18n?.format('GURPS.item.deleteContents', { count: count.toString() })}` +
-          `</label>`,
-        yes: {
-          action: '',
-          callback: (event: PointerEvent | SubmitEvent) => {
-            const deleteContents = (
-              (event.currentTarget as HTMLElement).querySelector('[name="deleteContents"]') as HTMLInputElement
-            )?.checked
-
-            this.delete({ deleteContents })
-          },
-        },
-        options: { ...options },
-      })
-
-      return response ? this : undefined
-    }
-
-    return super.deleteDialog(options)
+  override async deleteDialog(
+    options?: InexactPartial<foundry.applications.api.DialogV2.ConfirmConfig>,
+    operation?: Document.Database.DeleteOperationForName<'Item'>
+  ): Promise<this | false | null | undefined> {
+    return (await deleteDialogWithContents.call(this, options, operation as any)) as unknown as Promise<
+      this | false | null | undefined
+    >
   }
 
   /* ---------------------------------------- */

--- a/src/module/item/gurps-item.ts
+++ b/src/module/item/gurps-item.ts
@@ -1,9 +1,9 @@
 import { Document } from '@gurps-types/foundry/index.js'
 import { CollectionField } from '@module/data/fields/collection-field.js'
 import { deleteDialogWithContents } from '@module/util/delete-dialog.js'
+import { recurselist } from '@util/utilities.js'
 import { AnyObject, InexactPartial } from 'fvtt-types/utils'
 
-import { recurselist } from '@util/utilities.js'
 import { MeleeAttackModel, RangedAttackModel } from '../action/index.js'
 import { IContainable, isContainable } from '../data/mixins/containable.js'
 import { ModelCollection } from '../data/model-collection.js'

--- a/src/module/pseudo-document/index.ts
+++ b/src/module/pseudo-document/index.ts
@@ -1,0 +1,32 @@
+import { GurpsModule } from '@gurps-types/gurps-module.js'
+
+import { PseudoDocumentSheet } from './pseudo-document-sheet.js'
+import { PseudoDocument } from './pseudo-document.js'
+import { TypedPseudoDocument } from './typed-pseudo-document.js'
+
+interface ActorModule extends GurpsModule {
+  dataModels: {
+    PseudoDocument: typeof PseudoDocument
+    TypedPseudoDocument: typeof TypedPseudoDocument
+  }
+  sheets: {
+    PseudoDocumentSheet: typeof PseudoDocumentSheet
+  }
+}
+
+function init() {
+  console.log('GURPS | Initializing GURPS Pseudo-Document module.')
+
+  Hooks.on('init', async () => {})
+}
+
+export const Pseudo: ActorModule = {
+  init,
+  dataModels: {
+    PseudoDocument,
+    TypedPseudoDocument,
+  },
+  sheets: {
+    PseudoDocumentSheet,
+  },
+}

--- a/src/module/pseudo-document/index.ts
+++ b/src/module/pseudo-document/index.ts
@@ -14,12 +14,7 @@ interface ActorModule extends GurpsModule {
   }
 }
 
-function init() {
-  console.log('GURPS | Initializing GURPS Pseudo-Document module.')
-
-  Hooks.on('init', async () => {})
-}
-
+function init() {}
 export const Pseudo: ActorModule = {
   init,
   dataModels: {

--- a/src/module/pseudo-document/index.ts
+++ b/src/module/pseudo-document/index.ts
@@ -15,6 +15,7 @@ interface ActorModule extends GurpsModule {
 }
 
 function init() {}
+
 export const Pseudo: ActorModule = {
   init,
   dataModels: {

--- a/src/module/pseudo-document/pseudo-document-sheet.ts
+++ b/src/module/pseudo-document/pseudo-document-sheet.ts
@@ -4,28 +4,46 @@ import { AnyObject, DeepPartial } from 'fvtt-types/utils'
 import { PseudoDocument } from './pseudo-document.js'
 
 namespace PseudoDocumentSheet {
-  export interface Configuration extends Application.Configuration {
-    document: {
-      uuid: string
-      document: foundry.abstract.Document.Any
-    }
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  export interface RenderOptions extends Application.RenderOptions {}
+
+  export interface Configuration<Doc extends PseudoDocument.Any> extends Application.Configuration {
+    document: Doc
   }
+
+  export interface RenderContext<Doc extends PseudoDocument.Any> extends Application.RenderContext {
+    document: Doc
+    fields?: Record<string, { field: foundry.data.fields.DataField.Any; value: any; name: string }>
+  }
+
+  export type DefaultOptions<Conf extends Configuration<PseudoDocument.Any>> = DeepPartial<Conf> &
+    object & {
+      document?: never
+    }
 }
 
-class PseudoDocumentSheet extends foundry.applications.api.HandlebarsApplicationMixin(Application) {
+class PseudoDocumentSheet<
+  Doc extends PseudoDocument.Any = PseudoDocument.Any,
+  RenderOptions extends PseudoDocumentSheet.RenderOptions = PseudoDocumentSheet.RenderOptions,
+  Configuration extends PseudoDocumentSheet.Configuration<Doc> = PseudoDocumentSheet.Configuration<Doc>,
+  RenderContext extends PseudoDocumentSheet.RenderContext<Doc> = PseudoDocumentSheet.RenderContext<Doc>,
+> extends foundry.applications.api.HandlebarsApplicationMixin(Application) {
   constructor(
-    options: DeepPartial<PseudoDocumentSheet.Configuration> & {
-      document: { uuid: string; document: foundry.abstract.Document.Any }
+    options: DeepPartial<Configuration> & {
+      document: Doc
     }
   ) {
     super(options)
-    this.#pseudoUuid = options.document?.uuid
-    this.#document = options.document?.document
+    this.#document = options.document.document
+    this.#pseudoDocumentType = options.document.documentName as gurps.Pseudo.Name
+    this.#pseudoDocumentId = options.document._id
   }
 
   /* ---------------------------------------- */
 
-  static override DEFAULT_OPTIONS: DeepPartial<Application.Configuration> & object = {
+  static override DEFAULT_OPTIONS: PseudoDocumentSheet.DefaultOptions<
+    PseudoDocumentSheet.Configuration<PseudoDocument.Any>
+  > = {
     id: '{id}',
     actions: {
       copyUuid: {
@@ -54,7 +72,7 @@ class PseudoDocumentSheet extends foundry.applications.api.HandlebarsApplication
    * Retrieve or register a new instance of a pseudo-document sheet.
    * @returns An existing or new instance of a sheet, or null if the pseudo-document does not have a sheet class.
    */
-  static getSheet(pseudoDocument: PseudoDocument): PseudoDocumentSheet | null {
+  static getSheet<Doc extends PseudoDocument.Any>(pseudoDocument: Doc): PseudoDocumentSheet<Doc> | null {
     const doc = pseudoDocument.document
 
     if (!PseudoDocumentSheet.#sheets.get(doc)) {
@@ -65,51 +83,38 @@ class PseudoDocumentSheet extends foundry.applications.api.HandlebarsApplication
       const Cls = pseudoDocument.metadata.sheetClass
 
       if (!Cls) return null
+      // @ts-expect-error - No idea what is going on here.
       PseudoDocumentSheet.#sheets.get(doc)?.set(pseudoDocument.uuid, new Cls({ document: pseudoDocument }))
     }
 
-    return PseudoDocumentSheet.#sheets.get(doc)?.get(pseudoDocument.uuid) || null
+    return (PseudoDocumentSheet.#sheets.get(doc)?.get(pseudoDocument.uuid) as PseudoDocumentSheet<Doc>) || null
   }
+
+  /* ---------------------------------------- */
+
+  #document: gurps.Pseudo.ParentDocument
+  #pseudoDocumentType: gurps.Pseudo.Name
+  #pseudoDocumentId: string
 
   /* ---------------------------------------- */
 
   /**
    * The pseudo-document. This can be null if a parent pseudo-document is removed.
    */
-  get pseudoDocument(): PseudoDocument | null {
-    let relative = this.document
-    const uuidParts = this.#pseudoUuid.replace(relative.uuid, '').slice(1).split('.')
-
-    for (let i = 0; i < uuidParts.length; i += 2) {
-      const dname = uuidParts[i]
-      const id = uuidParts[i + 1]
-
-      // @ts-expect-error: TODO: define the Document types better so this doesn't resolve to "never"
-      relative = relative?.getEmbeddedDocument(dname, id)
-      if (!relative) return null
-    }
-
-    return relative as unknown as PseudoDocument | null
+  get pseudoDocument(): Doc | null {
+    return (
+      // @ts-expect-error - The documentNames between Actors and Items are not mutually compatible, but the safety
+      // should still be ensured at runtime
+      (this.#document.getEmbeddedCollection(this.#pseudoDocumentType)?.get(this.#pseudoDocumentId) as Doc) ?? null
+    )
   }
 
   /* ---------------------------------------- */
 
   /**
-   * Stored uuid of this pseudo document.
-   */
-  #pseudoUuid: string
-
-  /* ---------------------------------------- */
-
-  /**
    * The parent document.
    */
-  #document: foundry.abstract.Document.Any
-
-  /**
-   * The parent document.
-   */
-  get document(): foundry.abstract.Document.Any {
+  get document(): gurps.Pseudo.ParentDocument {
     return this.#document
   }
 
@@ -121,16 +126,28 @@ class PseudoDocumentSheet extends foundry.applications.api.HandlebarsApplication
     return `${game.i18n?.localize(`DOCUMENT.${documentName}`)}: ${name ? name : id}`
   }
 
-  /* -------------------------------------------------- */
+  /* ---------------------------------------- */
+  /*  Context Preparation                     */
+  /* ---------------------------------------- */
+
+  protected override async _prepareContext(options: RenderOptions): Promise<RenderContext> {
+    const superContext = await super._prepareContext(options)
+
+    return foundry.utils.mergeObject(superContext, {
+      fields: PseudoDocument.getSchemaFields(this.pseudoDocument!),
+    }) as unknown as RenderContext
+  }
+
+  /* ---------------------------------------- */
 
   protected override _initializeApplicationOptions({
     document,
     ...options
-  }: DeepPartial<PseudoDocumentSheet.Configuration>): PseudoDocumentSheet.Configuration {
+  }: DeepPartial<PseudoDocumentSheet.Configuration<Doc>>): PseudoDocumentSheet.Configuration<Doc> {
     options = super._initializeApplicationOptions(options)
     options.uniqueId = `${this.constructor.name}-${document?.uuid?.replaceAll('.', '-')}`
 
-    return options as PseudoDocumentSheet.Configuration
+    return options as PseudoDocumentSheet.Configuration<Doc>
   }
 
   /* -------------------------------------------------- */
@@ -140,7 +157,6 @@ class PseudoDocumentSheet extends foundry.applications.api.HandlebarsApplication
     options: DeepPartial<Application.RenderOptions>
   ) {
     await super._onFirstRender(context, options)
-    // @ts-expect-error: TODO: define the Document types better so this doesn't resolve to "never"
     this.document.apps[this.id] = this
   }
 
@@ -148,7 +164,6 @@ class PseudoDocumentSheet extends foundry.applications.api.HandlebarsApplication
 
   override _onClose(options: DeepPartial<Application.RenderOptions>): void {
     super._onClose(options)
-    // @ts-expect-error: TODO: define the Document types better so this doesn't resolve to "never"
     delete this.document.apps[this.id]
   }
 
@@ -191,15 +206,16 @@ class PseudoDocumentSheet extends foundry.applications.api.HandlebarsApplication
   /**
    * Handle form submission.
    */
-  static #onSubmitForm(
+  static async #onSubmitForm(
     this: PseudoDocumentSheet,
     _event: Event | SubmitEvent,
     _form: HTMLElement,
     formData: FormDataExtended
-  ) {
+  ): Promise<void> {
     const submitData = foundry.utils.expandObject(formData.object)
 
-    this.pseudoDocument!.update(submitData as AnyObject)
+    await this.pseudoDocument!.update(submitData as AnyObject)
+    await this.render()
   }
 
   /* -------------------------------------------------- */

--- a/src/module/pseudo-document/pseudo-document.ts
+++ b/src/module/pseudo-document/pseudo-document.ts
@@ -98,7 +98,7 @@ class PseudoDocument<
   /* ---------------------------------------- */
 
   /**
-   * Gets the default new name for a PsuedoDocument
+   * Gets the default new name for a PseudoDocument
    * @param {object} context                    The context for which to create the Document name.
    * @param {string} [context.type]             The sub-type of the document
    * @param {Document|null} [context.parent]    A parent document within which the created Document should belong
@@ -366,8 +366,6 @@ class PseudoDocument<
       throw new Error('Source is not an object!')
     }
 
-    console.log('source object', source)
-
     return this.id in source
   }
 
@@ -384,7 +382,7 @@ class PseudoDocument<
     const isArray = Array.isArray(data)
     const createData = isArray ? data : [data]
 
-    const created = await this.createDocuments(createData, operation)
+    const created = await this.createDocuments(createData, { parent, ...operation })
 
     if (renderSheet && created) {
       created.forEach(pseudo => pseudo.sheet?.render({ force: true }))

--- a/src/module/pseudo-document/pseudo-document.ts
+++ b/src/module/pseudo-document/pseudo-document.ts
@@ -466,11 +466,6 @@ class PseudoDocument<
     if (!isUpdatableDocument(this.document)) throw new Error('Document does not support updates!')
 
     Object.assign(operation, { pseudo: { operation: 'delete', type: this.documentName, uuid: this.uuid } })
-    const update: Record<string, unknown> = { [`${this.fieldPath}.-=${this.id}`]: null }
-
-    if (hasMetadata(this.constructor)) {
-      PseudoDocument._configureUpdates('delete', this.document, update, operation)
-    }
 
     const deleted = await (this.constructor as typeof PseudoDocument).deleteDocuments(this.id, {
       parent: this.document as gurps.Pseudo.ParentDocument,
@@ -533,6 +528,7 @@ class PseudoDocument<
 
       if (maybeDeleted) {
         updates[`${fieldPath}.-=${id}`] = null
+        deleted.push(maybeDeleted as InstanceType<T>)
 
         if (isContainable(maybeDeleted) && maybeDeleted.contents.length > 0) {
           if (operation && operation.deleteContents) {
@@ -540,6 +536,7 @@ class PseudoDocument<
 
             allContents.forEach((doc: PseudoDocument) => {
               updates[`${doc.fieldPath}.-=${doc.id}`] = null
+              deleted.push(doc as InstanceType<T>)
             })
           } else {
             const containedBy = maybeDeleted.containedBy ?? null

--- a/src/module/pseudo-document/pseudo-document.ts
+++ b/src/module/pseudo-document/pseudo-document.ts
@@ -1,5 +1,7 @@
 import { DataModel, Document, fields } from '@gurps-types/foundry/index.js'
 import { type BaseDisplayPseudoDocument } from '@gurps-types/gurps/display-item.js'
+import { isContainable } from '@module/data/mixins/containable.js'
+import { deleteDialogWithContents } from '@module/util/delete-dialog.js'
 import { getGame, hasMetadata, isUpdatableDocument } from '@module/util/guards.js'
 import { systemPath } from '@module/util/misc.js'
 import { AnyObject, Identity, InexactPartial } from 'fvtt-types/utils'
@@ -11,9 +13,11 @@ import { PseudoDocumentSheet } from './pseudo-document-sheet.js'
 class PseudoDocument<
   Schema extends PseudoDocument.Schema = PseudoDocument.Schema,
   Parent extends DataModel.Any = DataModel.Any,
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-  ExtraConstructorOptions extends AnyObject = {},
+  ExtraConstructorOptions extends PseudoDocument.ConstructorOptions = PseudoDocument.ConstructorOptions,
 > extends DataModel<Schema, Parent> {
+  // @ts-expect-error: No idea what is going on here
+  declare collection: ModelCollection<this>
+
   constructor(...args: DataModel.ConstructorArgs<Schema, Parent, ExtraConstructorOptions>) {
     super(...args)
   }
@@ -31,22 +35,6 @@ class PseudoDocument<
     }
   }
 
-  protected get static() {
-    return this.constructor as typeof PseudoDocument
-  }
-
-  /* ---------------------------------------- */
-
-  get metadata(): PseudoDocument.Metadata<gurps.Pseudo.Name> {
-    return this.static.metadata
-  }
-
-  /* ---------------------------------------- */
-
-  static override defineSchema(): PseudoDocument.Schema {
-    return pseudoDocumentSchema()
-  }
-
   /* ---------------------------------------- */
 
   static override LOCALIZATION_PREFIXES: string[] = ['DOCUMENT']
@@ -57,6 +45,12 @@ class PseudoDocument<
    * Template for {@link createDialog}.
    */
   static CREATE_TEMPLATE = systemPath('templates/pseudo-document/base-create-dialog.hbs')
+
+  /* ---------------------------------------- */
+
+  protected get static() {
+    return this.constructor as typeof PseudoDocument
+  }
 
   /* ---------------------------------------- */
 
@@ -78,6 +72,94 @@ class PseudoDocument<
 
   /* ---------------------------------------- */
 
+  get metadata(): PseudoDocument.Metadata<gurps.Pseudo.Name> {
+    return this.static.metadata
+  }
+
+  /* ---------------------------------------- */
+
+  static override defineSchema(): PseudoDocument.Schema {
+    return pseudoDocumentSchema()
+  }
+
+  /* ---------------------------------------- */
+
+  static getSchemaFields(
+    pseudo: PseudoDocument.Any
+  ): Record<string, { field: foundry.data.fields.DataField.Any; value: any; name: string }> {
+    return Object.fromEntries(
+      Object.keys(pseudo.schema.fields).map(key => [
+        key,
+        { field: pseudo.schema.getField(key)!, value: pseudo[key as keyof typeof pseudo], name: key },
+      ])
+    )
+  }
+
+  /* ---------------------------------------- */
+
+  /**
+   * Gets the default new name for a PsuedoDocument
+   * @param {object} context                    The context for which to create the Document name.
+   * @param {string} [context.type]             The sub-type of the document
+   * @param {Document|null} [context.parent]    A parent document within which the created Document should belong
+   * @param {string|null} [context.pack]        A compendium pack within which the Document should be created
+   * @returns {string}
+   */
+  static defaultName({
+    type,
+    parent,
+    pack,
+  }: {
+    type?: string
+    parent?: gurps.Pseudo.ParentDocument | null
+    pack?: string | null
+  } = {}): string {
+    const documentName = this.metadata.documentName
+
+    let collection: foundry.utils.Collection.Any | undefined
+
+    // @ts-expect-error: Document.prototype.getEmbeddedCollection documentName is typed as `never`, but subclasses override it.
+    if (parent) collection = parent.getEmbeddedCollection(documentName)
+    else if (pack) collection = getGame().packs.get(pack)?.index
+    else collection = getGame().collections.get(documentName)
+    const takenNames = new Set()
+
+    if (!collection) {
+      console.warn(
+        `GURPS | PseudoDocument.defaultName was unable to find a collection for document name '${documentName}'!`
+      )
+
+      return 'Document'
+    }
+
+    for (const document of collection) takenNames.add((document as PseudoDocument.Any).name)
+    let baseNameKey = this.metadata.label
+
+    if (type && 'documentConfig' in this && typeof this.documentConfig === 'object' && this.documentConfig !== null) {
+      const types = this.documentConfig as Record<string, gurps.Pseudo.ConfigEntry<any>>
+
+      if (type in types) {
+        const typeNameKey = types[type]?.label
+
+        if (typeNameKey && getGame().i18n.has(typeNameKey)) baseNameKey = typeNameKey
+      } else {
+        console.warn(
+          `GURPS | The type '${type}' is not valid for a '${this.metadata.documentName}' pseudo-document! Valid types are: ${Object.keys(types).join(', ')}`
+        )
+      }
+    }
+
+    const baseName = getGame().i18n.localize(baseNameKey)
+    let name = baseName
+    let index = 1
+
+    while (takenNames.has(name)) name = `${baseName} (${++index})`
+
+    return name
+  }
+
+  /* ---------------------------------------- */
+
   /**
    * The uuid of this document.
    */
@@ -88,6 +170,8 @@ class PseudoDocument<
 
     return [parent.uuid, this.documentName, this.id].join('.')
   }
+
+  /* ---------------------------------------- */
 
   /* ---------------------------------------- */
 
@@ -120,20 +204,19 @@ class PseudoDocument<
    * Reference to the sheet of this pseudo-document, registered in a static map.
    * A pseudo-document is temporary, unlike regular documents, so the relation here
    * is not one-to-one.
-   * @type {PseudoDocumentSheet | null}
    */
-  get sheet() {
-    return PseudoDocumentSheet.getSheet(this)
+  get sheet(): PseudoDocumentSheet | null {
+    return PseudoDocumentSheet.getSheet(this as PseudoDocument.Any)
   }
 
   /* ---------------------------------------- */
 
-  toDisplayItem(): BaseDisplayPseudoDocument {
-    return {
-      id: this.id,
-      uuid: this.uuid,
-      documentName: this.documentName,
-    }
+  protected override _configure(options: DataModel.ConfigureOptions & ExtraConstructorOptions) {
+    super._configure(options)
+    Object.defineProperty(this, 'collection', {
+      value: options.collection ?? null,
+      writable: false,
+    })
   }
 
   /* ---------------------------------------- */
@@ -158,6 +241,33 @@ class PseudoDocument<
   /*   Instance Methods                       */
   /* ---------------------------------------- */
 
+  getRelativeUUID(relative: PseudoDocument.Any | gurps.Pseudo.ParentDocument): string {
+    // This PseudoDocument is a sibling of the relative Document.
+    if (this.collection === relative.collection) return `.${this.id}`
+
+    // This PseudoDocument may be a descendant of the relative Document, so walk up the hierarchy to check.
+    const parts = [this.documentName, this.id]
+    let parent: DataModel.Any = this.parent
+
+    while (parent) {
+      if (parent === relative) break
+
+      // Skip intermediate non-Document/PseudoDocument data models
+      if ('documentName' in parent)
+        parts.unshift((parent as PseudoDocument).documentName, (parent as PseudoDocument).id)
+
+      parent = parent.parent
+    }
+
+    // The relative Document was a parent or grandparent of this one.
+    if (parent === relative) return `.${parts.join('.')}`
+
+    // The relative Document was unrelated to this one.
+    return this.uuid
+  }
+
+  /* ---------------------------------------- */
+
   /**
    * Retrieve an embedded pseudo-document.
    */
@@ -166,17 +276,7 @@ class PseudoDocument<
     id: string,
     { invalid = false, strict = false }: { invalid?: boolean; strict?: boolean } = {}
   ): PseudoDocument | null {
-    const embeds = this.metadata.embedded ?? {}
-
-    if (embeddedName in embeds) {
-      const path = embeds[embeddedName]
-
-      return (
-        (foundry.utils.getProperty(this, path) as ModelCollection<PseudoDocument>).get(id, { invalid, strict }) ?? null
-      )
-    }
-
-    return null
+    return this.getEmbeddedCollection(embeddedName).get(id, { invalid, strict }) ?? null
   }
 
   /* ---------------------------------------- */
@@ -184,7 +284,7 @@ class PseudoDocument<
   /**
    * Obtain the embedded collection of a given pseudo-document type.
    */
-  getEmbeddedPseudoDocumentCollection(embeddedName: string): ModelCollection {
+  getEmbeddedCollection(embeddedName: string): ModelCollection<PseudoDocument> {
     const collectionPath = this.metadata.embedded[embeddedName]
 
     if (!collectionPath) {
@@ -193,7 +293,7 @@ class PseudoDocument<
       )
     }
 
-    return foundry.utils.getProperty(this, collectionPath) as ModelCollection
+    return foundry.utils.getProperty(this, collectionPath) as ModelCollection<PseudoDocument>
   }
 
   /* ---------------------------------------- */
@@ -208,6 +308,43 @@ class PseudoDocument<
     }
   }
 
+  /* ---------------------------------------- */
+
+  /**
+   * A helper function to handle obtaining the relevant PseudoDocument from dropped data provided via a DataTransfer event.
+   * The dropped data must have a UUID.
+   *
+   * @param   data The data object extracted from a DataTransfer event.
+   * @returns      The resolved PseudoDocument.
+   * @throws If a Document could not be retrieved from the provided data.
+   */
+  static async fromDropData(data: { uuid: string; type: string }): Promise<PseudoDocument> {
+    const pseudo = (await foundry.utils.fromUuid(data.uuid as string)) as PseudoDocument | null
+
+    // Ensure that we retrieved a valid document
+    if (!pseudo) {
+      throw new Error('Failed to resolve PseudoDocument from provided DragData. A valid UUID must be provided.')
+    }
+
+    if (pseudo.documentName !== this.metadata.documentName) {
+      throw new Error(`Invalid Document type '${pseudo.documentName}' provided to ${this.name}.fromDropData.`)
+    }
+
+    return pseudo
+  }
+
+  /* ---------------------------------------- */
+
+  toDisplayItem(): BaseDisplayPseudoDocument {
+    return {
+      id: this.id,
+      uuid: this.uuid,
+      documentName: this.documentName,
+    }
+  }
+
+  /* ---------------------------------------- */
+  /*  CRUD Handlers                           */
   /* ---------------------------------------- */
 
   /**
@@ -229,6 +366,8 @@ class PseudoDocument<
       throw new Error('Source is not an object!')
     }
 
+    console.log('source object', source)
+
     return this.id in source
   }
 
@@ -238,18 +377,37 @@ class PseudoDocument<
    * Create a new instance of this pseudo-document.
    * @returns a promise that resolves to the created pseudo-document instance, or `undefined` if it cannot be retrieved.
    */
-  static async create<T extends typeof PseudoDocument>(
-    data: fields.SchemaField.CreateData<PseudoDocument.Schema>,
+  static async create(
+    data: fields.SchemaField.CreateData<PseudoDocument.Schema> | fields.SchemaField.CreateData<PseudoDocument.Schema>[],
     { parent, renderSheet = true, ...operation }: Partial<gurps.Pseudo.CreateOperation>
-  ): Promise<InstanceType<T> | undefined> {
-    if (!parent) {
-      throw new Error('A parent document must be specified for the creation of a pseudo-document!')
+  ) {
+    const isArray = Array.isArray(data)
+    const createData = isArray ? data : [data]
+
+    const created = await this.createDocuments(createData, operation)
+
+    if (renderSheet && created) {
+      created.forEach(pseudo => pseudo.sheet?.render({ force: true }))
     }
 
-    const id: string =
-      operation.keepId && foundry.data.validators.isValidId((data._id as string | undefined) ?? '')
-        ? (data._id as string)
-        : foundry.utils.randomID()
+    return isArray ? created : created.shift()
+  }
+
+  /* ---------------------------------------- */
+
+  static async createDocuments<T extends typeof PseudoDocument>(
+    data: fields.SchemaField.CreateData<PseudoDocument.Schema> | fields.SchemaField.CreateData<PseudoDocument.Schema>[],
+    { parent, pack, ...operation }: Partial<gurps.Pseudo.CreateOperation>
+  ): Promise<InstanceType<T>[]> {
+    if (!parent) {
+      console.error('A parent document must be specified for the creation of pseudo-documents!')
+
+      return []
+    }
+
+    data = Array.isArray(data) ? data : [data]
+
+    const updates: Record<string, any> = {}
 
     const fieldPath = (parent.system?.constructor as unknown as gurps.MetadataOwner).metadata.embedded?.[
       this.metadata.documentName
@@ -258,25 +416,148 @@ class PseudoDocument<
     if (!fieldPath) {
       const type = 'type' in parent ? parent.type : 'base'
 
-      throw new Error(`A ${parent.documentName} of type '${type}' does not support ${this.metadata.documentName}!`)
+      console.error(`A ${parent.documentName} of type '${type}' does not support ${this.metadata.documentName}!`)
+
+      return []
     }
 
-    const update = { [`${fieldPath}.${id}`]: { ...data, _id: id } }
+    for (const dataEntry of data) {
+      const _id: string =
+        operation.keepId && foundry.data.validators.isValidId((dataEntry._id as string | undefined) ?? '')
+          ? (dataEntry._id as string)
+          : foundry.utils.randomID()
 
-    this._configureUpdates('create', parent, update, operation)
+      dataEntry._id = _id
 
-    await parent.update(update, operation)
+      if (!('name' in dataEntry) || typeof dataEntry.name !== 'string' || dataEntry.name.trim() === '') {
+        const type = 'type' in dataEntry ? String(dataEntry.type) : undefined
 
-    // HACK: There is really no cleaner way to define this.
-    const pseudo = (
-      parent as {
-        getEmbeddedDocument(name: string, id: string, options: object): InstanceType<T> | undefined
+        const defaultName = this.defaultName({ type, parent, pack })
+
+        dataEntry.name = defaultName
       }
-    ).getEmbeddedDocument(this.metadata.documentName, id, {})
 
-    if (renderSheet && pseudo) pseudo.sheet?.render({ force: true })
+      updates[`${fieldPath}.${_id}`] = { ...dataEntry, _id }
+    }
 
-    return pseudo
+    this._configureUpdates('create', parent, updates, operation)
+
+    await parent.update(updates, operation)
+
+    const created: InstanceType<T>[] = []
+
+    for (const dataEntry of data) {
+      const maybeCreated = (parent as any).getEmbeddedDocument(this.metadata.documentName, dataEntry._id as string, {})
+
+      if (maybeCreated) created.push(maybeCreated as InstanceType<T>)
+    }
+
+    return created
+  }
+
+  /* ---------------------------------------- */
+
+  /**
+   * Delete this pseudo-document.
+   * @returns a promise that resolves to the updated document.
+   */
+  async delete(operation?: PseudoDocument.DeleteOperation): Promise<this | undefined> {
+    operation ??= {}
+
+    if (!this.isSource) throw new Error('You cannot delete a non-source pseudo-document!')
+    if (!isUpdatableDocument(this.document)) throw new Error('Document does not support updates!')
+
+    Object.assign(operation, { pseudo: { operation: 'delete', type: this.documentName, uuid: this.uuid } })
+    const update: Record<string, unknown> = { [`${this.fieldPath}.-=${this.id}`]: null }
+
+    if (hasMetadata(this.constructor)) {
+      PseudoDocument._configureUpdates('delete', this.document, update, operation)
+    }
+
+    const deleted = await (this.constructor as typeof PseudoDocument).deleteDocuments(this.id, {
+      parent: this.document as gurps.Pseudo.ParentDocument,
+      ...operation,
+    })
+
+    return (deleted?.shift() as this) ?? undefined
+  }
+
+  /* ---------------------------------------- */
+
+  /**
+   * Present a Dialog form to confirm deletion of this PseudoDocument.
+   * @param [options] Additional options passed to `DialogV2.confirm`
+   * @param [operation]  Document deletion options.
+   * @returns A Promise that resolves to the deleted PseudoDocument
+   */
+  async deleteDialog(
+    options?: InexactPartial<foundry.applications.api.DialogV2.ConfirmConfig>,
+    operation?: PseudoDocument.DeleteOperation
+  ): Promise<this | false | null | undefined> {
+    return (await deleteDialogWithContents.call(
+      this as PseudoDocument.Any,
+      options,
+      operation as any
+    )) as unknown as Promise<this | false | null | undefined>
+  }
+
+  /* ---------------------------------------- */
+
+  static async deleteDocuments<T extends typeof PseudoDocument>(
+    ids: string | Array<string>,
+    { parent, ...operation }: Partial<PseudoDocument.DeleteOperation>
+  ): Promise<InstanceType<T>[]> {
+    if (!parent) {
+      console.error('A parent document must be specified for the deletion of pseudo-documents!')
+
+      return []
+    }
+
+    ids = Array.isArray(ids) ? ids : [ids]
+
+    const fieldPath = (parent.system?.constructor as unknown as gurps.MetadataOwner).metadata.embedded?.[
+      this.metadata.documentName
+    ]
+
+    if (!fieldPath) {
+      const type = 'type' in parent ? parent.type : 'base'
+
+      console.error(`A ${parent.documentName} of type '${type}' does not support ${this.metadata.documentName}!`)
+
+      return []
+    }
+
+    const updates: Record<string, any> = {}
+    const deleted: InstanceType<T>[] = []
+
+    for (const id of ids) {
+      const maybeDeleted = (parent as any).getEmbeddedDocument(this.metadata.documentName, id, {})
+
+      if (maybeDeleted) {
+        updates[`${fieldPath}.-=${id}`] = null
+
+        if (isContainable(maybeDeleted) && maybeDeleted.contents.length > 0) {
+          if (operation && operation.deleteContents) {
+            const allContents = maybeDeleted.allContents as PseudoDocument[]
+
+            allContents.forEach((doc: PseudoDocument) => {
+              updates[`${doc.fieldPath}.-=${doc.id}`] = null
+            })
+          } else {
+            const containedBy = maybeDeleted.containedBy ?? null
+            const contents = maybeDeleted.contents as PseudoDocument[]
+
+            contents.forEach((doc: PseudoDocument) => {
+              updates[`${doc.fieldPath}.${doc.id}.containedBy`] = containedBy
+            })
+          }
+        }
+      }
+    }
+
+    await (parent as any).update(updates, operation)
+
+    return deleted
   }
 
   /* ---------------------------------------- */
@@ -310,7 +591,7 @@ class PseudoDocument<
 
     if (!result) return
 
-    return this.create({ ...data, ...result }, { parent, ...operation })
+    return this.create({ ...data, ...result }, { parent, ...operation }) as InstanceType<T> | undefined
   }
 
   /* ---------------------------------------- */
@@ -333,67 +614,6 @@ class PseudoDocument<
    * the choices for a select field based on the parent document.
    */
   protected static _createDialogRenderCallback(_event: Event, _dialog: foundry.applications.api.DialogV2): void {}
-
-  /* ---------------------------------------- */
-
-  /**
-   * Delete this pseudo-document.
-   * @returns a promise that resolves to the updated document.
-   */
-  async delete(
-    operation?: Document.Database.DeleteOperation<foundry.abstract.types.DatabaseDeleteOperation<Document.Any>>
-  ): Promise<Document.Any | undefined> {
-    operation ??= {}
-
-    if (!this.isSource) throw new Error('You cannot delete a non-source pseudo-document!')
-    if (!isUpdatableDocument(this.document)) throw new Error('Document does not support updates!')
-
-    Object.assign(operation, { pseudo: { operation: 'delete', type: this.documentName, uuid: this.uuid } })
-    const update = { [`${this.fieldPath}.-=${this.id}`]: null }
-
-    if (hasMetadata(this.constructor)) {
-      PseudoDocument._configureUpdates('delete', this.document, update, operation)
-    }
-
-    return this.document.update(update, operation)
-  }
-
-  /**
-   * Present a Dialog form to confirm deletion of this PseudoDocument.
-   * @param [options] Additional options passed to `DialogV2.confirm`
-   * @param [operation]  Document deletion options.
-   * @returns A Promise that resolves to the deleted PseudoDocument
-   */
-  async deleteDialog(
-    options?: InexactPartial<foundry.applications.api.DialogV2.ConfirmConfig>,
-    operation?: PseudoDocument.DeleteOperation
-  ): Promise<this | false | null | undefined> {
-    let content = options?.content
-
-    const type = getGame().i18n.localize(this.metadata.label)
-    const name = ('name' in this ? this.name : null) as string | null
-
-    if (!content) {
-      const question = getGame().i18n.localize('AreYouSure')
-      const warning = getGame().i18n.format('SIDEBAR.DeleteWarning', { type })
-
-      content = `<p><strong>${question}</strong> ${warning}</p>`
-    }
-
-    return foundry.applications.api.DialogV2.confirm(
-      foundry.utils.mergeObject(
-        {
-          content,
-          yes: { callback: () => this.delete(operation) },
-          window: {
-            icon: 'fa-solid fa-trash',
-            title: `${getGame().i18n.format('DOCUMENT.Delete', { type })}: ${name}`,
-          },
-        },
-        options
-      ) as foundry.applications.api.DialogV2.ConfirmConfig
-    ) as Promise<this | false | null | undefined>
-  }
 
   /* ---------------------------------------- */
 
@@ -425,10 +645,22 @@ class PseudoDocument<
    */
   async update(
     change: AnyObject = {},
-    operation: Document.Database.UpdateOperation<foundry.abstract.types.DatabaseUpdateOperation> = {}
+    operation: PseudoDocument.UpdateOperation = {}
   ): Promise<gurps.UpdatableDocument> {
     if (!this.isSource) throw new Error('You cannot update a non-source pseudo-document!')
     if (!isUpdatableDocument(this.document)) throw new Error('Document does not support updates!')
+
+    // Do not update the _id of the pseudo-document, as it is used to track the document in the parent source data.
+    if ('_id' in change) {
+      console.warn('The _id of a pseudo-document cannot be updated! Ignoring _id change.', {
+        attemptedId: change._id,
+        documentId: this.id,
+      })
+
+      const { _id, ...rest } = change
+
+      change = rest
+    }
 
     const path = [this.fieldPath, this.id].join('.')
     const update = { [path]: change }
@@ -451,7 +683,7 @@ class PseudoDocument<
    */
   static _configureUpdates(
     _action: 'create' | 'update' | 'delete',
-    _document: Document.Any,
+    _document: gurps.Pseudo.ParentDocument,
     _update: AnyObject,
     _operation: Document.Database.UpdateOperation<foundry.abstract.types.DatabaseUpdateOperation>
   ) {}
@@ -502,9 +734,17 @@ namespace PseudoDocument {
 
   /* ---------------------------------------- */
 
-  export type DeleteOperation = Document.Database.DeleteOperation<
-    foundry.abstract.types.DatabaseDeleteOperation<Document.Any>
-  >
+  export type ConstructorOptions = AnyObject & {
+    collection?: ModelCollection<PseudoDocument>
+  }
+
+  /* ---------------------------------------- */
+
+  export interface DeleteOperation extends Document.Database.DeleteOperation<
+    foundry.abstract.types.DatabaseDeleteOperation<gurps.Pseudo.ParentDocument>
+  > {
+    deleteContents?: boolean
+  }
 
   /* ---------------------------------------- */
 
@@ -527,6 +767,10 @@ namespace PseudoDocument {
   export interface AnyConstructor extends Identity<typeof AnyPseudoDocument> {}
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   export interface ConcreteConstructor extends Identity<typeof ConcretePseudoDocument> {}
+
+  /* ---------------------------------------- */
+
+  export type UpdateOperation = Document.Database.UpdateOperation<foundry.abstract.types.DatabaseUpdateOperation>
 }
 
 /* ---------------------------------------- */

--- a/src/module/pseudo-document/typed-pseudo-document.ts
+++ b/src/module/pseudo-document/typed-pseudo-document.ts
@@ -6,7 +6,6 @@ import { PseudoDocument, pseudoDocumentSchema } from './pseudo-document.js'
 
 /* ---------------------------------------- */
 
-// @ts-expect-error - Polymorphic static create return type is incompatible with base class signature, this is a TS limitation
 class TypedPseudoDocument<
   DocumentName extends gurps.Pseudo.WithTypes = gurps.Pseudo.WithTypes,
   Schema extends TypedPseudoDocument.Schema = TypedPseudoDocument.Schema,
@@ -175,7 +174,11 @@ namespace TypedPseudoDocument {
   /* ---------------------------------------- */
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  declare class ConcreteTypedPseudoDocument extends TypedPseudoDocument<any, DataSchema, DataModel.Any> {}
+  declare class ConcreteTypedPseudoDocument extends TypedPseudoDocument<
+    gurps.Pseudo.WithTypes,
+    DataSchema,
+    DataModel.Any
+  > {}
 
   /* ---------------------------------------- */
 

--- a/src/module/util/delete-dialog.ts
+++ b/src/module/util/delete-dialog.ts
@@ -1,0 +1,72 @@
+import { Document } from '@gurps-types/foundry/index.js'
+import { isContainable } from '@module/data/mixins/containable.js'
+import { PseudoDocument } from '@module/pseudo-document/pseudo-document.js'
+import { InexactPartial } from 'fvtt-types/utils'
+
+import { getGame } from './guards.js'
+
+type DeleteOperationFor<Doc extends Document.Any | PseudoDocument.Any> =
+  Doc extends Document<infer Type, infer _Schema, infer _Parent>
+    ? Document.Database.DeleteOperationForName<Type>
+    : PseudoDocument.DeleteOperation
+
+/**
+ * Present a Dialog form to confirm deletion of this PseudoDocument or Document.
+ * @param [options] Additional options passed to `DialogV2.confirm`
+ * @param [operation]  Document deletion options.
+ * @returns A Promise that resolves to the deleted PseudoDocument
+ */
+export async function deleteDialogWithContents<Doc extends Document.Any | PseudoDocument.Any>(
+  this: Doc,
+  options?: InexactPartial<foundry.applications.api.DialogV2.ConfirmConfig>,
+  operation?: DeleteOperationFor<Doc>
+): Promise<Doc | false | null | undefined> {
+  let content = options?.content
+
+  const documentName = getGame().i18n.localize(`DOCUMENT.${this.documentName}`)
+  const name = ('name' in this ? this.name : null) as string | null
+
+  if (!content) {
+    const question = getGame().i18n.localize('AreYouSure')
+    const warning = getGame().i18n.format('SIDEBAR.DeleteWarning', { documentName })
+
+    content = `<p><strong>${question}</strong> ${warning}</p>`
+  }
+
+  if (isContainable(this)) {
+    const contentsCount = this.allContents.length
+
+    if (contentsCount > 0) {
+      content += `<label>
+          <input type="checkbox" name="deleteContents">
+          ${game.i18n?.format('GURPS.item.deleteContents', { count: contentsCount.toString() })}
+          </label>`
+    }
+  }
+
+  let title = `${getGame().i18n.format('DOCUMENT.Delete', { type: documentName })}`
+
+  if (name) title += `: ${name}`
+
+  return foundry.applications.api.DialogV2.confirm(
+    foundry.utils.mergeObject(
+      {
+        content,
+        yes: {
+          callback: async (event: PointerEvent | SubmitEvent) => {
+            const deleteContents = (
+              (event.currentTarget as HTMLElement).querySelector('[name="deleteContents"]') as HTMLInputElement
+            )?.checked
+
+            await this.delete({ ...operation, deleteContents } as any)
+          },
+        },
+        window: {
+          icon: 'fa-solid fa-trash',
+          title,
+        },
+      },
+      options
+    ) as foundry.applications.api.DialogV2.ConfirmConfig
+  ) as Promise<Doc | false | null | undefined>
+}

--- a/src/module/util/delete-dialog.ts
+++ b/src/module/util/delete-dialog.ts
@@ -39,7 +39,7 @@ export async function deleteDialogWithContents<Doc extends Document.Any | Pseudo
     if (contentsCount > 0) {
       content += `<label>
           <input type="checkbox" name="deleteContents">
-          ${game.i18n?.format('GURPS.item.deleteContents', { count: contentsCount.toString() })}
+          ${getGame().i18n.format('GURPS.item.deleteContents', { count: contentsCount.toString() })}
           </label>`
     }
   }

--- a/src/types/gurps.d.ts
+++ b/src/types/gurps.d.ts
@@ -261,6 +261,21 @@ declare global {
       interface CreateOperation extends foundry.abstract.types.DatabaseCreateOperation {
         parent: Pseudo.ParentDocument
       }
+
+      /* ---------------------------------------- */
+
+      /**
+       * The creation data type for a pseudo-document embedded in a parent document. Derived from the
+       * pseudo-document's DataModel schema so that callers get field-level type checking on create data.
+       */
+      type EmbeddedCreateData<
+        ParentType extends keyof PseudoDocumentConfig.Embeds,
+        EmbeddedName extends keyof PseudoDocumentConfig.Embeds[ParentType],
+      > = PseudoDocumentConfig.Embeds[ParentType][EmbeddedName] extends foundry.abstract.DataModel.Any
+        ? foundry.abstract.DataModel.CreateData<
+            foundry.abstract.DataModel.SchemaOf<PseudoDocumentConfig.Embeds[ParentType][EmbeddedName]>
+          >
+        : AnyObject
     }
   }
 


### PR DESCRIPTION
This is PR 2/4 of my large set of changes. This PR:
- Refactors PseudoDocument, ModelCollection, and CollectionField, hopefully making the code easier to read and understand.
- Introduces the `pseudoCollections` property for Actors and Items which allows easier access to PseudoDocument collections on an Item without needing to know what system path the collection is stored under.
- Introduces generic creation, edit, and deletion event handlers for the base Actor sheet, which work for both built in FoundryVTT documents like Actors and Items, and Pseudo-Documents, using the dataset variables `documentName`, `type`, and `carried` (for Items only. If we ever need another special case, I would consider changing this to `extraData` or something like that.

Due to some inter-dependencies between this PR and PR 4/4, Actor migration currently doesn't work properly in PRs 2/4 and 3/4. I can move things around to patch that, but the end result does in fact work, and I'd like to keep the scope as clean as I can manage for each.

**Note**: Claude Code was used to split the larger branch into 4 more digestible chunks, but the code within is all written by me, save for some auto-completed comments.