### PR TITLE
Bugfix: modifierTags handling

### DIFF
--- a/src/module/actor/data/character.ts
+++ b/src/module/actor/data/character.ts
@@ -1534,7 +1534,10 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
           break
         }
         case 'string': {
-          modifierTags = optionalArgs.obj.modifierTags.split(' ').map((tag: string) => tag.trim().toLowerCase())
+          modifierTags = optionalArgs.obj.modifierTags
+            .split(/\s*,\s*|\s+/)
+            .map((tag: string) => tag.trim().toLowerCase())
+            .filter((tag: string) => tag.length > 0)
         }
       }
 


### PR DESCRIPTION
`modifierTags` is sometimes `undefined` or a type other than `string`, `Array` or `Set` and is therefore not handled correctly when processing an OTF. This PR properly accounts for the various possible types `modifierTags` could belong to.