### PR TITLE
Refactor: GCS Importer

### DIFF
--- a/src/module/importer/gcs-importer/importer.ts
+++ b/src/module/importer/gcs-importer/importer.ts
@@ -22,11 +22,13 @@ import { ImportSettings } from '../index.js'
 
 import { GcsCollection } from './schema/base.js'
 import { GcsCharacter } from './schema/character.js'
+import { GcsEquipmentModifier } from './schema/equipment-modifier.js'
 import { GcsEquipment } from './schema/equipment.js'
 import { AnyGcsItem, AnyGcsItemCollection } from './schema/index.js'
 import { GcsNote } from './schema/note.js'
 import { GcsSkill } from './schema/skill.js'
 import { GcsSpell } from './schema/spell.js'
+import { GcsTraitModifier } from './schema/trait-modifier.js'
 import { GcsTrait } from './schema/trait.js'
 import { GcsWeapon } from './schema/weapon.js'
 
@@ -1026,7 +1028,7 @@ Portrait will not be imported.`
 
     const modifiers = trait.modifiers?.filter(mod => mod.isEnabled) ?? []
 
-    for (const modifier of modifiers) {
+    for (const modifier of modifiers as unknown as GcsTraitModifier[]) {
       if (modifierNotes) modifierNotes += '; '
 
       modifierNotes += modifier.name
@@ -1203,7 +1205,7 @@ Portrait will not be imported.`
 
     const modifiers = equipment.modifiers?.filter(mod => mod.isEnabled) ?? []
 
-    for (const modifier of modifiers) {
+    for (const modifier of modifiers as unknown as GcsEquipmentModifier[]) {
       if (modifierNotes) modifierNotes += '; '
 
       modifierNotes += modifier.name

--- a/src/module/importer/gcs-importer/schema/base.ts
+++ b/src/module/importer/gcs-importer/schema/base.ts
@@ -12,16 +12,40 @@ type SourcedIdSchema = ReturnType<typeof sourcedIdSchema>
 
 /* ---------------------------------------- */
 
+interface GcsElementClass {
+  importSchema(data: any, schema?: any, verbose?: boolean): any
+}
+
+class GcsLazyEmbeddedField extends fields.ObjectField<fields.ObjectField.DefaultOptions> {
+  readonly #classGetter: () => GcsElementClass
+
+  constructor(classGetter: () => GcsElementClass, options?: fields.DataField.Options<AnyMutableObject>) {
+    super(options as fields.ObjectField.DefaultOptions)
+    this.#classGetter = classGetter
+  }
+
+  get modelClass(): GcsElementClass {
+    return this.#classGetter()
+  }
+}
+
+/* ---------------------------------------- */
+
 class GcsElement<
   Schema extends fields.DataSchema = fields.DataSchema,
   Parent extends DataModel.Any | null = DataModel.Any | null,
 > extends DataModel<Schema, Parent> {
   container: null | GcsElement<any> = null
 
-  static fromImportData<Schema extends fields.DataSchema>(importData: AnyObject, parent: null | GcsElement = null) {
+  static fromImportData<Schema extends fields.DataSchema>(
+    importData: AnyObject,
+    parent: null | GcsElement = null,
+    verbose = false
+  ) {
     const createData: DataModel.CreateData<Schema> = this.importSchema(
       importData as Partial<Schema> & AnyObject,
-      this.defineSchema() as Schema
+      this.defineSchema() as Schema,
+      verbose
     )
 
     return new this(createData as DataModel.CreateData<Schema>, { parent })
@@ -31,13 +55,21 @@ class GcsElement<
 
   static importSchema<Schema extends fields.DataSchema>(
     importData: Partial<Schema> & AnyObject,
-    schema: Schema = this.defineSchema() as Schema
+    schema: Schema = this.defineSchema() as Schema,
+    verbose = false
   ): DataModel.CreateData<Schema> {
     const data: AnyMutableObject = {}
     const replacements: Record<string, string> = (importData?.replacements as unknown as Record<string, string>) ?? {}
 
+    if (verbose) {
+      const schemaKeys = new Set(Object.keys(schema))
+      const unknownKeys = Object.keys(importData).filter(key => !schemaKeys.has(key) && key !== 'replacements')
+
+      if (unknownKeys.length) console.debug(`[GCS Import: ${this.name}] Unknown data keys:`, unknownKeys)
+    }
+
     for (const [key, field] of Object.entries(schema)) {
-      data[key] = this._importField(importData[key], field, key, replacements)
+      data[key] = this._importField(importData[key], field, key, replacements, verbose)
     }
 
     return data as DataModel.CreateData<Schema>
@@ -49,8 +81,15 @@ class GcsElement<
     data: any,
     field: fields.DataField.Any,
     _name: string,
-    _replacements: Record<string, string> = {}
+    _replacements: Record<string, string> = {},
+    verbose = false
   ): any {
+    if (verbose) {
+      if (data === undefined)
+        console.debug(`[GCS Import: ${this.name}] Field '${_name}' (${field.constructor.name}): missing from data`)
+      else console.debug(`[GCS Import: ${this.name}] Field '${_name}' (${field.constructor.name}):`, data)
+    }
+
     if (
       field instanceof fields.StringField ||
       field instanceof fields.NumberField ||
@@ -61,18 +100,47 @@ class GcsElement<
     }
 
     if (field instanceof fields.ArrayField) {
-      return (
-        data?.map(
-          (item: any) => item ?? (field as fields.ArrayField<fields.DataField.Any>).element.getInitialValue()
-        ) ?? []
-      )
+      const element = (field as fields.ArrayField<fields.DataField.Any>).element
+
+      if (element instanceof fields.EmbeddedDataField) {
+        const ModelClass = element.model as typeof GcsElement
+
+        if (verbose)
+          console.debug(
+            `[GCS Import: ${this.name}] Field '${_name}': dispatching ${ModelClass.name}.importSchema x${data?.length ?? 0}`
+          )
+
+        return data?.map((item: any) => ModelClass.importSchema(item, undefined, verbose)) ?? []
+      }
+
+      if (element instanceof GcsLazyEmbeddedField) {
+        const ModelClass = element.modelClass
+
+        if (verbose)
+          console.debug(
+            `[GCS Import: ${this.name}] Field '${_name}': dispatching (lazy) ${(ModelClass as any).name}.importSchema x${data?.length ?? 0}`
+          )
+
+        return data?.map((item: any) => ModelClass.importSchema(item, undefined, verbose)) ?? []
+      }
+
+      return data?.map((item: any) => item ?? element.getInitialValue()) ?? []
     }
 
-    if (field instanceof fields.EmbeddedDataField || field instanceof fields.SchemaField) {
-      return this.importSchema(data ?? {}, (field as fields.SchemaField<any>).fields)
+    if (field instanceof fields.EmbeddedDataField) {
+      const ModelClass = field.model as typeof GcsElement
+
+      if (verbose)
+        console.debug(`[GCS Import: ${this.name}] Field '${_name}': dispatching ${ModelClass.name}.importSchema`)
+
+      return ModelClass.importSchema(data ?? {}, undefined, verbose)
     }
 
-    console.warn(`Unsupported field type ${field.constructor.name} for import`)
+    if (field instanceof fields.SchemaField) {
+      return this.importSchema(data ?? {}, (field as fields.SchemaField<any>).fields, verbose)
+    }
+
+    console.warn(`[GCS Import] Unsupported field type ${field.constructor.name} for key '${_name}'`)
   }
 
   /* ---------------------------------------- */
@@ -146,33 +214,6 @@ class GcsItem<Schema extends fields.DataSchema = fields.DataSchema> extends GcsE
 
   /* ---------------------------------------- */
 
-  protected static override _importField(
-    data: any,
-    field: fields.DataField.Any,
-    name: string,
-    _replacements: Record<string, string> = {}
-  ): any {
-    switch (name) {
-      case 'children':
-        if (this.metadata.childClass === null) return null
-
-        return data?.map((childData: any) => this.metadata.childClass?.importSchema(childData))
-      case 'modifiers':
-        if (this.metadata.modifierClass === null) return null
-
-        return data?.map((modifierData: any) => this.metadata.modifierClass?.importSchema(modifierData))
-
-      case 'weapons':
-        if (this.metadata.weaponClass === null) return null
-
-        return data?.map((weaponData: any) => this.metadata.weaponClass?.importSchema(weaponData))
-      default:
-        return super._importField(data, field, name)
-    }
-  }
-
-  /* ---------------------------------------- */
-
   get childItems() {
     if (this.metadata.childClass === null) return []
 
@@ -235,6 +276,7 @@ type GcsCollectionSchema<T extends DataModel.AnyConstructor> = ReturnType<typeof
 export {
   GcsElement,
   GcsItem,
+  GcsLazyEmbeddedField,
   sourcedIdSchema,
   type SourcedIdSchema,
   GcsCollection,

--- a/src/module/importer/gcs-importer/schema/base.ts
+++ b/src/module/importer/gcs-importer/schema/base.ts
@@ -137,7 +137,7 @@ class GcsElement<
     }
 
     if (field instanceof fields.SchemaField) {
-      return this.importSchema(data ?? {}, (field as fields.SchemaField<any>).fields, verbose)
+      return this.importSchema(data ?? field.getInitialValue(), (field as fields.SchemaField<any>).fields, verbose)
     }
 
     console.warn(`[GCS Import] Unsupported field type ${field.constructor.name} for key '${_name}'`)

--- a/src/module/importer/gcs-importer/schema/character.ts
+++ b/src/module/importer/gcs-importer/schema/character.ts
@@ -1,4 +1,5 @@
 import { fields } from '@gurps-types/foundry/index.js'
+import { AnyObject } from 'fvtt-types/utils'
 
 import { GcsAttributeDefinition } from './attribute-definition.js'
 import { GcsAttribute } from './attribute.js'
@@ -18,31 +19,18 @@ class GcsCharacter extends GcsElement<GcsCharacterModel> {
 
   /* ---------------------------------------- */
 
-  protected static override _importField(data: any, field: fields.DataField.Any, name: string) {
-    switch (name) {
-      case 'body_type':
-        return GcsBody.importSchema(data, GcsBody.defineSchema())
-      case 'attributes': {
-        // Only happens for settings.attributes
-        if (field.fieldPath === 'attributes') {
-          return data?.map((attributeData: any) => GcsAttributeDefinition.importSchema(attributeData))
-        }
+  static override importSchema<Schema extends fields.DataSchema>(
+    importData: Partial<Schema> & AnyObject,
+    schema: Schema = this.defineSchema() as unknown as Schema,
+    verbose = false
+  ) {
+    // Older GCS files use 'advantages' as the top-level traits key
+    const data: typeof importData =
+      'advantages' in importData && !('traits' in importData)
+        ? { ...importData, traits: (importData as AnyObject).advantages }
+        : importData
 
-        return data?.map((attributeData: any) => GcsAttribute.importSchema(attributeData))
-      }
-      case 'advantages':
-      case 'traits':
-        return data?.map((traitData: any) => GcsTrait.importSchema(traitData))
-      case 'skills':
-        return data?.map((skillData: any) => GcsSkill.importSchema(skillData))
-      case 'spells':
-        return data?.map((spellData: any) => GcsSpell.importSchema(spellData))
-      case 'equipment':
-      case 'other_equipment':
-        return data?.map((equipmentData: any) => GcsEquipment.importSchema(equipmentData))
-      default:
-        return super._importField(data, field, name)
-    }
+    return super.importSchema(data, schema, verbose)
   }
 
   /* ---------------------------------------- */

--- a/src/module/importer/gcs-importer/schema/equipment-modifier.ts
+++ b/src/module/importer/gcs-importer/schema/equipment-modifier.ts
@@ -1,6 +1,6 @@
 import { fields } from '@gurps-types/foundry/index.js'
 
-import { GcsItem, sourcedIdSchema, SourcedIdSchema } from './base.js'
+import { GcsItem, GcsLazyEmbeddedField, sourcedIdSchema, SourcedIdSchema } from './base.js'
 
 /* ---------------------------------------- */
 
@@ -39,11 +39,10 @@ const equipmentModifierData = () => {
   return {
     // START: EquipmentModifierData
     third_party: new fields.ObjectField(),
-    // Change from Gcs' own schema, allowing for recursion of data models
-    children: new fields.ArrayField(new fields.ObjectField({ required: true, nullable: false }), {
-      required: true,
-      nullable: true,
-    }),
+    children: new fields.ArrayField(
+      new GcsLazyEmbeddedField(() => GcsEquipmentModifier, { required: true, nullable: false }),
+      { required: true, nullable: true }
+    ),
     // END: EquipmentModifierData
 
     // START: EquipmentModifierEditData

--- a/src/module/importer/gcs-importer/schema/equipment.ts
+++ b/src/module/importer/gcs-importer/schema/equipment.ts
@@ -5,6 +5,7 @@ import {
   GcsCollectionSchema,
   gcsCollectionSchema,
   GcsItem,
+  GcsLazyEmbeddedField,
   sourcedIdSchema,
   SourcedIdSchema,
 } from './base.js'
@@ -33,14 +34,15 @@ class GcsEquipment extends GcsItem<EquipmentModel> {
     data: any,
     field: fields.DataField.Any,
     name: string,
-    replacements: Record<string, string>
+    replacements: Record<string, string>,
+    verbose = false
   ): any {
     switch (name) {
       case 'description':
       case 'local_notes':
         return this.processReplacements(data, replacements) ?? field.getInitialValue()
       default:
-        return super._importField(data, field, name, replacements)
+        return super._importField(data, field, name, replacements, verbose)
     }
   }
 
@@ -70,8 +72,7 @@ const equipmentData = () => {
   return {
     // START: EquipmentModel
     // third_party: new fields.ObjectField(),
-    // Change from Gcs' own schema, allowing for recursion of data models
-    children: new fields.ArrayField(new fields.ObjectField({ required: true, nullable: false }), {
+    children: new fields.ArrayField(new GcsLazyEmbeddedField(() => GcsEquipment, { required: true, nullable: false }), {
       required: true,
       nullable: true,
     }),
@@ -82,11 +83,10 @@ const equipmentData = () => {
     // END: EquipmentModel
 
     // START: EquipmentEditData
-    modifiers: new fields.ArrayField(new fields.EmbeddedDataField(GcsEquipmentModifier), {
-      required: true,
-      nullable: true,
-      initial: null,
-    }),
+    modifiers: new fields.ArrayField(
+      new GcsLazyEmbeddedField(() => GcsEquipmentModifier, { required: true, nullable: false }),
+      { required: true, nullable: true, initial: null }
+    ),
     // rated_strength: new fields.NumberField({ required: true, nullable: true, initial: null }),
     quantity: new fields.NumberField({ required: true, nullable: true, initial: null }),
     // level: new fields.NumberField({ required: true, nullable: true, initial: null }),

--- a/src/module/importer/gcs-importer/schema/note.ts
+++ b/src/module/importer/gcs-importer/schema/note.ts
@@ -1,6 +1,6 @@
 import { fields } from '@gurps-types/foundry/index.js'
 
-import { GcsItem, sourcedIdSchema, SourcedIdSchema } from './base.js'
+import { GcsItem, GcsLazyEmbeddedField, sourcedIdSchema, SourcedIdSchema } from './base.js'
 
 class GcsNote extends GcsItem<NoteData> {
   static override metadata = {
@@ -31,8 +31,7 @@ const noteData = () => {
   return {
     // START: NoteData
     third_party: new fields.ObjectField(),
-    // Change from Gcs' own schema, allowing for recursion of data models
-    children: new fields.ArrayField(new fields.ObjectField({ required: true, nullable: false }), {
+    children: new fields.ArrayField(new GcsLazyEmbeddedField(() => GcsNote, { required: true, nullable: false }), {
       required: true,
       nullable: true,
     }),

--- a/src/module/importer/gcs-importer/schema/skill.ts
+++ b/src/module/importer/gcs-importer/schema/skill.ts
@@ -1,11 +1,11 @@
 import { fields } from '@gurps-types/foundry/index.js'
-import { AnyObject } from 'fvtt-types/utils'
 
 import {
   GcsCollection,
   GcsCollectionSchema,
   gcsCollectionSchema,
   GcsItem,
+  GcsLazyEmbeddedField,
   sourcedIdSchema,
   SourcedIdSchema,
 } from './base.js'
@@ -46,17 +46,16 @@ class GcsSkill extends GcsItem<SkillModel> {
     data: any,
     field: fields.DataField.Any,
     name: string,
-    replacements: Record<string, string>
+    replacements: Record<string, string>,
+    verbose = false
   ): any {
     switch (name) {
-      case 'defaults':
-        return data?.map((defaultData: AnyObject) => GcsSkillDefault.fromImportData(defaultData as any))
       case 'name':
       case 'specialization':
       case 'local_notes':
         return this.processReplacements(data, replacements) ?? field.getInitialValue()
       default:
-        return super._importField(data, field, name, replacements)
+        return super._importField(data, field, name, replacements, verbose)
     }
   }
 }
@@ -66,9 +65,7 @@ class GcsSkill extends GcsItem<SkillModel> {
 const skillData = () => {
   return {
     // START: SkillModel
-
-    // Change from Gcs' own schema, allowing for recursion of data models
-    children: new fields.ArrayField(new fields.ObjectField({ required: true, nullable: false }), {
+    children: new fields.ArrayField(new GcsLazyEmbeddedField(() => GcsSkill, { required: true, nullable: false }), {
       required: true,
       nullable: true,
       initial: null,

--- a/src/module/importer/gcs-importer/schema/spell.ts
+++ b/src/module/importer/gcs-importer/schema/spell.ts
@@ -5,6 +5,7 @@ import {
   GcsCollectionSchema,
   gcsCollectionSchema,
   GcsItem,
+  GcsLazyEmbeddedField,
   sourcedIdSchema,
   SourcedIdSchema,
 } from './base.js'
@@ -32,7 +33,8 @@ class GcsSpell extends GcsItem<SpellModel> {
     data: any,
     field: fields.DataField.Any,
     name: string,
-    replacements: Record<string, string>
+    replacements: Record<string, string>,
+    verbose = false
   ): any {
     switch (name) {
       case 'name':
@@ -48,7 +50,7 @@ class GcsSpell extends GcsItem<SpellModel> {
       case 'college':
         return this.processReplacements(data, replacements) ?? field.getInitialValue()
       default:
-        return super._importField(data, field, name, replacements)
+        return super._importField(data, field, name, replacements, verbose)
     }
   }
 
@@ -65,8 +67,7 @@ const spellData = () => {
   return {
     // START: SpellModel
     third_party: new fields.ObjectField(),
-    // Change from Gcs' own schema, allowing for recursion of data models
-    children: new fields.ArrayField(new fields.ObjectField({ required: true, nullable: false }), {
+    children: new fields.ArrayField(new GcsLazyEmbeddedField(() => GcsSpell, { required: true, nullable: false }), {
       required: true,
       nullable: true,
       initial: null,

--- a/src/module/importer/gcs-importer/schema/trait-modifier.ts
+++ b/src/module/importer/gcs-importer/schema/trait-modifier.ts
@@ -1,6 +1,6 @@
 import { fields } from '@gurps-types/foundry/index.js'
 
-import { GcsItem, sourcedIdSchema, SourcedIdSchema } from './base.js'
+import { GcsItem, GcsLazyEmbeddedField, sourcedIdSchema, SourcedIdSchema } from './base.js'
 
 /* ---------------------------------------- */
 
@@ -56,11 +56,10 @@ const traitModifierData = () => {
   return {
     // START: TraitModifierData
     third_party: new fields.ObjectField(),
-    // Change from Gcs' own schema, allowing for recursion of data models
-    children: new fields.ArrayField(new fields.ObjectField({ required: true, nullable: false }), {
-      required: true,
-      nullable: true,
-    }),
+    children: new fields.ArrayField(
+      new GcsLazyEmbeddedField(() => GcsTraitModifier, { required: true, nullable: false }),
+      { required: true, nullable: true }
+    ),
     // END: TraitModifierData
 
     // START: TraitModifierEditData

--- a/src/module/importer/gcs-importer/schema/trait.ts
+++ b/src/module/importer/gcs-importer/schema/trait.ts
@@ -5,6 +5,7 @@ import {
   gcsCollectionSchema,
   GcsCollectionSchema,
   GcsItem,
+  GcsLazyEmbeddedField,
   sourcedIdSchema,
   SourcedIdSchema,
 } from './base.js'
@@ -33,7 +34,8 @@ class GcsTrait extends GcsItem<TraitModel> {
     data: any,
     field: fields.DataField.Any,
     name: string,
-    replacements: Record<string, string> = {}
+    replacements: Record<string, string> = {},
+    verbose = false
   ): any {
     switch (name) {
       case 'name':
@@ -41,7 +43,7 @@ class GcsTrait extends GcsItem<TraitModel> {
       case 'userdesc':
         return this.processReplacements(data, replacements) ?? field.getInitialValue()
       default:
-        return super._importField(data, field, name, replacements)
+        return super._importField(data, field, name, replacements, verbose)
     }
   }
 
@@ -128,8 +130,7 @@ class GcsTrait extends GcsItem<TraitModel> {
 const traitData = () => {
   return {
     // START: TraitModel
-    // Change from Gcs' own schema, allowing for recursion of data models
-    children: new fields.ArrayField(new fields.ObjectField({ required: true, nullable: false }), {
+    children: new fields.ArrayField(new GcsLazyEmbeddedField(() => GcsTrait, { required: true, nullable: false }), {
       required: true,
       nullable: true,
       initial: null,
@@ -142,11 +143,14 @@ const traitData = () => {
 
     // START: TraitEditData
     userdesc: new fields.StringField({ required: true, nullable: true, initial: null }),
-    modifiers: new fields.ArrayField(new fields.EmbeddedDataField(GcsTraitModifier), {
-      required: true,
-      nullable: true,
-      initial: null,
-    }),
+    modifiers: new fields.ArrayField(
+      new GcsLazyEmbeddedField(() => GcsTraitModifier, { required: true, nullable: false }),
+      {
+        required: true,
+        nullable: true,
+        initial: null,
+      }
+    ),
     cr: new fields.NumberField({ required: true, nullable: true, initial: null }),
     disabled: new fields.BooleanField({ required: true, nullable: true, initial: null }),
     // END: TraitEditData


### PR DESCRIPTION
This PR refactors the GCS Importer Schema functionality for easier support of nested schemas and recursive models (i.e. all item arrays, where items can include children of the same type).