### PR TITLE
Fix: Error message shows when dropping an Item onto the canvas

### DIFF
--- a/src/module/actor/data/gcs-character/gcs-character.ts
+++ b/src/module/actor/data/gcs-character/gcs-character.ts
@@ -149,7 +149,7 @@ const gcsCharacterSchema = () => {
       required: true,
       nullable: false,
       initial: (data: any) =>
-        data.settings?._attributes ? GcsAttribute.setFromDefinitions(data.settings._attributes) : {},
+        data?.settings?._attributes ? GcsAttribute.setFromDefinitions(data.settings._attributes) : {},
     }),
     createdOn: new fields.StringField({ required: true, nullable: false }),
     modifiedOn: new fields.StringField({ required: true, nullable: false }),

--- a/src/module/damage/damagechat.js
+++ b/src/module/damage/damagechat.js
@@ -90,17 +90,14 @@ export default class DamageChat {
    * @param {{ type: string; x: number; y: number; payload: any; }} dropData
    */
   static async _dropCanvasData(canvas, dropData) {
-    const actor = game.actors.get(dropData.actorid)
-
     switch (dropData.type) {
       case DragDropType.DAMAGE:
         await DamageChat._calculateAndSelectTargets(canvas, dropData)
-        break
-      case 'Item':
-        await actor.handleItemDrop(dropData)
+
+        return false
     }
 
-    return false
+    return true
   }
 
   /**


### PR DESCRIPTION
This PR removes the system-specific handling of Items dropped onto the canvas.

Resolves #2683 