### PR TITLE
GCS Actor Sheet CSS Tweaks

### DIFF
--- a/src/styles/gcs-sheet/_items.scss
+++ b/src/styles/gcs-sheet/_items.scss
@@ -20,22 +20,46 @@
     }
   }
 
-  colgroup {
-    col.gcs-col-name {
-      width: 100%;
-    }
-  }
-
   /* ---------------------------------------- */
 
   // Column sizing: min-width is enforced by the browser; max-width clips overflow.
   // Alignment is co-located here since it is tightly coupled to column identity.
+
+  td.gcs-item-name {
+    @include gcs-col(10rem, 100%);
+  }
 
   td.gcs-item-modifier {
     @include gcs-col(2rem, 3.5rem);
   }
 
   td.gcs-item-level {
+    @include gcs-col(2rem, 3.5rem);
+    text-align: center;
+  }
+
+  td.gcs-item-usage {
+    @include gcs-col(3rem, 6rem);
+    text-align: center;
+  }
+
+  td.gcs-item-damage {
+    @include gcs-col(3rem, 4rem);
+    text-align: center;
+  }
+
+  td.gcs-item-parry,
+  td.gcs-item-block {
+    @include gcs-col(2rem, 4.5rem);
+    text-align: center;
+  }
+
+  td.gcs-item-reach {
+    @include gcs-col(2rem, 3rem);
+    text-align: center;
+  }
+
+  td.gcs-item-st {
     @include gcs-col(2rem, 3.5rem);
     text-align: center;
   }

--- a/static/templates/actor/gcs/resources.hbs
+++ b/static/templates/actor/gcs/resources.hbs
@@ -102,7 +102,7 @@
         <tbody>
           {{#each systemSource.hitlocationsV2 as |location|}}
             <tr>
-              <td>{{location.rollText}}</td>
+              <td class="gcs-row-roll">{{location.rollText}}</td>
               <td>{{location.where}}</td>
               <td
                 class="form-fields {{ifThen (gte location.penalty 0) 'gcs-mod-positive' 'gcs-mod-negative' }}"
@@ -110,7 +110,7 @@
                 data-value="{{location.penalty}}"
                 data-comment="{{localize 'GURPS.hitLocationPenalty'}}: {{location.where}}"
                 >{{location.penalty}}</td>
-              <td>{{location._dr}}</td>
+              <td class="gcs-row-dr">{{location._dr}}</td>
             </tr>
           {{/each}}
         </tbody>


### PR DESCRIPTION
This PR changes the combat table display so usage and damage have adequate space in order to not wrap in most cases.
It also center-aligns the roll range values on the hit location table