### PR TITLE
Bugfix: Wrong `isContainer` return value for Items

### DIFF
--- a/src/module/item/data/base.ts
+++ b/src/module/item/data/base.ts
@@ -127,6 +127,12 @@ abstract class BaseItemModel<Schema extends BaseItemModelSchema = BaseItemModelS
 
   /* ---------------------------------------- */
 
+  get isContainer(): boolean {
+    return this.children.length > 0
+  }
+
+  /* ---------------------------------------- */
+
   /**
    * Return the consolidated list of conditional modifiers provided by this item, combining any modifiers with the same
    * situation by summing their modifier values. This allows for multiple conditional modifiers to be applied to an item
@@ -404,13 +410,6 @@ const baseItemModelSchema = () => {
      * their already-resolved types rather than freshly evaluating the generic chain.
      */
     actions: new CollectionField(BaseAction as Action.AnyConstructor, { required: true, nullable: false }),
-
-    /**
-     * Is this Item a container that can hold other items? This should be toggleable in the UI for any Item,
-     * and allows for empty containers Items, which the previous accessor value based on the presence of contained
-     * Items did not.
-     */
-    isContainer: new fields.BooleanField({ required: true, nullable: false, initial: false }),
 
     /** Is this Item active? This determined whether bonuses provided by the Item are applied to the Actor. */
     disabled: new fields.BooleanField({ required: true, nullable: false, initial: false }),

--- a/src/module/item/migrations/v1_0_0.ts
+++ b/src/module/item/migrations/v1_0_0.ts
@@ -308,7 +308,6 @@ function migrateEquipmentSystem(oldData: Equipment, parentId: string | null): Ne
   const newData: NewDataWrapper<ItemType.Equipment> = {
     ...migrateBaseItemSystem(oldData, parentId),
     ...oldData.eqt,
-    isContainer: Boolean(oldData.eqt.contains && Object.keys(oldData.eqt.contains).length > 0),
     uses: Number(oldData.eqt.uses) || 0,
     maxuses: Number(oldData.eqt.maxuses) || 0,
     importid: oldData.eqt.uuid || '',
@@ -337,7 +336,6 @@ function migrateTraitSystem(oldData: Feature, parentId: string | null): NewDataW
     ...migrateBaseItemSystem(oldData, parentId),
     ...oldData.fea,
     notes,
-    isContainer: Boolean(oldData.fea.contains && Object.keys(oldData.fea.contains).length > 0),
     importid: oldData.fea.uuid || '',
   }
 
@@ -359,7 +357,6 @@ function migrateSkillSystem(oldData: Skill, parentId: string | null): NewDataWra
   const newData: NewDataWrapper<ItemType.Skill> = {
     ...migrateBaseItemSystem(oldData, parentId),
     ...oldData.ski,
-    isContainer: Boolean(oldData.ski.contains && Object.keys(oldData.ski.contains).length > 0),
     importedLevel: Number(oldData.ski.import) || 0,
     relativelevel: (oldData.ski.relativelevel ?? '').toString(),
     importid: oldData.ski.uuid || '',
@@ -383,7 +380,6 @@ function migrateSpellSystem(oldData: Spell, parentId: string | null): NewDataWra
   const newData: NewDataWrapper<ItemType.Spell> = {
     ...migrateBaseItemSystem(oldData, parentId),
     ...oldData.spl,
-    isContainer: Boolean(oldData.spl.contains && Object.keys(oldData.spl.contains).length > 0),
     importedLevel: Number(oldData.spl.import) || 0,
     relativelevel: (oldData.spl.relativelevel ?? '').toString(),
     importid: oldData.spl.uuid || '',


### PR DESCRIPTION
This PR turns `isContainer` in GURPS item system objects into a derived value (I think I changed it to a persistent value at some point), which matches closer with how item containers are currently managed by the system. This fixes an issue where container items were sometimes not recognized as such.