### PR TITLE
Fix: Technique notes not imported from GCS

### DIFF
--- a/src/module/importer/gcs-importer/importer.ts
+++ b/src/module/importer/gcs-importer/importer.ts
@@ -13,6 +13,7 @@ import { SkillSchema } from '@module/item/data/skill.js'
 import { SpellSchema } from '@module/item/data/spell.js'
 import { TraitSchema } from '@module/item/data/trait.js'
 import { ItemType } from '@module/item/types.js'
+import { getGame } from '@module/util/guards.js'
 import { HitLocationRole } from '@rules/hit-locations/types.js'
 import { AnyMutableObject, AnyObject } from 'fvtt-types/utils'
 
@@ -1057,8 +1058,52 @@ Portrait will not be imported.`
 
     const [baseSystem, _id] = this.#importItem(skill)
 
+    let notes = baseSystem.notes || ''
+
+    if (skill.isTechnique && skill.default) {
+      let defaultName = ''
+
+      switch (skill.default.type) {
+        case 'parry':
+        case 'block':
+        case 'skill': {
+          defaultName = skill.default.name || ''
+
+          if (skill.default.specialization) defaultName += ` (${skill.default.specialization})`
+
+          if (skill.default.type === 'block') defaultName += ' ' + globalThis._loc('GURPS.block')
+          else if (skill.default.type === 'parry') defaultName += ' ' + globalThis._loc('GURPS.parry')
+
+          break
+        }
+
+        default: {
+          if (this._mode === GcsImporterMode.Character) {
+            const attribute = (this.input as GcsCharacter).settings.attributes.find(
+              att => att.id === skill.default!.type
+            )
+
+            defaultName = attribute?.fullName || ''
+          }
+        }
+      }
+
+      if (skill.default.modifier) {
+        defaultName += skill.default.modifier.signedString()
+      }
+
+      const defaultNote = getGame().i18n.format('GURPS.item.skill.techniqueDefaultNote', { defaultName })
+
+      if (notes) {
+        notes = defaultNote + '\n' + notes
+      } else {
+        notes = defaultNote
+      }
+    }
+
     const system: DataModel.CreateData<SkillSchema> = {
       ...baseSystem,
+      notes,
       containedBy: containedBy ?? null,
       points: skill.points ?? 0,
       difficulty: skill.difficulty ?? '',

--- a/src/module/importer/gcs-importer/schema/attribute-definition.ts
+++ b/src/module/importer/gcs-importer/schema/attribute-definition.ts
@@ -1,0 +1,40 @@
+import { fields } from '@gurps-types/foundry/index.js'
+
+import { GcsElement } from './base.js'
+
+/* ---------------------------------------- */
+
+class GcsAttributeDefinition extends GcsElement<AttributeDefinitionData> {
+  static override defineSchema(): AttributeDefinitionData {
+    return attributeDefinitionData()
+  }
+
+  /* ---------------------------------------- */
+
+  get fullName(): string {
+    if (!this.full_name) return this.name
+
+    return this.full_name
+  }
+}
+
+/* ---------------------------------------- */
+
+const attributeDefinitionData = () => {
+  return {
+    id: new fields.StringField({ required: true, nullable: false }),
+    type: new fields.StringField({ required: true, nullable: false }),
+    placement: new fields.StringField({ required: true, nullable: false }),
+    name: new fields.StringField({ required: true, nullable: false }),
+    full_name: new fields.StringField({ required: true, nullable: false }),
+    base: new fields.StringField({ required: true, nullable: false }),
+    cost_per_point: new fields.NumberField({ required: true, nullable: false, initial: 0 }),
+    cost_adj_percent_per_sm: new fields.NumberField({ required: true, nullable: false, initial: 0 }),
+  }
+}
+
+type AttributeDefinitionData = ReturnType<typeof attributeDefinitionData>
+
+/* ---------------------------------------- */
+
+export { GcsAttributeDefinition, attributeDefinitionData, type AttributeDefinitionData }

--- a/src/module/importer/gcs-importer/schema/character.ts
+++ b/src/module/importer/gcs-importer/schema/character.ts
@@ -1,5 +1,6 @@
 import { fields } from '@gurps-types/foundry/index.js'
 
+import { GcsAttributeDefinition } from './attribute-definition.js'
 import { GcsAttribute } from './attribute.js'
 import { GcsElement } from './base.js'
 import { GcsBody } from './body.js'
@@ -21,8 +22,14 @@ class GcsCharacter extends GcsElement<GcsCharacterModel> {
     switch (name) {
       case 'body_type':
         return GcsBody.importSchema(data, GcsBody.defineSchema())
-      case 'attributes':
+      case 'attributes': {
+        // Only happens for settings.attributes
+        if (field.fieldPath === 'attributes') {
+          return data?.map((attributeData: any) => GcsAttributeDefinition.importSchema(attributeData))
+        }
+
         return data?.map((attributeData: any) => GcsAttribute.importSchema(attributeData))
+      }
       case 'advantages':
       case 'traits':
         return data?.map((traitData: any) => GcsTrait.importSchema(traitData))
@@ -33,8 +40,6 @@ class GcsCharacter extends GcsElement<GcsCharacterModel> {
       case 'equipment':
       case 'other_equipment':
         return data?.map((equipmentData: any) => GcsEquipment.importSchema(equipmentData))
-      // case 'notes':
-      //   return data?.map((noteData: any) => GcsNote.importSchema(noteData))
       default:
         return super._importField(data, field, name)
     }
@@ -163,6 +168,14 @@ const characterData = () => {
     settings: new fields.SchemaField(
       {
         body_type: new fields.EmbeddedDataField(GcsBody, { required: true, nullable: false }),
+        attributes: new fields.ArrayField(
+          new fields.EmbeddedDataField(GcsAttributeDefinition, { required: true, nullable: false }),
+
+          {
+            required: true,
+            nullable: false,
+          }
+        ),
       },
       { required: true, nullable: false }
     ),

--- a/src/module/importer/gcs-importer/schema/skill.ts
+++ b/src/module/importer/gcs-importer/schema/skill.ts
@@ -30,6 +30,12 @@ class GcsSkill extends GcsItem<SkillModel> {
 
   /* ---------------------------------------- */
 
+  get isTechnique(): boolean {
+    return this.id.startsWith('q')
+  }
+
+  /* ---------------------------------------- */
+
   override get isContainer(): boolean {
     return this.id.startsWith('S')
   }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -21,7 +21,7 @@ export {}
 declare global {
   /* ---------------------------------------- */
 
-  const _loc: typeof game.i18n.localize
+  var _loc: typeof game.i18n.localize
 
   /* ---------------------------------------- */
 

--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -979,6 +979,7 @@
     "forPerfectBalance": "{mod} für Perfekte Standfestigkeit",
     "FP": "AP",
     "frightcheck": "Schreckprobe",
+    "frightCheck": "Schreckprobe",
     "fromEllipses": "von ...",
     "gameAidUsersGuide": "GURPS 4e Spielhilfe BENUTZERHANDBUCH",
     "grapplingControlled": "Kontrolliert",
@@ -1344,7 +1345,8 @@
           "techlevel": {
             "label": "TL"
           }
-        }
+        },
+        "techniqueDefaultNote": "Standard: {defaultName}"
       },
       "spell": {
         "FIELDS": {
@@ -1805,10 +1807,18 @@
       },
       "note": {
         "FIELDS": {
-          "title": { "label": "Titel" },
-          "markdown": { "label": "Text" },
-          "reference": { "label": "Referenz" },
-          "reference_highlight": { "label": "Referenz-Hervorhebung" }
+          "markdown": {
+            "label": "Text"
+          },
+          "reference": {
+            "label": "Referenz"
+          },
+          "reference_highlight": {
+            "label": "Referenz-Hervorhebung"
+          },
+          "title": {
+            "label": "Titel"
+          }
         }
       }
     },

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -979,6 +979,7 @@
     "forPerfectBalance": "{mod} for Perfect Balance",
     "FP": "FP",
     "frightcheck": "Fright Check",
+    "frightCheck": "Fright Check",
     "fromEllipses": "from ...",
     "gameAidUsersGuide": "GURPS 4e Game Aid USERS GUIDE",
     "grapplingControlled": "Controlled [-8 DX]",
@@ -1344,7 +1345,8 @@
           "techlevel": {
             "label": "TL"
           }
-        }
+        },
+        "techniqueDefaultNote": "Default: {defaultName}"
       },
       "spell": {
         "FIELDS": {
@@ -1805,10 +1807,18 @@
       },
       "note": {
         "FIELDS": {
-          "title": { "label": "Title" },
-          "markdown": { "label": "Text" },
-          "reference": { "label": "Reference" },
-          "reference_highlight": { "label": "Reference Highlight" }
+          "markdown": {
+            "label": "Text"
+          },
+          "reference": {
+            "label": "Reference"
+          },
+          "reference_highlight": {
+            "label": "Reference Highlight"
+          },
+          "title": {
+            "label": "Title"
+          }
         }
       }
     },

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -979,6 +979,7 @@
     "forPerfectBalance": "{mod} pour Équilibre Parfait",
     "FP": "PF",
     "frightcheck": "Résistance à la peur",
+    "frightCheck": "Résistance à la peur",
     "fromEllipses": "De ...",
     "gameAidUsersGuide": "GURPS 4e GUIDE UTILISATEUR Aide de Jeu",
     "grapplingControlled": "Contrôlé",
@@ -1344,7 +1345,8 @@
           "techlevel": {
             "label": "TL"
           }
-        }
+        },
+        "techniqueDefaultNote": "Défaut : {defaultName}"
       },
       "spell": {
         "FIELDS": {
@@ -1805,10 +1807,18 @@
       },
       "note": {
         "FIELDS": {
-          "title": { "label": "Titre" },
-          "markdown": { "label": "Texte" },
-          "reference": { "label": "Référence" },
-          "reference_highlight": { "label": "Mise en évidence de la référence" }
+          "markdown": {
+            "label": "Texte"
+          },
+          "reference": {
+            "label": "Référence"
+          },
+          "reference_highlight": {
+            "label": "Mise en évidence de la référence"
+          },
+          "title": {
+            "label": "Titre"
+          }
         }
       }
     },

--- a/static/lang/pt_br.json
+++ b/static/lang/pt_br.json
@@ -979,6 +979,7 @@
     "forPerfectBalance": "{mod} para Equilíbrio Perfeito",
     "FP": "PF",
     "frightcheck": "Verif. de Pânico",
+    "frightCheck": "Verif. de Pânico",
     "fromEllipses": "de ...",
     "gameAidUsersGuide": "Guia do Usuário do Auxílio de Jogo GURPS 4e",
     "grapplingControlled": "Sendo controlado(a)",
@@ -1344,7 +1345,8 @@
           "techlevel": {
             "label": "NT"
           }
-        }
+        },
+        "techniqueDefaultNote": "Padrão: {defaultName}"
       },
       "spell": {
         "FIELDS": {
@@ -1805,10 +1807,18 @@
       },
       "note": {
         "FIELDS": {
-          "title": { "label": "Título" },
-          "markdown": { "label": "Texto" },
-          "reference": { "label": "Referência" },
-          "reference_highlight": { "label": "Destaque de Referência" }
+          "markdown": {
+            "label": "Texto"
+          },
+          "reference": {
+            "label": "Referência"
+          },
+          "reference_highlight": {
+            "label": "Destaque de Referência"
+          },
+          "title": {
+            "label": "Título"
+          }
         }
       }
     },

--- a/static/lang/ru.json
+++ b/static/lang/ru.json
@@ -979,6 +979,7 @@
     "forPerfectBalance": "{mod} для Идеального равновесия",
     "FP": "ЕУ",
     "frightcheck": "Бросок страха",
+    "frightCheck": "Бросок страха",
     "fromEllipses": "из ...",
     "gameAidUsersGuide": "Руководство пользователя GURPS 4e Game Aid",
     "grapplingControlled": "Под контролем",
@@ -1344,7 +1345,8 @@
           "techlevel": {
             "label": "ТУ"
           }
-        }
+        },
+        "techniqueDefaultNote": "По умолчанию: {defaultName}"
       },
       "spell": {
         "FIELDS": {
@@ -1805,10 +1807,18 @@
       },
       "note": {
         "FIELDS": {
-          "title": { "label": "Заголовок" },
-          "markdown": { "label": "Текст" },
-          "reference": { "label": "Ссылка" },
-          "reference_highlight": { "label": "Выделение ссылки" }
+          "markdown": {
+            "label": "Текст"
+          },
+          "reference": {
+            "label": "Ссылка"
+          },
+          "reference_highlight": {
+            "label": "Выделение ссылки"
+          },
+          "title": {
+            "label": "Заголовок"
+          }
         }
       }
     },


### PR DESCRIPTION
This PR adds Technique notes to the GCS import. These notes are generated from the in-built skill default of a Technique.

Resolves #2681 