### PR TITLE
0.18 Fixes for Foundry v14

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -583,7 +583,8 @@ const SINGLE_QUOTE = "'"
  * @returns {string}
  */
 export function quotedAttackName(item) {
-  let name = !!item.mode ? item.name + ' (' + item.mode + ')' : (item.name ?? '')
+  const baseName = item.name ?? ''
+  let name = baseName && item.mode ? baseName + ' (' + item.mode + ')' : baseName
   if (name.includes(DOUBLE_QUOTE)) {
     // use single quotes
     name = name.replace(/'/g, "\\'") // Escape single quotes

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -583,7 +583,7 @@ const SINGLE_QUOTE = "'"
  * @returns {string}
  */
 export function quotedAttackName(item) {
-  let name = !!item.mode ? item.name + ' (' + item.mode + ')' : item.name
+  let name = !!item.mode ? item.name + ' (' + item.mode + ')' : (item.name ?? '')
   if (name.includes(DOUBLE_QUOTE)) {
     // use single quotes
     name = name.replace(/'/g, "\\'") // Escape single quotes

--- a/module/actor/actor-importer.js
+++ b/module/actor/actor-importer.js
@@ -227,13 +227,9 @@ export class ActorImporter {
 
     console.log('Starting commit')
 
-    let deletes = Object.fromEntries(Object.entries(commit).filter(([key, _value]) => key.includes('.-=')))
-    let adds = Object.fromEntries(Object.entries(commit).filter(([key, _value]) => !key.includes('.-=')))
-
     try {
       this.ignoreRender = true
-      await this.actor.internalUpdate(deletes, { diff: true })
-      await this.actor.internalUpdate(adds, { diff: false })
+      await this.actor.internalUpdate(commit)
       // This has to be done after everything is loaded
       await this.actor.postImport()
       this.actor._forceRender()
@@ -456,13 +452,9 @@ export class ActorImporter {
     }
     console.log('Starting commit')
 
-    let deletes = Object.fromEntries(Object.entries(commit).filter(([key, _value]) => key.includes('.-=')))
-    let adds = Object.fromEntries(Object.entries(commit).filter(([key, _value]) => !key.includes('.-=')))
-
     try {
       this.ignoreRender = true
-      await this.actor.internalUpdate(deletes, { diff: false })
-      await this.actor.internalUpdate(adds, { diff: false })
+      await this.actor.internalUpdate(commit)
       // This has to be done after everything is loaded
       await this.actor.postImport()
       this.actor._forceRender()
@@ -676,8 +668,7 @@ export class ActorImporter {
       console.log(this)
     }
     return {
-      'system.-=traits': null,
-      'system.traits': ts,
+      'system.traits': _replace(ts),
     }
   }
 
@@ -707,8 +698,7 @@ export class ActorImporter {
     }
 
     return {
-      'system.-=ads': null,
-      'system.ads': this.foldList(list),
+      'system.ads': _replace(this.foldList(list)),
     }
   }
 
@@ -783,8 +773,7 @@ export class ActorImporter {
     }
 
     return {
-      'system.-=skills': null,
-      'system.skills': this.foldList(temp),
+      'system.skills': _replace(this.foldList(temp)),
     }
   }
 
@@ -845,8 +834,7 @@ export class ActorImporter {
     }
 
     return {
-      'system.-=spells': null,
-      'system.spells': this.foldList(temp),
+      'system.spells': _replace(this.foldList(temp)),
     }
   }
 
@@ -888,14 +876,13 @@ export class ActorImporter {
             let old = this._findElementIn('melee', false, m.name, m.mode)
             this._migrateOtfsAndNotes(old, m, readXmlText(j2.vtt_notes))
 
-            GURPS.put(melee, m, index++)
+            GURPS.put(melee, { ...m }, index++)
           }
         }
       }
     }
     return {
-      'system.-=melee': null,
-      'system.melee': melee,
+      'system.melee': _replace(melee),
     }
   }
 
@@ -948,14 +935,13 @@ export class ActorImporter {
             let old = this._findElementIn('ranged', false, r.name, r.mode)
             this._migrateOtfsAndNotes(old, r, readXmlText(j2.vtt_notes))
 
-            GURPS.put(ranged, r, index++)
+            GURPS.put(ranged, { ...r }, index++)
           }
         }
       }
     }
     return {
-      'system.-=ranged': null,
-      'system.ranged': ranged,
+      'system.ranged': _replace(ranged),
     }
   }
 
@@ -996,8 +982,7 @@ export class ActorImporter {
       if (!!t.save) temp.push(t)
     })
     return {
-      'system.-=notes': null,
-      'system.notes': this.foldList(temp),
+      'system.notes': _replace(this.foldList(temp)),
     }
   }
 
@@ -1120,8 +1105,8 @@ export class ActorImporter {
       // After retrieve all relevant data
       // Lets remove equipments now
       await this.actor.internalUpdate({
-        'system.equipment.-=carried': null,
-        'system.equipment.-=other': null,
+        'system.equipment.carried': _del,
+        'system.equipment.other': _del,
       })
     }
 
@@ -1136,7 +1121,7 @@ export class ActorImporter {
       let parent = null
       if (!!eqt.parentuuid) {
         parent = temp.find(e => e.uuid === eqt.parentuuid)
-        if (!!parent) GURPS.put(parent.contains, eqt)
+        if (!!parent) GURPS.put(parent.contains, { ...eqt })
         else eqt.parentuuid = '' // Can't find a parent, so put it in the top list
       }
       await this._updateItemContains(eqt, parent)
@@ -1152,13 +1137,12 @@ export class ActorImporter {
     for (const eqt of temp) {
       await Equipment.calc(eqt)
       if (!eqt.parentuuid) {
-        if (eqt.carried) GURPS.put(equipment.carried, eqt, cindex++)
-        else GURPS.put(equipment.other, eqt, oindex++)
+        if (eqt.carried) GURPS.put(equipment.carried, { ...eqt }, cindex++)
+        else GURPS.put(equipment.other, { ...eqt }, oindex++)
       }
     }
     return {
-      'system.-=equipment': null,
-      'system.equipment': equipment,
+      'system.equipment': _replace(equipment),
     }
   }
 
@@ -1301,7 +1285,7 @@ export class ActorImporter {
 
     let prot = {}
     let index = 0
-    temp.forEach(it => GURPS.put(prot, it, index++))
+    temp.forEach(it => GURPS.put(prot, { ...it }, index++))
 
     let saveprot = false
     if (!!data.lastImport && !!data.additionalresources.bodyplan && bodyplan != data.additionalresources.bodyplan) {
@@ -1316,8 +1300,7 @@ export class ActorImporter {
     if (saveprot) return {}
     else
       return {
-        'system.-=hitlocations': null,
-        'system.hitlocations': prot,
+        'system.hitlocations': _replace(prot),
         'system.additionalresources.bodyplan': bodyplan,
       }
   }
@@ -1360,12 +1343,11 @@ export class ActorImporter {
         let w = readXmlText(j.written)
         let p = readXmlText(j.points)
         let l = new Language(n, s, w, p)
-        GURPS.put(langs, l, index++)
+        GURPS.put(langs, { ...l }, index++)
       }
     }
     return {
-      'system.-=languages': null,
-      'system.languages': langs,
+      'system.languages': _replace(langs),
     }
   }
 
@@ -1384,12 +1366,11 @@ export class ActorImporter {
         let mod = m.trim().substring(0, i)
         let sit = m.trim().substring(i + 1)
         let r = new Reaction(mod, sit)
-        GURPS.put(rs, r, index++)
+        GURPS.put(rs, { ...r }, index++)
       }
     })
     return {
-      'system.-=reactions': null,
-      'system.reactions': rs,
+      'system.reactions': _replace(rs),
     }
   }
 
@@ -1420,13 +1401,12 @@ export class ActorImporter {
         cm = e.move
         cd = e.dodge
       }
-      GURPS.put(es, e, index++)
+      GURPS.put(es, { ...e }, index++)
     }
     return {
       'system.currentmove': cm,
       'system.currentdodge': cd,
-      'system.-=encumbrance': null,
-      'system.encumbrance': es,
+      'system.encumbrance': _replace(es),
     }
   }
 
@@ -1578,8 +1558,7 @@ export class ActorImporter {
     ts.sizemod = p.SM || '+0'
 
     const r = {
-      'system.-=traits': null,
-      'system.traits': ts,
+      'system.traits': _replace(ts),
     }
 
     if (!!game.settings.get(Settings.SYSTEM_NAME, Settings.SETTING_OVERWRITE_PORTRAITS)) {
@@ -1618,8 +1597,7 @@ export class ActorImporter {
     }
 
     return {
-      'system.-=ads': null,
-      'system.ads': this.foldList(temp),
+      'system.ads': _replace(this.foldList(temp)),
     }
   }
 
@@ -1695,8 +1673,7 @@ export class ActorImporter {
     }
 
     return {
-      'system.-=skills': null,
-      'system.skills': this.foldList(temp),
+      'system.skills': _replace(this.foldList(temp)),
     }
   }
 
@@ -1764,8 +1741,7 @@ export class ActorImporter {
     })
 
     return {
-      'system.-=spells': null,
-      'system.spells': this.foldList(temp),
+      'system.spells': _replace(this.foldList(temp)),
     }
   }
 
@@ -1840,8 +1816,8 @@ export class ActorImporter {
       // After retrieve all relevant data
       // Lets remove equipments now
       await this.actor.internalUpdate({
-        'system.equipment.-=carried': null,
-        'system.equipment.-=other': null,
+        'system.equipment.carried': _del,
+        'system.equipment.other': _del,
       })
     }
 
@@ -1854,7 +1830,7 @@ export class ActorImporter {
       let parent = null
       if (!!e.parentuuid) {
         parent = temp.find(f => f.uuid === e.parentuuid)
-        if (!!parent) GURPS.put(parent.contains, e)
+        if (!!parent) GURPS.put(parent.contains, { ...e })
         else e.parentuuid = ''
       }
       await this._updateItemContains(e, parent)
@@ -1870,13 +1846,12 @@ export class ActorImporter {
     for (const eqt of temp) {
       await Equipment.calc(eqt)
       if (!eqt.parentuuid) {
-        if (eqt.carried) GURPS.put(equipment.carried, eqt, cindex++)
-        else GURPS.put(equipment.other, eqt, oindex++)
+        if (eqt.carried) GURPS.put(equipment.carried, { ...eqt }, cindex++)
+        else GURPS.put(equipment.other, { ...eqt }, oindex++)
       }
     }
     return {
-      'system.-=equipment': null,
-      'system.equipment': equipment,
+      'system.equipment': _replace(equipment),
     }
   }
 
@@ -1953,8 +1928,7 @@ export class ActorImporter {
       if (!!t.save) temp.push(t)
     })
     return {
-      'system.-=notes': null,
-      'system.notes': this.foldList(temp),
+      'system.notes': _replace(this.foldList(temp)),
     }
   }
 
@@ -1995,8 +1969,7 @@ export class ActorImporter {
     }
     ts.sizemod = this.signedNum(final)
     return {
-      'system.-=traits': null,
-      'system.traits': ts,
+      'system.traits': _replace(ts),
     }
   }
 
@@ -2105,7 +2078,7 @@ export class ActorImporter {
 
     let prot = {}
     let index = 0
-    temp.forEach(it => GURPS.put(prot, it, index++))
+    temp.forEach(it => GURPS.put(prot, { ...it }, index++))
 
     let saveprot = false
     if (!!data.lastImport && !!data.additionalresources.bodyplan && bodyplan != data.additionalresources.bodyplan) {
@@ -2118,12 +2091,12 @@ export class ActorImporter {
       }
     }
     if (saveprot) return {}
-    else
+    else {
       return {
-        'system.-=hitlocations': null,
-        'system.hitlocations': prot,
+        'system.hitlocations': _replace(prot),
         'system.additionalresources.bodyplan': bodyplan,
       }
+    }
   }
 
   importPointTotalsFromGCS(total, atts, ads, skills, spells) {
@@ -2202,19 +2175,17 @@ export class ActorImporter {
       let r = new Reaction()
       r.modifier = i.modifier.toString()
       r.situation = i.situation
-      GURPS.put(rs, r, index_r++)
+      GURPS.put(rs, { ...r }, index_r++)
     }
     for (let i of temp_c2) {
       let c = new Modifier()
       c.modifier = i.modifier.toString()
       c.situation = i.situation
-      GURPS.put(cs, c, index_c++)
+      GURPS.put(cs, { ...c }, index_c++)
     }
     return {
-      'system.-=reactions': null,
-      'system.reactions': rs,
-      'system.-=conditionalmods': null,
-      'system.conditionalmods': cs,
+      'system.reactions': _replace(rs),
+      'system.conditionalmods': _replace(cs),
     }
   }
 
@@ -2254,7 +2225,7 @@ export class ActorImporter {
             let old = this._findElementIn('melee', false, m.name, m.mode)
             this._migrateOtfsAndNotes(old, m, i.vtt_notes, w.usage_notes)
 
-            GURPS.put(melee, m, m_index++)
+            GURPS.put(melee, { ...m }, m_index++)
           } else if (w.type == 'ranged_weapon') {
             let r = new Ranged()
             r.name = i.name || i.description || ''
@@ -2282,16 +2253,14 @@ export class ActorImporter {
             let old = this._findElementIn('ranged', false, r.name, r.mode)
             this._migrateOtfsAndNotes(old, r, i.vtt_notes, w.usage_notes)
 
-            GURPS.put(ranged, r, r_index++)
+            GURPS.put(ranged, { ...r }, r_index++)
           }
         }
       }
     }
     return {
-      'system.-=melee': null,
-      'system.melee': melee,
-      'system.-=ranged': null,
-      'system.ranged': ranged,
+      'system.melee': _replace(melee),
+      'system.ranged': _replace(ranged),
     }
   }
 
@@ -2478,13 +2447,13 @@ export class ActorImporter {
         const parent = flat.find(o => o.uuid == obj.parentuuid)
         if (!!parent) {
           if (!parent.contains) parent.contains = {} // lazy init for older characters
-          GURPS.put(parent.contains, obj)
+          GURPS.put(parent.contains, { ...obj })
         } else obj.parentuuid = '' // Can't find a parent, so put it in the top list.  should never happen with GCS
       }
     })
     let index = 0
     flat.forEach(obj => {
-      if (!obj.parentuuid) GURPS.put(target, obj, index++)
+      if (!obj.parentuuid) GURPS.put(target, { ...obj }, index++)
     })
     return target
   }

--- a/module/actor/actor-importer.js
+++ b/module/actor/actor-importer.js
@@ -668,7 +668,7 @@ export class ActorImporter {
       console.log(this)
     }
     return {
-      'system.traits': _replace(ts),
+      'system.traits': globalThis._replace(ts),
     }
   }
 
@@ -698,7 +698,7 @@ export class ActorImporter {
     }
 
     return {
-      'system.ads': _replace(this.foldList(list)),
+      'system.ads': globalThis._replace(this.foldList(list)),
     }
   }
 
@@ -773,7 +773,7 @@ export class ActorImporter {
     }
 
     return {
-      'system.skills': _replace(this.foldList(temp)),
+      'system.skills': globalThis._replace(this.foldList(temp)),
     }
   }
 
@@ -834,7 +834,7 @@ export class ActorImporter {
     }
 
     return {
-      'system.spells': _replace(this.foldList(temp)),
+      'system.spells': globalThis._replace(this.foldList(temp)),
     }
   }
 
@@ -882,7 +882,7 @@ export class ActorImporter {
       }
     }
     return {
-      'system.melee': _replace(melee),
+      'system.melee': globalThis._replace(melee),
     }
   }
 
@@ -941,7 +941,7 @@ export class ActorImporter {
       }
     }
     return {
-      'system.ranged': _replace(ranged),
+      'system.ranged': globalThis._replace(ranged),
     }
   }
 
@@ -982,7 +982,7 @@ export class ActorImporter {
       if (!!t.save) temp.push(t)
     })
     return {
-      'system.notes': _replace(this.foldList(temp)),
+      'system.notes': globalThis._replace(this.foldList(temp)),
     }
   }
 
@@ -1105,8 +1105,8 @@ export class ActorImporter {
       // After retrieve all relevant data
       // Lets remove equipments now
       await this.actor.internalUpdate({
-        'system.equipment.carried': _del,
-        'system.equipment.other': _del,
+        'system.equipment.carried': globalThis._del,
+        'system.equipment.other': globalThis._del,
       })
     }
 
@@ -1142,7 +1142,7 @@ export class ActorImporter {
       }
     }
     return {
-      'system.equipment': _replace(equipment),
+      'system.equipment': globalThis._replace(equipment),
     }
   }
 
@@ -1300,7 +1300,7 @@ export class ActorImporter {
     if (saveprot) return {}
     else
       return {
-        'system.hitlocations': _replace(prot),
+        'system.hitlocations': globalThis._replace(prot),
         'system.additionalresources.bodyplan': bodyplan,
       }
   }
@@ -1347,7 +1347,7 @@ export class ActorImporter {
       }
     }
     return {
-      'system.languages': _replace(langs),
+      'system.languages': globalThis._replace(langs),
     }
   }
 
@@ -1370,7 +1370,7 @@ export class ActorImporter {
       }
     })
     return {
-      'system.reactions': _replace(rs),
+      'system.reactions': globalThis._replace(rs),
     }
   }
 
@@ -1406,7 +1406,7 @@ export class ActorImporter {
     return {
       'system.currentmove': cm,
       'system.currentdodge': cd,
-      'system.encumbrance': _replace(es),
+      'system.encumbrance': globalThis._replace(es),
     }
   }
 
@@ -1558,7 +1558,7 @@ export class ActorImporter {
     ts.sizemod = p.SM || '+0'
 
     const r = {
-      'system.traits': _replace(ts),
+      'system.traits': globalThis._replace(ts),
     }
 
     if (!!game.settings.get(Settings.SYSTEM_NAME, Settings.SETTING_OVERWRITE_PORTRAITS)) {
@@ -1597,7 +1597,7 @@ export class ActorImporter {
     }
 
     return {
-      'system.ads': _replace(this.foldList(temp)),
+      'system.ads': globalThis._replace(this.foldList(temp)),
     }
   }
 
@@ -1673,7 +1673,7 @@ export class ActorImporter {
     }
 
     return {
-      'system.skills': _replace(this.foldList(temp)),
+      'system.skills': globalThis._replace(this.foldList(temp)),
     }
   }
 
@@ -1741,7 +1741,7 @@ export class ActorImporter {
     })
 
     return {
-      'system.spells': _replace(this.foldList(temp)),
+      'system.spells': globalThis._replace(this.foldList(temp)),
     }
   }
 
@@ -1816,8 +1816,8 @@ export class ActorImporter {
       // After retrieve all relevant data
       // Lets remove equipments now
       await this.actor.internalUpdate({
-        'system.equipment.carried': _del,
-        'system.equipment.other': _del,
+        'system.equipment.carried': globalThis._del,
+        'system.equipment.other': globalThis._del,
       })
     }
 
@@ -1851,7 +1851,7 @@ export class ActorImporter {
       }
     }
     return {
-      'system.equipment': _replace(equipment),
+      'system.equipment': globalThis._replace(equipment),
     }
   }
 
@@ -1928,7 +1928,7 @@ export class ActorImporter {
       if (!!t.save) temp.push(t)
     })
     return {
-      'system.notes': _replace(this.foldList(temp)),
+      'system.notes': globalThis._replace(this.foldList(temp)),
     }
   }
 
@@ -1969,7 +1969,7 @@ export class ActorImporter {
     }
     ts.sizemod = this.signedNum(final)
     return {
-      'system.traits': _replace(ts),
+      'system.traits': globalThis._replace(ts),
     }
   }
 
@@ -2093,7 +2093,7 @@ export class ActorImporter {
     if (saveprot) return {}
     else {
       return {
-        'system.hitlocations': _replace(prot),
+        'system.hitlocations': globalThis._replace(prot),
         'system.additionalresources.bodyplan': bodyplan,
       }
     }
@@ -2184,8 +2184,8 @@ export class ActorImporter {
       GURPS.put(cs, { ...c }, index_c++)
     }
     return {
-      'system.reactions': _replace(rs),
-      'system.conditionalmods': _replace(cs),
+      'system.reactions': globalThis._replace(rs),
+      'system.conditionalmods': globalThis._replace(cs),
     }
   }
 
@@ -2259,8 +2259,8 @@ export class ActorImporter {
       }
     }
     return {
-      'system.melee': _replace(melee),
-      'system.ranged': _replace(ranged),
+      'system.melee': globalThis._replace(melee),
+      'system.ranged': globalThis._replace(ranged),
     }
   }
 

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -791,7 +791,7 @@ export class GurpsActorSheet extends ActorSheet {
     let list = foundry.utils.getProperty(this.actor, key)
     let t = parentpath + '.' + objkey
 
-    await this.actor.internalUpdate({ [t]: _del }) // Delete the whole object
+    await this.actor.internalUpdate({ [t]: globalThis._del }) // Delete the whole object
 
     let sortedobj = {}
     let index = 0
@@ -1448,7 +1448,7 @@ export class GurpsActorSheet extends ActorSheet {
     let objkey = key.substr(i + 1)
     let object = GURPS.decode(this.actor, key)
     let t = parentpath + '.' + objkey
-    await this.actor.internalUpdate({ [t]: _del }) // Delete the whole object
+    await this.actor.internalUpdate({ [t]: globalThis._del }) // Delete the whole object
     let sortedobj = {}
     let index = 0
     Object.values(object)
@@ -1463,7 +1463,7 @@ export class GurpsActorSheet extends ActorSheet {
     let objkey = key.substr(i + 1)
     let object = GURPS.decode(this.actor, key)
     let t = parentpath + '.' + objkey
-    await this.actor.internalUpdate({ [t]: _del }) // Delete the whole object
+    await this.actor.internalUpdate({ [t]: globalThis._del }) // Delete the whole object
     let sortedobj = {}
     let index = 0
     Object.values(object)
@@ -1603,7 +1603,7 @@ export class GurpsActorSheet extends ActorSheet {
     // Delete the whole object.
     let last = components.pop()
     let t = `${components.join('.')}.${last}`
-    await this.actor.internalUpdate({ [t]: _del })
+    await this.actor.internalUpdate({ [t]: globalThis._del })
 
     // Insert the element into the array.
     array.splice(index, 0, element)
@@ -1628,7 +1628,7 @@ export class GurpsActorSheet extends ActorSheet {
     // Delete the whole object.
     let last = components.pop()
     let t = `${components.join('.')}.${last}`
-    await this.actor.internalUpdate({ [t]: _del })
+    await this.actor.internalUpdate({ [t]: globalThis._del })
 
     // Remove the element from the array
     array.splice(index, 1)
@@ -2081,7 +2081,7 @@ export class GurpsActorEditorSheet extends GurpsActorSheet {
             GURPS.put(hitlocations, it, count++)
           }
           await this.actor.update({
-            'system.hitlocations': _replace(hitlocations),
+            'system.hitlocations': globalThis._replace(hitlocations),
             'system.additionalresources.bodyplan': bodyplan,
           })
         }

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -789,9 +789,9 @@ export class GurpsActorSheet extends ActorSheet {
   async _sortContent(parentpath, objkey, reverse) {
     let key = parentpath + '.' + objkey
     let list = foundry.utils.getProperty(this.actor, key)
-    let t = parentpath + '.-=' + objkey
+    let t = parentpath + '.' + objkey
 
-    await this.actor.internalUpdate({ [t]: null }) // Delete the whole object
+    await this.actor.internalUpdate({ [t]: _del }) // Delete the whole object
 
     let sortedobj = {}
     let index = 0
@@ -1447,8 +1447,8 @@ export class GurpsActorSheet extends ActorSheet {
     let parentpath = key.substring(0, i)
     let objkey = key.substr(i + 1)
     let object = GURPS.decode(this.actor, key)
-    let t = parentpath + '.-=' + objkey
-    await this.actor.internalUpdate({ [t]: null }) // Delete the whole object
+    let t = parentpath + '.' + objkey
+    await this.actor.internalUpdate({ [t]: _del }) // Delete the whole object
     let sortedobj = {}
     let index = 0
     Object.values(object)
@@ -1462,8 +1462,8 @@ export class GurpsActorSheet extends ActorSheet {
     let parentpath = key.substring(0, i)
     let objkey = key.substr(i + 1)
     let object = GURPS.decode(this.actor, key)
-    let t = parentpath + '.-=' + objkey
-    await this.actor.internalUpdate({ [t]: null }) // Delete the whole object
+    let t = parentpath + '.' + objkey
+    await this.actor.internalUpdate({ [t]: _del }) // Delete the whole object
     let sortedobj = {}
     let index = 0
     Object.values(object)
@@ -1602,8 +1602,8 @@ export class GurpsActorSheet extends ActorSheet {
 
     // Delete the whole object.
     let last = components.pop()
-    let t = `${components.join('.')}.-=${last}`
-    await this.actor.internalUpdate({ [t]: null })
+    let t = `${components.join('.')}.${last}`
+    await this.actor.internalUpdate({ [t]: _del })
 
     // Insert the element into the array.
     array.splice(index, 0, element)
@@ -1627,8 +1627,8 @@ export class GurpsActorSheet extends ActorSheet {
 
     // Delete the whole object.
     let last = components.pop()
-    let t = `${components.join('.')}.-=${last}`
-    await this.actor.internalUpdate({ [t]: null })
+    let t = `${components.join('.')}.${last}`
+    await this.actor.internalUpdate({ [t]: _del })
 
     // Remove the element from the array
     array.splice(index, 1)
@@ -2080,14 +2080,10 @@ export class GurpsActorEditorSheet extends GurpsActorSheet {
             let it = new HitLocation(loc, dr, hit.penalty, hit.roll)
             GURPS.put(hitlocations, it, count++)
           }
-          this.actor.ignoreRender = true
           await this.actor.update({
-            'system.-=hitlocations': null,
+            'system.hitlocations': _replace(hitlocations),
             'system.additionalresources.bodyplan': bodyplan,
           })
-          await this.actor.update({ 'system.hitlocations': 0 }) // A hack. The delete above doesn't always get rid of the properties, so set it to Zero
-          this.actor.ignoreRender = false
-          await this.actor.update({ 'system.hitlocations': hitlocations })
         }
       }
     })

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1563,6 +1563,7 @@ export class GurpsActor extends Actor {
 
         // 5. Update Actor System with new Component
         const systemObject = foundry.utils.duplicate(foundry.utils.getProperty(this, targetKey))
+        await GURPS.put(systemObject, actorComp)
         await this.internalUpdate({ [targetKey]: globalThis._replace(systemObject) })
         if (data.type === 'equipment') await Equipment.calc(actorComp)
 

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1255,8 +1255,7 @@ export class GurpsActor extends Actor {
 
     // Remove all trackers first. Add the new "array" of trackers.
     if (data) {
-      await this.update({ 'system.additionalresources.-=tracker': null })
-      await this.update({ 'system.additionalresources.tracker': data })
+      await this.update({ 'system.additionalresources.tracker': globalThis._replace(data) })
     }
   }
 
@@ -1334,11 +1333,9 @@ export class GurpsActor extends Actor {
     let trackers = objectToArray(trackerData)
     let data = arrayToObject(trackers)
 
-    // remove all trackers
-    await this.update({ 'system.additionalresources.-=tracker': null })
     // add the new "array" of trackers
-    if (data) this.update({ 'system.additionalresources.tracker': data })
-    else this.update('system.additionalresources.tracker', {})
+    if (data) this.update({ 'system.additionalresources.tracker': _replace(data) })
+    else this.update('system.additionalresources.tracker', _replace({}))
 
     this._forceRender()
   }
@@ -1349,8 +1346,7 @@ export class GurpsActor extends Actor {
     let trackerData = { name: '', value: 0, min: 0, max: 0, points: 0 }
     let data = GurpsActor.addTrackerToDataObject(this.system, trackerData)
 
-    await this.update({ 'system.additionalresources.-=tracker': null })
-    await this.update({ 'system.additionalresources.tracker': data })
+    await this.update({ 'system.additionalresources.tracker': _replace(data) })
 
     this._forceRender()
   }
@@ -1382,8 +1378,7 @@ export class GurpsActor extends Actor {
     for (const key in move) {
       move[key].default = value === key
     }
-    await this.update({ 'system.-=move': null })
-    await this.update({ 'system.move': move })
+    await this.update({ 'system.move': _replace(move) })
     this._forceRender()
   }
 
@@ -1568,10 +1563,7 @@ export class GurpsActor extends Actor {
 
         // 5. Update Actor System with new Component
         const systemObject = foundry.utils.duplicate(foundry.utils.getProperty(this, targetKey))
-        const removeKey = targetKey.replace(/(\w+)$/, '-=$1')
-        await this.internalUpdate({ [removeKey]: null })
-        await GURPS.put(systemObject, actorComp)
-        await this.internalUpdate({ [targetKey]: systemObject })
+        await this.internalUpdate({ [targetKey]: _replace(systemObject) })
         if (data.type === 'equipment') await Equipment.calc(actorComp)
 
         // 6. Process Child Items for created Item
@@ -2179,16 +2171,14 @@ export class GurpsActor extends Actor {
     if (!!obj.collapsed && Object.keys(obj.collapsed).length > 0) {
       let temp = { ...obj.contains, ...obj.collapsed }
       let update = {
-        [path + '.-=collapsed']: null,
-        [path + '.collapsed']: {},
+        [path + '.collapsed']: _replace({}),
         [path + '.contains']: temp,
       }
       await this.update(update)
     } else if (!expandOnly && !!obj.contains && Object.keys(obj.contains).length > 0) {
       let temp = { ...obj.contains, ...obj.collapsed }
       let update = {
-        [path + '.-=contains']: null,
-        [path + '.contains']: {},
+        [path + '.contains']: _replace({}),
         [path + '.collapsed']: temp,
       }
       await this.update(update)
@@ -2900,8 +2890,7 @@ export class GurpsActor extends Actor {
     }
     if (changed) {
       // Exclude than rewrite the hitlocations on Actor
-      await this.internalUpdate({ 'system.-=hitlocations': null })
-      await this.update({ 'system.hitlocations': actorLocations })
+      await this.update({ 'system.hitlocations': _replace(actorLocations) })
       const msg = `${this.name}: DR ${drFormula} applied to ${
         affectedLocations.length > 0 ? affectedLocations.join(', ') : 'all locations'
       }`

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1334,7 +1334,7 @@ export class GurpsActor extends Actor {
     let data = arrayToObject(trackers)
 
     // add the new "array" of trackers
-    if (data) this.update({ 'system.additionalresources.tracker': _replace(data) })
+    if (data) this.update({ 'system.additionalresources.tracker': globalThis._replace(data) })
     else this.update('system.additionalresources.tracker', _replace({}))
 
     this._forceRender()
@@ -1346,7 +1346,7 @@ export class GurpsActor extends Actor {
     let trackerData = { name: '', value: 0, min: 0, max: 0, points: 0 }
     let data = GurpsActor.addTrackerToDataObject(this.system, trackerData)
 
-    await this.update({ 'system.additionalresources.tracker': _replace(data) })
+    await this.update({ 'system.additionalresources.tracker': globalThis._replace(data) })
 
     this._forceRender()
   }
@@ -1378,7 +1378,7 @@ export class GurpsActor extends Actor {
     for (const key in move) {
       move[key].default = value === key
     }
-    await this.update({ 'system.move': _replace(move) })
+    await this.update({ 'system.move': globalThis._replace(move) })
     this._forceRender()
   }
 
@@ -1563,7 +1563,7 @@ export class GurpsActor extends Actor {
 
         // 5. Update Actor System with new Component
         const systemObject = foundry.utils.duplicate(foundry.utils.getProperty(this, targetKey))
-        await this.internalUpdate({ [targetKey]: _replace(systemObject) })
+        await this.internalUpdate({ [targetKey]: globalThis._replace(systemObject) })
         if (data.type === 'equipment') await Equipment.calc(actorComp)
 
         // 6. Process Child Items for created Item
@@ -2171,14 +2171,14 @@ export class GurpsActor extends Actor {
     if (!!obj.collapsed && Object.keys(obj.collapsed).length > 0) {
       let temp = { ...obj.contains, ...obj.collapsed }
       let update = {
-        [path + '.collapsed']: _replace({}),
+        [path + '.collapsed']: globalThis._replace({}),
         [path + '.contains']: temp,
       }
       await this.update(update)
     } else if (!expandOnly && !!obj.contains && Object.keys(obj.contains).length > 0) {
       let temp = { ...obj.contains, ...obj.collapsed }
       let update = {
-        [path + '.contains']: _replace({}),
+        [path + '.contains']: globalThis._replace({}),
         [path + '.collapsed']: temp,
       }
       await this.update(update)
@@ -2890,7 +2890,7 @@ export class GurpsActor extends Actor {
     }
     if (changed) {
       // Exclude than rewrite the hitlocations on Actor
-      await this.update({ 'system.hitlocations': _replace(actorLocations) })
+      await this.update({ 'system.hitlocations': globalThis._replace(actorLocations) })
       const msg = `${this.name}: DR ${drFormula} applied to ${
         affectedLocations.length > 0 ? affectedLocations.join(', ') : 'all locations'
       }`

--- a/module/actor/move-mode-editor.js
+++ b/module/actor/move-mode-editor.js
@@ -160,7 +160,7 @@ export default class MoveModeEditor extends Application {
                 default: this.moveData[k].default,
               })
           }
-          await this.actor.update({ 'system.move': _replace(move) })
+          await this.actor.update({ 'system.move': globalThis._replace(move) })
         }
         break
 

--- a/module/actor/move-mode-editor.js
+++ b/module/actor/move-mode-editor.js
@@ -124,11 +124,8 @@ export default class MoveModeEditor extends Application {
           let empty = Object.values(this.moveData).length === 0
           GURPS.put(move, { mode: 'other', basic: 0, default: !!empty })
 
-          // remove existing entries
-          await this.actor.update({ 'system.-=move': null })
-
           // add the new entries
-          await this.actor.update({ 'system.move': move })
+          await this.actor.update({ 'system.move': globalThis._replace(move) })
         }
         break
 
@@ -163,10 +160,7 @@ export default class MoveModeEditor extends Application {
                 default: this.moveData[k].default,
               })
           }
-          // remove existing entries
-          await this.actor.update({ 'system.-=move': null })
-          // add the new entries
-          await this.actor.update({ 'system.move': move })
+          await this.actor.update({ 'system.move': _replace(move) })
         }
         break
 

--- a/module/actor/splitdr-editor.js
+++ b/module/actor/splitdr-editor.js
@@ -67,7 +67,7 @@ export default class SplitDREditor extends Application {
         {
           // remove existing entries
           let entry = {}
-          entry[`${this.key}.-=split`] = null
+          entry[`${this.key}.split`] = globalThis._del
           await this.actor.update(entry)
         }
         break
@@ -129,7 +129,7 @@ export default class SplitDREditor extends Application {
 
   async _updateSplitDRKey(existingValue, newKey) {
     let old = {}
-    old[`${this.key}.-=split`] = null
+    old[`${this.key}.split`] = globalThis._del
     await this.actor.update(old)
 
     let split = {}

--- a/module/chat/chat-processors.js
+++ b/module/chat/chat-processors.js
@@ -905,7 +905,7 @@ class LightChatProcessor extends ChatProcessor {
     }
 
     if (this.match.groups.off) {
-      data.light['-=color'] = null
+      data.light['color'] = globalThis._del
     } else {
       if (this.match.groups.color) data.light.color = this.match.groups.color
       if (this.match.groups.colorint) data.light.alpha = parseFloat(this.match.groups.colorint)

--- a/module/chat/frightcheck.js
+++ b/module/chat/frightcheck.js
@@ -195,7 +195,8 @@ export class FrightCheckChatProcessor extends ChatProcessor {
     })
 
     await ChatMessage.create({
-      type: CONST.CHAT_MESSAGE_STYLES.ROLL,
+      style: CONST.CHAT_MESSAGE_STYLES.ROLL,
+      type: 'base',
       speaker: ChatMessage.getSpeaker(actor),
       content: content,
       roll: JSON.stringify(roll),

--- a/module/damage/applydamage.js
+++ b/module/damage/applydamage.js
@@ -711,7 +711,8 @@ export default class ApplyDamageDialog extends Application {
     let msgData = {
       content: message,
       author: game.user.id,
-      type: CONST.CHAT_MESSAGE_STYLES.OOC,
+      style: CONST.CHAT_MESSAGE_STYLES.OOC,
+      type: 'base',
     }
     if (game.settings.get(Settings.SYSTEM_NAME, Settings.SETTING_WHISPER_STATUS_EFFECTS)) {
       let users = this.actor.getOwners()
@@ -795,7 +796,8 @@ export default class ApplyDamageDialog extends Application {
         user: game.user.id,
         speaker: speaker,
         content: html,
-        type: CONST.CHAT_MESSAGE_STYLES.OTHER,
+        style: CONST.CHAT_MESSAGE_STYLES.OTHER,
+        type: 'base',
       }
 
       if (!publicly) {

--- a/module/damage/damagecalculator.js
+++ b/module/damage/damagecalculator.js
@@ -324,10 +324,7 @@ export class CompositeDamageCalculator {
   }
 
   async addEffectsContext() {
-    let tokenId = this._defender.token?.id
-    if (!tokenId) tokenId = canvas.tokens.placeables.find(it => it.actor === this._defender).id
-    const defenderToken = canvas.tokens.get(tokenId)
-    const actions = await TokenActions.fromToken(defenderToken)
+    const actions = await TokenActions.fromActor(this._defender)
     let isReady
     const data = this.effects.map(effect => {
       if (effect.type.includes('shock')) {
@@ -335,7 +332,7 @@ export class CompositeDamageCalculator {
         if (applyAt === 'AtNextTurn') {
           isReady = actions.getNextTurnEffects().includes(`${effect.type}${effect.amount}`)
         } else {
-          isReady = defenderToken.actor.effects.find(e => e.statuses.find(s => s === `${effect.type}${effect.amount}`))
+          isReady = this._defender.effects.find(e => e.statuses.find(s => s === `${effect.type}${effect.amount}`))
         }
         return {
           ...effect,
@@ -356,8 +353,8 @@ export class CompositeDamageCalculator {
           case 'headvitalshit':
           case 'majorwound':
           case 'crippling':
-            const stunIsReady = defenderToken.actor.effects.find(e => e.statuses.find(s => s === 'stun'))
-            const proneIsReady = defenderToken.actor.effects.find(e => e.statuses.find(s => s === 'prone'))
+            const stunIsReady = this._defender.effects.find(e => e.statuses.find(s => s === 'stun'))
+            const proneIsReady = this._defender.effects.find(e => e.statuses.find(s => s === 'prone'))
             return {
               ...effect,
               testTitle: game.i18n.localize('GURPS.saveRollforEffect'),
@@ -385,7 +382,7 @@ export class CompositeDamageCalculator {
               ],
             }
           case 'knockback':
-            isReady = defenderToken.actor.effects.find(e => e.statuses.find(s => s === 'prone'))
+            isReady = this._defender.effects.find(e => e.statuses.find(s => s === 'prone'))
             return {
               ...effect,
               testTitle: game.i18n.localize('GURPS.saveRollforEffect'),

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1684,7 +1684,7 @@ if (!globalThis.GURPS) {
     let objkey = objpath.substring(i + 1)
     let object = GURPS.decode(actor, objpath)
     let t = parentpath + '.' + objkey
-    await actor.internalUpdate({ [t]: _del }) // Delete the whole object
+    await actor.internalUpdate({ [t]: globalThis._del }) // Delete the whole object
     let start = parseInt(key)
 
     i = start + 1

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -2089,7 +2089,8 @@ if (!globalThis.GURPS) {
           cmd = '[' + cmd + ']'
           let messageData = {
             user: game.user.id,
-            type: CONST.CHAT_MESSAGE_STYLES.OOC,
+            style: CONST.CHAT_MESSAGE_STYLES.OOC,
+            type: 'base',
             content: cmd,
           }
           ChatMessage.create(messageData, {})

--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1683,8 +1683,8 @@ if (!globalThis.GURPS) {
     let parentpath = objpath.substring(0, i)
     let objkey = objpath.substring(i + 1)
     let object = GURPS.decode(actor, objpath)
-    let t = parentpath + '.-=' + objkey
-    await actor.internalUpdate({ [t]: null }) // Delete the whole object
+    let t = parentpath + '.' + objkey
+    await actor.internalUpdate({ [t]: _del }) // Delete the whole object
     let start = parseInt(key)
 
     i = start + 1

--- a/module/modifier-bucket/bucket-app.js
+++ b/module/modifier-bucket/bucket-app.js
@@ -781,7 +781,8 @@ export class ModifierBucket extends Application {
       if (!game.user?.isGM) {
         let messageData = {
           content: this.chatString(this.modifierStack),
-          type: CONST.CHAT_MESSAGE_STYLES.OOC,
+          style: CONST.CHAT_MESSAGE_STYLES.OOC,
+          type: 'base',
         }
         ChatMessage.create(messageData, {})
       } else this.showOthers()

--- a/module/token-actions.js
+++ b/module/token-actions.js
@@ -57,6 +57,18 @@ export class TokenActions {
     return await tokenActions.init()
   }
 
+  static async fromActor(actor) {
+    if (actor.token) {
+      const tokenActions = new TokenActions(actor.token)
+      return await tokenActions.init()
+    }
+
+    const tokenDocument = await actor.getTokenDocument()
+    const token = new Token(tokenDocument, { parent: canvas.scene })
+    const tokenActions = new TokenActions(token)
+    return await tokenActions.init()
+  }
+
   _getNewLastManeuvers() {
     return {
       maneuver: 'do_nothing',

--- a/module/token-actions.js
+++ b/module/token-actions.js
@@ -58,13 +58,13 @@ export class TokenActions {
   }
 
   static async fromActor(actor) {
-    if (actor.token) {
-      const tokenActions = new TokenActions(actor.token)
-      return await tokenActions.init()
+    let token = actor.token?.object
+
+    if (!token) {
+      const tokenDocument = await actor.getTokenDocument()
+      token = tokenDocument.object
     }
 
-    const tokenDocument = await actor.getTokenDocument()
-    const token = new Token(tokenDocument, { parent: canvas.scene })
     const tokenActions = new TokenActions(token)
     return await tokenActions.init()
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6327,7 +6327,7 @@
     "node_modules/fvtt-types": {
       "name": "@league-of-foundry-developers/foundry-vtt-types",
       "version": "13.346.0",
-      "resolved": "git+ssh://git@github.com/League-of-Foundry-Developers/foundry-vtt-types.git#316ec660f7f5cc0df2080c6f1e0f2b7395441cad",
+      "resolved": "git+ssh://git@github.com/League-of-Foundry-Developers/foundry-vtt-types.git#fec20ae1abfa80d00f37d6b59cc7f045865cb3f8",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/styles/apps.css
+++ b/styles/apps.css
@@ -542,12 +542,7 @@ ul#result-effects li {
 }
 
 .offscreen-only {
-  position: absolute;
-  left: -10000px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
+  display: none;
 }
 
 /* remove the top margin and indent */

--- a/templates/damage-message.hbs
+++ b/templates/damage-message.hbs
@@ -28,7 +28,6 @@
 
         <div class='roll-message'>
           <div class='collapsible-wrapperXXXX'>
-            <!-- <input id='collapsible-{{id}}' class='toggle offscreen-only' type='checkbox'> -->
             <label for='collapsible-{{id}}' class='roll-result {{#if hasExplanation}}label-toggleXXXX{{/if}}'>
               <span>{{#if target}}&nbsp;{{target}}:{{/if}} 
                 {{#if ../loaded}}


### PR DESCRIPTION
This PR:
- Replaces all instances of `-=` keys used for path deletion with the new `_del` and `_replace` global helper operators. This fixes all v14-related issues with importing characters. Fixes #2629 
- Removes the need for the Damage Calculator's `addEffectsContext` function requiring an Actor to have a token (this was causing errors when a non-combatant Actor had damage applied to them)
- Fixes an issue which would cause some chat messages to not appear (they were applying the chat message style value of the message tot the `type` variable, where it should be `style` in v14)
- Fixes an issue which would cause the chat log to disappear when clicking on a "Show the Math" toggle on a damage chat message.