### PR TITLE
Bugfix: Can't roll attacks or damage from Modern Sheet

### DIFF
--- a/src/module/actor/data/character.ts
+++ b/src/module/actor/data/character.ts
@@ -1523,8 +1523,7 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
         }
       }
 
-      modifierTags =
-        (optionalArgs.obj.modifierTags as string)?.split(',').map((tag: string) => tag.trim().toLowerCase()) ?? []
+      modifierTags = [...(optionalArgs.obj.modifierTags as Set<string>)]
       allTags = [...modifierTags, ...allRollTags, ...refTags]
       itemRef = (optionalArgs.obj.name as string) ?? ''
     } else if (chatThing) {
@@ -1797,7 +1796,7 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
 
     const weapons = this.parent.getItemAttacks().filter(attack => attackType === 'both' || attack.type === attackType)
 
-    let weapon = weapons.find(attack => attack.item.name === nameWithoutUsage && (!usage || attack.mode === usage))
+    let weapon = weapons.find(attack => attack._displayName === nameWithoutUsage && (!usage || attack.mode === usage))
 
     if (!weapon) {
       // Account for the possibility that the usage was matched incorrectly as part of the name (e.g. "Guns (Pistol)")

--- a/src/module/actor/data/character.ts
+++ b/src/module/actor/data/character.ts
@@ -1523,7 +1523,21 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
         }
       }
 
-      modifierTags = [...(optionalArgs.obj.modifierTags as Set<string>)]
+      switch (typeof optionalArgs.obj.modifierTags) {
+        case 'object': {
+          if (Array.isArray(optionalArgs.obj.modifierTags)) {
+            modifierTags = optionalArgs.obj.modifierTags
+          } else if (optionalArgs.obj.modifierTags instanceof Set) {
+            modifierTags = [...optionalArgs.obj.modifierTags]
+          }
+
+          break
+        }
+        case 'string': {
+          modifierTags = optionalArgs.obj.modifierTags.split(' ').map((tag: string) => tag.trim().toLowerCase())
+        }
+      }
+
       allTags = [...modifierTags, ...allRollTags, ...refTags]
       itemRef = (optionalArgs.obj.name as string) ?? ''
     } else if (chatThing) {

--- a/src/util/parselink.js
+++ b/src/util/parselink.js
@@ -16,7 +16,7 @@ import { d6ify, sanitize, utoa } from './utilities.js'
   "ST12"
   "SW+1"/"THR-1"
   "PDF:B102"
-  	
+
   "modifier", "attribute", "selfcontrol", "damage", "roll", "skill", "pdf"
 
   (\(-?[\.\d]+\))? == (-.#)
@@ -1018,6 +1018,8 @@ export function parseForRollOrDamage(str, overridetxt) {
   // Straight roll 4d, 2d-1, etc. Is "damage" if it includes a damage type. Allows "!" suffix to indicate minimum of 1.
   // Supports:  2d+1x3(5), 4dX2(0.5), etc
   // Straight roll, no damage type. 4d, 2d-1, etc. Allows "!" suffix to indicate minimum of 1.
+  if (str instanceof Set) str = Array.from(str)
+
   str = str.toString() // convert possible array to single string
   let damageMatch = str.match(DAMAGE_REGEX)
 


### PR DESCRIPTION
This PR fixes an issue wherein clicking on attack or damage buttons on the modern sheet did not work, due to the wrong field being used for attack name lookup.

Resolves #2649 
Resolves #2662 