### PR TITLE
Fix: Modifier Notes are not being imported from GCS

### DIFF
--- a/src/module/importer/gca-importer/importer.ts
+++ b/src/module/importer/gca-importer/importer.ts
@@ -815,7 +815,7 @@ Portrait will not be imported.`
   #importTrait(trait: GCATrait, containedBy: string | null = null): void {
     const type = ItemType.Trait
 
-    let name = trait.name ?? 'Trait'
+    let name = trait.name || globalThis._loc('TYPES.Item.feature')
     const crRegex = /\[\s*CR: (\d{1,2})\s*\]/i
 
     const isLeveled = trait.calcs.cost?.includes('/') ?? false
@@ -860,8 +860,7 @@ Portrait will not be imported.`
 
   #importSkill(skill: GCATrait, containedBy: string | null = null): void {
     const type = ItemType.Skill
-    // TODO: localize
-    const name = skill.name ?? 'Skill'
+    const name = skill.name || globalThis._loc('TYPES.Item.skill')
 
     const [baseSystem, _id] = this.#importItem(skill, containedBy)
 
@@ -889,8 +888,7 @@ Portrait will not be imported.`
 
   #importSpell(spell: GCATrait, containedBy: string | null = null): void {
     const type = ItemType.Spell
-    // TODO: localize
-    const name = spell.name ?? 'Spell'
+    const name = spell.name || globalThis._loc('TYPES.Item.spell')
 
     let spellClass = ''
     let spellResist = ''
@@ -952,7 +950,7 @@ Portrait will not be imported.`
 
   #importEquipment(equipment: GCATrait, containedBy: string | null = null): void {
     const type = ItemType.Equipment
-    const name = equipment.name ?? 'Equipment'
+    const name = equipment.name || globalThis._loc('TYPES.Item.equipment')
 
     const [baseSystem, _id] = this.#importItem(equipment, containedBy)
 

--- a/src/module/importer/gcs-importer/importer.ts
+++ b/src/module/importer/gcs-importer/importer.ts
@@ -1017,13 +1017,29 @@ Portrait will not be imported.`
 
   #importTrait(trait: GcsTrait, index: number, containedBy?: string | undefined): Item.CreateData {
     const type = ItemType.Trait
-    // TODO: localize
-    const name = trait.name ?? 'Trait'
+    const name = trait.name || globalThis._loc('TYPES.Item.feature')
 
     const [baseSystem, _id] = this.#importItem(trait)
+    let modifierNotes = ''
 
+    const modifiers = trait.modifiers?.filter(mod => mod.isEnabled) ?? []
+
+    for (const modifier of modifiers) {
+      if (modifierNotes) modifierNotes += '; '
+
+      modifierNotes += modifier.name
+      const modNotes = modifier.calc?.resolved_notes || modifier.local_notes || ''
+
+      if (modifier.levels) modifierNotes += `${modifier.levels}`
+
+      if (modNotes) modifierNotes += ` (${modNotes})`
+    }
+
+    const baseNotes = baseSystem.notes || ''
+    const notes = [modifierNotes, baseNotes].filter(note => note !== '').join('\n')
     const system: DataModel.CreateData<TraitSchema> = {
       ...baseSystem,
+      notes,
       disabled: trait.disabled,
       containedBy: containedBy ?? null,
       cr: trait.cr ?? null,
@@ -1034,7 +1050,6 @@ Portrait will not be imported.`
 
     trait.childItems?.forEach((child: GcsTrait, childIndex: number) => this.#importTrait(child, childIndex, _id))
 
-    // component.contains = children.map((c: Item.CreateData) => c._id as string)
     const item: Item.CreateData<ItemType.Trait> = {
       _id,
       type,
@@ -1052,8 +1067,7 @@ Portrait will not be imported.`
 
   #importSkill(skill: GcsSkill, index: number, containedBy?: string | undefined): Item.CreateData {
     const type = ItemType.Skill
-    // TODO: localize
-    const name = skill.name ?? 'Skill'
+    const name = skill.name || globalThis._loc('TYPES.Item.skill')
 
     const [baseSystem, _id] = this.#importItem(skill)
 
@@ -1087,8 +1101,7 @@ Portrait will not be imported.`
 
   #importSpell(spell: GcsSpell, index: number, containedBy?: string | undefined): Item.CreateData {
     const type = ItemType.Spell
-    // TODO: localize
-    const name = spell.name ?? 'Spell'
+    const name = spell.name || globalThis._loc('TYPES.Item.spell')
 
     const [baseSystem, _id] = this.#importItem(spell)
 
@@ -1133,17 +1146,32 @@ Portrait will not be imported.`
     containedBy?: string | undefined
   ): Item.CreateData {
     const type = ItemType.Equipment
-    // TODO: localize
-    const name = equipment.name ?? 'Equipment'
+    const name = equipment.name || globalThis._loc('TYPES.Item.equipment')
 
     const weight = equipment.calc?.weight
       ? parseFloat(equipment.calc.weight)
       : parseFloat(equipment.calc?.extended_weight || '0')
 
     const [baseSystem, _id] = this.#importItem(equipment)
+    let modifierNotes = ''
+
+    const modifiers = equipment.modifiers?.filter(mod => mod.isEnabled) ?? []
+
+    for (const modifier of modifiers) {
+      if (modifierNotes) modifierNotes += '; '
+
+      modifierNotes += modifier.name
+      const modNotes = modifier.calc?.resolved_notes || modifier.local_notes || ''
+
+      if (modNotes) modifierNotes += ` (${modNotes})`
+    }
+
+    const baseNotes = baseSystem.notes || ''
+    const notes = [modifierNotes, baseNotes].filter(note => note !== '').join('\n')
 
     const system: DataModel.CreateData<EquipmentSchema> = {
       ...baseSystem,
+      notes,
       containedBy: containedBy ?? null,
       count: equipment.quantity ?? 1,
       weight,

--- a/src/module/importer/gcs-importer/schema/equipment-modifier.ts
+++ b/src/module/importer/gcs-importer/schema/equipment-modifier.ts
@@ -25,6 +25,12 @@ class GcsEquipmentModifier extends GcsItem<EquipmentModifierData> {
   override get isContainer(): boolean {
     return this.id.startsWith('F')
   }
+
+  /* ---------------------------------------- */
+
+  override get isEnabled(): boolean {
+    return !this.disabled || this.isContainer
+  }
 }
 
 /* ---------------------------------------- */
@@ -71,6 +77,15 @@ const equipmentModifierData = () => {
     weight: new fields.StringField({ required: true, nullable: true }),
     features: new fields.ArrayField(new fields.ObjectField({ required: true, nullable: false })),
     // END: EquipmentModifierNonContainerSyncData
+
+    // START: calc
+    calc: new fields.SchemaField(
+      {
+        resolved_notes: new fields.StringField({ required: true, nullable: true, initial: null }),
+      },
+      { required: true, nullable: true, initial: null }
+    ),
+    // END: calc
   }
 }
 

--- a/src/module/importer/gcs-importer/schema/equipment.ts
+++ b/src/module/importer/gcs-importer/schema/equipment.ts
@@ -82,7 +82,7 @@ const equipmentData = () => {
     // END: EquipmentModel
 
     // START: EquipmentEditData
-    modifiers: new fields.ArrayField(new fields.ObjectField({ required: true, nullable: false }), {
+    modifiers: new fields.ArrayField(new fields.EmbeddedDataField(GcsEquipmentModifier), {
       required: true,
       nullable: true,
       initial: null,

--- a/src/module/importer/gcs-importer/schema/trait-modifier.ts
+++ b/src/module/importer/gcs-importer/schema/trait-modifier.ts
@@ -22,8 +22,31 @@ class GcsTraitModifier extends GcsItem<TraitModifierData> {
 
   /* ---------------------------------------- */
 
+  protected static override _importField(
+    data: any,
+    field: fields.DataField.Any,
+    name: string,
+    replacements: Record<string, string> = {}
+  ): any {
+    switch (name) {
+      case 'name':
+      case 'local_notes':
+        return this.processReplacements(data, replacements) ?? field.getInitialValue()
+      default:
+        return super._importField(data, field, name, replacements)
+    }
+  }
+
+  /* ---------------------------------------- */
+
   override get isContainer(): boolean {
     return this.id.startsWith('M')
+  }
+
+  /* ---------------------------------------- */
+
+  override get isEnabled(): boolean {
+    return !this.disabled || this.isContainer
   }
 }
 
@@ -56,6 +79,11 @@ const traitModifierData = () => {
     }),
     // END: TraitModifierSyncData
 
+    // START: TraitModifierEditDataNonContainerOnly
+    levels: new fields.NumberField({ required: true, nullable: true }),
+    disabled: new fields.BooleanField({ required: true, nullable: true }),
+    // END: TraitModifierEditDataNonContainerOnly
+
     // START: TraitModifierNonContainerSyncData
     cost: new fields.NumberField({ required: true, nullable: true }),
     cost_type: new fields.StringField({ required: true, nullable: true }),
@@ -64,6 +92,15 @@ const traitModifierData = () => {
     affects: new fields.StringField({ required: true, nullable: true }),
     features: new fields.ArrayField(new fields.ObjectField({ required: true, nullable: false })),
     // END: TraitModifierNonContainerSyncData
+
+    // START: calc
+    calc: new fields.SchemaField(
+      {
+        resolved_notes: new fields.StringField({ required: true, nullable: true, initial: null }),
+      },
+      { required: true, nullable: true, initial: null }
+    ),
+    // END: calc
   }
 }
 

--- a/src/module/importer/gcs-importer/schema/trait.ts
+++ b/src/module/importer/gcs-importer/schema/trait.ts
@@ -116,7 +116,8 @@ class GcsTrait extends GcsItem<TraitModel> {
     return this.container_type === 'ancestry'
   }
 
-  /** @abstract */
+  /* ---------------------------------------- */
+
   override get isEnabled(): boolean {
     return !this.effectivelyDisabled
   }
@@ -141,7 +142,7 @@ const traitData = () => {
 
     // START: TraitEditData
     userdesc: new fields.StringField({ required: true, nullable: true, initial: null }),
-    modifiers: new fields.ArrayField(new fields.ObjectField({ required: true, nullable: false }), {
+    modifiers: new fields.ArrayField(new fields.EmbeddedDataField(GcsTraitModifier), {
       required: true,
       nullable: true,
       initial: null,

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -21,7 +21,7 @@ export {}
 declare global {
   /* ---------------------------------------- */
 
-  const _loc: typeof game.i18n.localize
+  var _loc: typeof game.i18n.localize
 
   /* ---------------------------------------- */
 


### PR DESCRIPTION
This PR fixes an issue wherein the notes generated by Trait and Equipment modifiers are not imported from GCS.

Resolves #2668 