### PR TITLE
Bugfix: Reference to @lib/acorn.mjs is ignored by tsc-alias when running build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "minimatch": "^10.2.2"
   },
   "scripts": {
-    "build": "npm run clean && npm run build:code && npm run build:styles && npm run build:static",
+    "build": "npm run clean && npm run build:static && npm run build:code && npm run build:styles",
     "build:code": "tsc && tsc-alias -p tsconfig.json",
     "build:static": "node build/sync-static-files.js",
     "build:styles": "sass --no-source-map src/styles/gurps.scss:dist/styles/gurps.css",


### PR DESCRIPTION
The issue was caused by running `build:code` before `build:static`, where `build:static` copies the contents of `src/lib/` to the `dist/` folder, and `build:code` runs `tsc-alias`. Since the contents of `src/lib/` is not copied by the time `tsc-alias` runs, the alias reference is not swapped out for a relative reference.

Resolves #2673 