### PR TITLE
Bugfix: Data preparation order prevents OTF-based action level calculation

### DIFF
--- a/src/module/action/base-attack.ts
+++ b/src/module/action/base-attack.ts
@@ -33,7 +33,6 @@ class BaseAttack<Schema extends BaseAttack.Schema = BaseAttack.Schema> extends B
 
   override prepareDerivedData(): void {
     super.prepareDerivedData()
-    this.#prepareLevelsFromOtf()
 
     if (Object.getOwnPropertyDescriptor(this, 'name') === undefined) {
       Object.defineProperty(this, 'name', {
@@ -43,6 +42,14 @@ class BaseAttack<Schema extends BaseAttack.Schema = BaseAttack.Schema> extends B
         configurable: true,
       })
     }
+  }
+
+  /* ---------------------------------------- */
+
+  override prepareSiblingData(): void {
+    super.prepareSiblingData()
+
+    this.#prepareLevelsFromOtf()
   }
 
   /* ---------------------------------------- */
@@ -85,14 +92,15 @@ class BaseAttack<Schema extends BaseAttack.Schema = BaseAttack.Schema> extends B
 
     action.action.calcOnly = true
     action.action.suppressWarnings = true
-    // TODO: verify that target is of type "number" (or replace this whole thing)
-    GURPS.performAction(action.action, this.actor).then(
-      (result: boolean | { target: number; thing: any } | undefined) => {
-        if (result && typeof result === 'object') {
-          this.level = result.target
-        }
-      }
-    )
+
+    const otfResult = GURPS.performAction(action.action, this.actor) as unknown as
+      | boolean
+      | { target: number; thing: any }
+      | undefined
+
+    if (otfResult && typeof otfResult === 'object') {
+      this.level = otfResult.target
+    }
   }
 
   /* ---------------------------------------- */

--- a/src/module/action/base-attack.ts
+++ b/src/module/action/base-attack.ts
@@ -93,12 +93,15 @@ class BaseAttack<Schema extends BaseAttack.Schema = BaseAttack.Schema> extends B
     action.action.calcOnly = true
     action.action.suppressWarnings = true
 
-    const otfResult = GURPS.performAction(action.action, this.actor) as unknown as
-      | boolean
-      | { target: number; thing: any }
-      | undefined
+    const otfResult = GURPS.performAction(action.action, this.actor) as unknown
 
-    if (otfResult && typeof otfResult === 'object') {
+    if (
+      otfResult &&
+      typeof otfResult === 'object' &&
+      !('then' in otfResult) &&
+      'target' in otfResult &&
+      typeof otfResult.target === 'number'
+    ) {
       this.level = otfResult.target
     }
   }

--- a/src/module/action/melee-attack.ts
+++ b/src/module/action/melee-attack.ts
@@ -109,8 +109,9 @@ class MeleeAttackModel extends BaseAttack<MeleeAttackSchema> {
   /*  Data Preparation                        */
   /* ---------------------------------------- */
 
-  override prepareDerivedData(): void {
-    super.prepareDerivedData()
+  override prepareSiblingData(): void {
+    super.prepareSiblingData()
+
     this.#prepareDefenses()
     this.#prepareDisplayValues()
   }

--- a/src/module/action/ranged-attack.ts
+++ b/src/module/action/ranged-attack.ts
@@ -214,8 +214,9 @@ class RangedAttackModel extends BaseAttack<RangedAttackSchema> {
 
   /* ---------------------------------------- */
 
-  override prepareDerivedData(): void {
-    super.prepareDerivedData()
+  override prepareSiblingData(): void {
+    super.prepareSiblingData()
+
     this.#prepareMusclePoweredRange()
     this.#prepareDisplayValues()
   }

--- a/src/module/actor/gurps-actor.ts
+++ b/src/module/actor/gurps-actor.ts
@@ -509,6 +509,8 @@ class GurpsActorV2<SubType extends Actor.SubType> extends Actor<SubType> {
   /*  Data Preparation                        */
   /* ---------------------------------------- */
 
+  /* ---------------------------------------- */
+
   /**
    * NOTE: Both character and characterV2.
    */
@@ -538,6 +540,8 @@ class GurpsActorV2<SubType extends Actor.SubType> extends Actor<SubType> {
     const isTypeData = this.system instanceof foundry.abstract.TypeDataModel
 
     if (isTypeData) this.system.prepareEmbeddedDocuments()
+
+    for (const item of this.items) item.prepareSiblingData()
   }
 
   /* ---------------------------------------- */

--- a/src/module/gurps.js
+++ b/src/module/gurps.js
@@ -458,7 +458,7 @@ if (!globalThis.GURPS) {
       return 0
     }
 
-    let skillLevel = skill.level
+    let skillLevel = skill.system.level
 
     // @ts-expect-error - dynamically adding obj property to action
     action.obj = skill
@@ -467,7 +467,7 @@ if (!globalThis.GURPS) {
     if (action.floatingAttribute) {
       if (actor) {
         let value = foundry.utils.getProperty(actordata, action.floatingAttribute)
-        let rsl = skill.relativelevel //  this is something like 'IQ-2' or 'Touch+3'
+        let rsl = skill.system.relativelevel //  this is something like 'IQ-2' or 'Touch+3'
         let valueText = rsl.replace(/^.*([+-]\d+)$/g, '$1')
 
         skillLevel = valueText === rsl ? parseInt(value) : parseInt(valueText) + parseInt(value)
@@ -1248,7 +1248,7 @@ if (!globalThis.GURPS) {
      * @param {string} data.originalOtf
      * @param {boolean} data.calcOnly
      */
-    async attribute({ action, actor, event, originalOtf, calcOnly }) {
+    attribute({ action, actor, event, originalOtf, calcOnly }) {
       // This can be complicated because Attributes (and Skills) can be pre-targeted (meaning we don't need an actor)
       if (!actor && (!action || !action.target)) {
         ui.notifications?.warn('You must have a character selected')
@@ -1285,35 +1285,37 @@ if (!globalThis.GURPS) {
         return { target: target + modifier, thing: thing }
       }
 
-      let targetmods = []
-      let aid = actor ? `@${actor.id}@` : ''
-      const chatthing = originalOtf ? `[${aid}${originalOtf}]` : `[${aid}${thing}]`
-      let opt = {
-        blind: action.blindroll,
-        event: event,
-        action: action,
-        obj: action.obj,
-        text: '',
-      }
+      return (async () => {
+        let targetmods = []
+        let aid = actor ? `@${actor.id}@` : ''
+        const chatthing = originalOtf ? `[${aid}${originalOtf}]` : `[${aid}${thing}]`
+        let opt = {
+          blind: action.blindroll,
+          event: event,
+          action: action,
+          obj: action.obj,
+          text: '',
+        }
 
-      if (opt.obj?.checkotf && !(await GURPS.executeOTF(opt.obj.checkotf, false, event, actor))) return false
-      if (opt.obj?.duringotf) await GURPS.executeOTF(opt.obj.duringotf, false, event, actor)
-      opt.text = ''
-      if (action.costs) GURPS.ModifierBucket.addModifier(0, action.costs)
-      if (action.mod) GURPS.ModifierBucket.addModifier(action.mod, action.desc, targetmods)
-      else if (action.desc) opt.text = "<span style='font-size:85%'>" + action.desc + '</span>'
-      if (action.overridetxt) opt.text += "<span style='font-size:85%'>" + action.overridetxt + '</span>'
+        if (opt.obj?.checkotf && !(await GURPS.executeOTF(opt.obj.checkotf, false, event, actor))) return false
+        if (opt.obj?.duringotf) await GURPS.executeOTF(opt.obj.duringotf, false, event, actor)
+        opt.text = ''
+        if (action.costs) GURPS.ModifierBucket.addModifier(0, action.costs)
+        if (action.mod) GURPS.ModifierBucket.addModifier(action.mod, action.desc, targetmods)
+        else if (action.desc) opt.text = "<span style='font-size:85%'>" + action.desc + '</span>'
+        if (action.overridetxt) opt.text += "<span style='font-size:85%'>" + action.overridetxt + '</span>'
 
-      return doRoll({
-        actor,
-        targetmods,
-        prefix: game.i18n.localize('GURPS.rollVs'),
-        thing,
-        chatthing,
-        origtarget: target,
-        optionalArgs: opt,
-        action,
-      })
+        return doRoll({
+          actor,
+          targetmods,
+          prefix: game.i18n.localize('GURPS.rollVs'),
+          thing,
+          chatthing,
+          origtarget: target,
+          optionalArgs: opt,
+          action,
+        })
+      })()
     },
     /**
      * @param {Object} data
@@ -1331,7 +1333,7 @@ if (!globalThis.GURPS) {
      * @param {string} data.originalOtf
      * @param {boolean} data.calcOnly
      */
-    async ['skill-spell']({ action, actor, event, originalOtf, calcOnly }) {
+    ['skill-spell']({ action, actor, event, originalOtf, calcOnly }) {
       if (!actor && (!action || !action.target)) {
         ui.notifications?.warn(game.i18n.localize('GURPS.chatYouMustHaveACharacterSelected'))
 
@@ -1354,26 +1356,28 @@ if (!globalThis.GURPS) {
         return { target: target + modifier, thing: thing }
       }
 
-      let targetmods = []
-      let aid = actor ? `@${actor.id}@` : ''
-      let chatthing = originalOtf ? `[${aid}${originalOtf}]` : `[${aid}S:"${thing}"]`
-      let opt = {
-        blind: action.blindroll,
-        event,
-        action,
-        obj: action.obj,
-        text: '',
-      }
+      return (async () => {
+        let targetmods = []
+        let aid = actor ? `@${actor.id}@` : ''
+        let chatthing = originalOtf ? `[${aid}${originalOtf}]` : `[${aid}S:"${thing}"]`
+        let opt = {
+          blind: action.blindroll,
+          event,
+          action,
+          obj: action.obj,
+          text: '',
+        }
 
-      if (opt.obj?.checkotf && !(await GURPS.executeOTF(opt.obj.checkotf, false, event, actor))) return false
-      if (opt.obj?.duringotf) await GURPS.executeOTF(opt.obj.duringotf, false, event, actor)
+        if (opt.obj?.checkotf && !(await GURPS.executeOTF(opt.obj.checkotf, false, event, actor))) return false
+        if (opt.obj?.duringotf) await GURPS.executeOTF(opt.obj.duringotf, false, event, actor)
 
-      if (action.costs) GURPS.ModifierBucket.addModifier(0, action.costs)
-      if (action.mod) GURPS.ModifierBucket.addModifier(action.mod, action.desc, targetmods)
-      else if (action.desc) opt.text = "<span style='font-size:85%'>" + action.desc + '</span>'
-      if (action.overridetxt) opt.text += "<span style='font-size:85%'>" + action.overridetxt + '</span>'
+        if (action.costs) GURPS.ModifierBucket.addModifier(0, action.costs)
+        if (action.mod) GURPS.ModifierBucket.addModifier(action.mod, action.desc, targetmods)
+        else if (action.desc) opt.text = "<span style='font-size:85%'>" + action.desc + '</span>'
+        if (action.overridetxt) opt.text += "<span style='font-size:85%'>" + action.overridetxt + '</span>'
 
-      return await doRoll({ actor, targetmods, thing, chatthing, origtarget: target, optionalArgs: opt, action })
+        return await doRoll({ actor, targetmods, thing, chatthing, origtarget: target, optionalArgs: opt, action })
+      })()
     },
 
     /*
@@ -1473,14 +1477,44 @@ if (!globalThis.GURPS) {
     return actions[levels.indexOf(bestLevel)]
   }
 
+  function findBestActionInChainSync({ action, actor, event, targets, originalOtf }) {
+    const actions = []
+    let overridetxt = action.overridetxt
+    const suppressWarnings = action.suppressWarnings
+
+    while (action) {
+      action.overridetxt = overridetxt
+      actions.push(action)
+      action = action.next
+    }
+
+    const calculations = actions.map(action =>
+      GURPS.actionFuncs[action.type]({ action: action, actor, event, targets, originalOtf, calcOnly: true })
+    )
+
+    const levels = calculations.map(result => (result ? result.target : 0))
+
+    if (!levels.some(level => level > 0)) {
+      if (!suppressWarnings) {
+        ui.notifications.warn(game.i18n.localize('GURPS.noViableSkill'))
+      }
+
+      return null
+    }
+
+    const bestLevel = Math.max(...levels)
+
+    return actions[levels.indexOf(bestLevel)]
+  }
+
   /**
    * @param {Action} action
    * @param {GurpsActorV2|null} actor
    * @param {JQuery.Event|null} [event]
-   * @param {string[] } [targets]
-   * @returns {Promise<boolean | {target: any, thing: any} | undefined>}
+   * @param {string[]} [targets]
+   * @returns {MaybePromise<boolean | {target: any, thing: any} | undefined>}
    */
-  async function performAction(action, actor, event = null, targets = []) {
+  function performAction(action, actor, event = null, targets = []) {
     if (!action || !(action.type in actionFuncs)) return false
 
     if (action.sourceId) {
@@ -1490,17 +1524,26 @@ if (!globalThis.GURPS) {
       if (!actor || actor.id === originalActor.id) actor = originalActor
     }
 
-    // const origAction = action
     const originalOtf = action.orig
     const calcOnly = action.calcOnly
 
-    if (['attribute', 'skill-spell'].includes(action.type)) {
-      action = await findBestActionInChain({ action, event, actor, targets, originalOtf })
+    if (calcOnly) {
+      if (['attribute', 'skill-spell'].includes(action.type)) {
+        action = findBestActionInChainSync({ action, event, actor, targets, originalOtf })
+      }
+
+      return !action ? false : GURPS.actionFuncs[action.type]({ action, actor, event, targets, originalOtf, calcOnly })
     }
 
-    return !action
-      ? false
-      : await GURPS.actionFuncs[action.type]({ action, actor, event, targets, originalOtf, calcOnly })
+    return (async () => {
+      if (['attribute', 'skill-spell'].includes(action.type)) {
+        action = await findBestActionInChain({ action, event, actor, targets, originalOtf })
+      }
+
+      return !action
+        ? false
+        : await GURPS.actionFuncs[action.type]({ action, actor, event, targets, originalOtf, calcOnly })
+    })()
   }
 
   GURPS.performAction = performAction
@@ -1519,21 +1562,25 @@ if (!globalThis.GURPS) {
     let skillRegExp = new RegExp(removeOtf + makeRegexPatternFrom(sname, false, false), 'i')
     let best = 0
 
-    if (!isSpellOnly)
-      recurselist(actor.skills, skill => {
-        if (skill.name?.match(skillRegExp) && skill.level > best) {
+    if (!isSpellOnly) {
+      actor.allSkillsV2.forEach(skill => {
+        if (skill.name?.match(skillRegExp) && skill.system.level > best) {
           item = skill
-          best = parseInt(skill.level)
+          best = skill.system.level
         }
       })
-    if (!item)
-      if (!isSkillOnly)
-        recurselist(actor.spells, spell => {
-          if (spell.name?.match(skillRegExp) && spell.level > best) {
+    }
+
+    if (!item) {
+      if (!isSkillOnly) {
+        actor.allSpellsV2.forEach(spell => {
+          if (spell.name?.match(skillRegExp) && spell.system.level > best) {
             item = spell
-            best = parseInt(spell.level)
+            best = spell.system.level
           }
         })
+      }
+    }
 
     return item
   }

--- a/src/module/gurps.js
+++ b/src/module/gurps.js
@@ -1532,7 +1532,13 @@ if (!globalThis.GURPS) {
         action = findBestActionInChainSync({ action, event, actor, targets, originalOtf })
       }
 
-      return !action ? false : GURPS.actionFuncs[action.type]({ action, actor, event, targets, originalOtf, calcOnly })
+      if (!action) return false
+
+      const result = GURPS.actionFuncs[action.type]({ action, actor, event, targets, originalOtf, calcOnly })
+      if (result && typeof result.then === 'function') {
+        throw new Error(`GURPS.performAction(calcOnly) requires a synchronous action handler for type "${action.type}"`)
+      }
+      return result
     }
 
     return (async () => {

--- a/src/module/gurps.js
+++ b/src/module/gurps.js
@@ -1535,9 +1535,11 @@ if (!globalThis.GURPS) {
       if (!action) return false
 
       const result = GURPS.actionFuncs[action.type]({ action, actor, event, targets, originalOtf, calcOnly })
+
       if (result && typeof result.then === 'function') {
         throw new Error(`GURPS.performAction(calcOnly) requires a synchronous action handler for type "${action.type}"`)
       }
+
       return result
     }
 

--- a/src/module/item/data/base.ts
+++ b/src/module/item/data/base.ts
@@ -332,6 +332,14 @@ abstract class BaseItemModel<Schema extends BaseItemModelSchema = BaseItemModelS
 
   /* ---------------------------------------- */
 
+  /**
+   * Called after individual data preparation for each Item is complete.
+   * Used to set varues that depend on the data of sibling items,
+   */
+  prepareSiblingData(): void {}
+
+  /* ---------------------------------------- */
+
   getGlobalBonuses(): AnyObject[] {
     const bonuses = []
 

--- a/src/module/item/data/base.ts
+++ b/src/module/item/data/base.ts
@@ -334,7 +334,7 @@ abstract class BaseItemModel<Schema extends BaseItemModelSchema = BaseItemModelS
 
   /**
    * Called after individual data preparation for each Item is complete.
-   * Used to set varues that depend on the data of sibling items,
+   * Used to set values that depend on the data of sibling items.
    */
   prepareSiblingData(): void {}
 

--- a/src/module/item/data/skill.ts
+++ b/src/module/item/data/skill.ts
@@ -92,9 +92,19 @@ class SkillModel extends BaseItemModel<SkillSchema> {
     const result = GURPS.performAction(action.action, this.actor) as unknown as
       | boolean
       | { target: number; thing: any }
+      | Promise<unknown>
       | undefined
 
-    if (result && typeof result === 'object') {
+    if (
+      result &&
+      typeof result === 'object' &&
+      'then' in result &&
+      typeof result.then === 'function'
+    ) {
+      return
+    }
+
+    if (result && typeof result === 'object' && typeof result.target === 'number') {
       this.level = result.target
     }
   }

--- a/src/module/item/data/skill.ts
+++ b/src/module/item/data/skill.ts
@@ -87,14 +87,16 @@ class SkillModel extends BaseItemModel<SkillSchema> {
     if (!action.action) return
 
     action.action.calcOnly = true
-    // TODO: verify that target is of type "number" (or replace this whole thing)
-    GURPS.performAction(action.action, this.actor).then(
-      (result: boolean | { target: number; thing: any } | undefined) => {
-        if (result && typeof result === 'object') {
-          this.level = result.target
-        }
-      }
-    )
+    action.action.suppressWarnings = true
+
+    const result = GURPS.performAction(action.action, this.actor) as unknown as
+      | boolean
+      | { target: number; thing: any }
+      | undefined
+
+    if (result && typeof result === 'object') {
+      this.level = result.target
+    }
   }
 
   /* ---------------------------------------- */

--- a/src/module/item/data/skill.ts
+++ b/src/module/item/data/skill.ts
@@ -96,10 +96,8 @@ class SkillModel extends BaseItemModel<SkillSchema> {
       | undefined
 
     if (
-      result &&
-      typeof result === 'object' &&
-      'then' in result &&
-      typeof result.then === 'function'
+      (result && result instanceof Promise) ||
+      (typeof result === 'object' && 'then' in result && typeof result.then === 'function')
     ) {
       return
     }

--- a/src/module/item/data/spell.ts
+++ b/src/module/item/data/spell.ts
@@ -91,12 +91,15 @@ class SpellModel extends BaseItemModel<SpellSchema> {
     action.action.calcOnly = true
     action.action.suppressWarnings = true
 
-    const result = GURPS.performAction(action.action, this.actor) as unknown as
-      | boolean
-      | { target: number; thing: any }
-      | undefined
+    const result = GURPS.performAction(action.action, this.actor) as unknown
 
-    if (result && typeof result === 'object') {
+    if (
+      result &&
+      typeof result === 'object' &&
+      typeof (result as PromiseLike<unknown>).then !== 'function' &&
+      'target' in result &&
+      typeof result.target === 'number'
+    ) {
       this.level = result.target
     }
   }

--- a/src/module/item/data/spell.ts
+++ b/src/module/item/data/spell.ts
@@ -89,14 +89,16 @@ class SpellModel extends BaseItemModel<SpellSchema> {
     if (!action.action) return
 
     action.action.calcOnly = true
-    // TODO: verify that target is of type "number" (or replace this whole thing)
-    GURPS.performAction(action.action, this.actor).then(
-      (result: boolean | { target: number; thing: any } | undefined) => {
-        if (result && typeof result === 'object') {
-          this.level = result.target
-        }
-      }
-    )
+    action.action.suppressWarnings = true
+
+    const result = GURPS.performAction(action.action, this.actor) as unknown as
+      | boolean
+      | { target: number; thing: any }
+      | undefined
+
+    if (result && typeof result === 'object') {
+      this.level = result.target
+    }
   }
 
   /* ---------------------------------------- */

--- a/src/module/item/gurps-item.ts
+++ b/src/module/item/gurps-item.ts
@@ -377,6 +377,19 @@ class GurpsItemV2<SubType extends Item.SubType = Item.SubType>
   }
 
   /* ---------------------------------------- */
+
+  /**
+   * Called after individual data preparation for each Item is complete.
+   * Used to set varues that depend on the data of sibling items,
+   */
+  prepareSiblingData() {
+    for (const collection of Object.values(this.pseudoCollections))
+      for (const pseudo of collection) pseudo.prepareSiblingData()
+
+    this.modelV2.prepareSiblingData()
+  }
+
+  /* ---------------------------------------- */
   /*  Data Migration                          */
   /* ---------------------------------------- */
 

--- a/src/module/item/gurps-item.ts
+++ b/src/module/item/gurps-item.ts
@@ -380,7 +380,7 @@ class GurpsItemV2<SubType extends Item.SubType = Item.SubType>
 
   /**
    * Called after individual data preparation for each Item is complete.
-   * Used to set varues that depend on the data of sibling items,
+   * Used to set values that depend on the data of sibling items.
    */
   prepareSiblingData() {
     for (const collection of Object.values(this.pseudoCollections))

--- a/src/module/pseudo-document/pseudo-document.ts
+++ b/src/module/pseudo-document/pseudo-document.ts
@@ -231,7 +231,7 @@ class PseudoDocument<
    * Prepare base data. This method is not called automatically; it is the responsibility
    * of the parent document to ensure pseudo-documents prepare base and derived data.
    */
-  prepareBaseData() {}
+  prepareBaseData(): void {}
 
   /* ---------------------------------------- */
 
@@ -239,7 +239,16 @@ class PseudoDocument<
    * Prepare derived data. This method is not called automatically; it is the responsibility
    * of the parent document to ensure pseudo-documents prepare base and derived data.
    */
-  prepareDerivedData() {}
+  prepareDerivedData(): void {}
+
+  /* ---------------------------------------- */
+
+  /**
+   * Prepare sibling data data. The siblings in question are siblings of the parent Document, rather than siblings of
+   * this pseudo-document. This method is not called automatically; it is the responsibility
+   * of the parent document to ensure pseudo-documents prepare base and derived data.
+   */
+  prepareSiblingData(): void {}
 
   /* ---------------------------------------- */
   /*   Instance Methods                       */

--- a/src/module/pseudo-document/pseudo-document.ts
+++ b/src/module/pseudo-document/pseudo-document.ts
@@ -244,9 +244,9 @@ class PseudoDocument<
   /* ---------------------------------------- */
 
   /**
-   * Prepare sibling data data. The siblings in question are siblings of the parent Document, rather than siblings of
+   * Prepare sibling data. The siblings in question are siblings of the parent Document, rather than siblings of
    * this pseudo-document. This method is not called automatically; it is the responsibility
-   * of the parent document to ensure pseudo-documents prepare base and derived data.
+   * of the parent document to ensure pseudo-documents prepare sibling data.
    */
   prepareSiblingData(): void {}
 

--- a/static/system.json
+++ b/static/system.json
@@ -69,7 +69,6 @@
   "documentTypes": {
     "Actor": {
       "character": {},
-      "enemy": {},
       "gcsCharacter": {},
       "gcsLoot": {}
     },

--- a/static/templates/action/partials/details-melee-attack.hbs
+++ b/static/templates/action/partials/details-melee-attack.hbs
@@ -6,6 +6,10 @@
     {{formGroup fields.importedLevel value=source.importedLevel}}
   </div>
 
+  <div class="ms-field-row" style="--ms-cols: 1;">
+    {{formGroup fields.otf value=source.otf }}
+  </div>
+
   <div class="ms-field-row">
     {{formGroup fields.st value=source.st}}
     {{formGroup fields.consumeAction value=source.consumeAction}}

--- a/static/templates/action/partials/details-ranged-attack.hbs
+++ b/static/templates/action/partials/details-ranged-attack.hbs
@@ -6,6 +6,10 @@
     {{formGroup fields.importedLevel value=source.importedLevel}}
   </div>
 
+  <div class="ms-field-row" style="--ms-cols: 1;">
+    {{formGroup fields.otf value=source.otf }}
+  </div>
+
   <div class="ms-field-row">
     {{formGroup fields.st value=source.st}}
     {{formGroup fields.consumeAction value=source.consumeAction}}

--- a/test/module/action/melee-attack.test.ts
+++ b/test/module/action/melee-attack.test.ts
@@ -118,6 +118,7 @@ describe('MeleeAttackModel', () => {
         const model = makeMelee({ parry: { canParry: false, fencing: false, unbalanced: false, modifier: 0 } })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.parryText).toBe('GURPS.action.meleeAttack.parryDisabled')
       })
@@ -142,6 +143,7 @@ describe('MeleeAttackModel', () => {
         )
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.parryText).toBe(expected)
       })
@@ -154,6 +156,7 @@ describe('MeleeAttackModel', () => {
         const model = makeMelee({ block: { canBlock: false, modifier: 0 } })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.blockText).toBe('GURPS.action.meleeAttack.blockDisabled')
       })
@@ -174,6 +177,7 @@ describe('MeleeAttackModel', () => {
         )
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.blockText).toBe(expected)
       })
@@ -196,6 +200,7 @@ describe('MeleeAttackModel', () => {
         const model = makeMelee({ reach })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.reachText).toBe(expected)
       })

--- a/test/module/action/ranged-attack.test.ts
+++ b/test/module/action/ranged-attack.test.ts
@@ -283,6 +283,7 @@ describe('RangedAttackModel', () => {
         const model = makeRanged({ acc: { base: 0, scope: 0, jet: true } })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.accText).toBe('GURPS.action.rangedAttack.jet')
       })
@@ -297,6 +298,7 @@ describe('RangedAttackModel', () => {
         const model = makeRanged({ acc })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.accText).toBe(expected)
       })
@@ -317,6 +319,7 @@ describe('RangedAttackModel', () => {
         const model = makeRanged({ bulk })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.bulkText).toBe(expected)
       })
@@ -340,6 +343,7 @@ describe('RangedAttackModel', () => {
         const model = makeRanged({ range })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.rangeText).toBe(expected)
       })
@@ -352,6 +356,7 @@ describe('RangedAttackModel', () => {
         const model = makeRanged({ rateOfFire: rofWith({}, {}, true) })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.rofText).toBe('GURPS.action.rangedAttack.jet')
       })
@@ -360,6 +365,7 @@ describe('RangedAttackModel', () => {
         const model = makeRanged({ rateOfFire: rofWith() })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.rofText).toBe('')
       })
@@ -378,6 +384,7 @@ describe('RangedAttackModel', () => {
         const model = makeRanged({ rateOfFire: rofWith(mode1Overrides) })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.rofText).toBe(expected)
       })
@@ -386,6 +393,7 @@ describe('RangedAttackModel', () => {
         const model = makeRanged({ rateOfFire: rofWith({ shotsPerAttack: 3 }, { shotsPerAttack: 20 }) })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.rofText).toBe('3/20')
       })
@@ -394,6 +402,7 @@ describe('RangedAttackModel', () => {
         const model = makeRanged({ rateOfFire: rofWith({}, { shotsPerAttack: 20 }) })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.rofText).toBe('20')
       })
@@ -410,6 +419,7 @@ describe('RangedAttackModel', () => {
         const model = makeRanged({ recoil })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.recoilText).toBe(expected)
       })
@@ -424,6 +434,7 @@ describe('RangedAttackModel', () => {
         })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.shotsText).toBe('T')
       })
@@ -449,6 +460,7 @@ describe('RangedAttackModel', () => {
         const model = makeRanged({ shots: { ...shotsDefaults, ...shotsOverrides } })
 
         model.prepareDerivedData()
+        model.prepareSiblingData()
 
         expect(model.shotsText).toBe(expected)
       })


### PR DESCRIPTION
This PR fixes issues caused by the calculation of Attack levels being tied to the data preparation of a given Item, which may have its data prepared before Items on which the Action's OTF level calculation depends.

This bug would sometimes cause an incorrect level to render on the sheet for some attacks, and also cause some attacks to appear to have a level of `0` immediately after import.

The fix consists of the following:
- Changes `GURPS.performAction` so that passing `calcOnly = true` leads to a synchronous response.
- Adds a `prepareSiblingData` method to Items and PseudoDocuments, which runs for all owned items _after_ the individual data preparation of each item is completed.

Resolves #2672 
Resolves #2670 