### PR TITLE
Display Item Tweaks

### DIFF
--- a/src/module/action/melee-attack.ts
+++ b/src/module/action/melee-attack.ts
@@ -1,7 +1,8 @@
 import { fields } from '@gurps-types/foundry/index.js'
 import { DisplayMeleeAttack } from '@gurps-types/gurps/display-item.js'
 import { PseudoDocument } from '@module/pseudo-document/pseudo-document.js'
-import { makeRegexPatternFrom } from '@util/utilities.js'
+import { getGame } from '@module/util/guards.js'
+import { makeRegexPatternFrom, quotedAttackName } from '@util/utilities.js'
 import { AnyMutableObject, AnyObject } from 'fvtt-types/utils'
 
 import { BaseAttack } from './base-attack.js'
@@ -183,21 +184,36 @@ class MeleeAttackModel extends BaseAttack<MeleeAttackSchema> {
   /* ---------------------------------------- */
 
   override toDisplayItem(): DisplayMeleeAttack {
-    const fullName = super.toDisplayItem().fullName
+    const name = this._displayName || ''
+    const mode = this.mode || null
 
-    const block = this.block.canBlock ? `B:"${fullName}"` : null
+    const baseOtf = quotedAttackName({ name, mode })
 
-    const parry = this.parry.canParry ? `P:"${fullName}"` : null
+    const block = this.block.canBlock ? `B:${baseOtf}` : null
+
+    const parry = this.parry.canParry ? `P:${baseOtf}` : null
+
+    const parryFencing = this.parry.canParry
+      ? this.parry.fencing
+        ? `P:${baseOtf} +3 ${getGame().i18n.localize('GURPS.modifiers_.fencingRetreat')}`
+        : `P:${baseOtf} +1 ${getGame().i18n.localize('GURPS.modifiers_.blockRetreat')}`
+      : null
+
+    const blockRetreat = this.block.canBlock
+      ? `B:${baseOtf} +1 ${getGame().i18n.localize('GURPS.modifiers_.blockRetreat')}`
+      : null
 
     return foundry.utils.mergeObject(super.toDisplayItem(), {
       reach: this.reachText,
       parry: this.parryText,
       block: this.blockText,
       otf: {
-        level: `M:"${fullName}"`,
-        damage: `D:"${fullName}"`,
+        level: `M:${baseOtf}`,
+        damage: `D:${baseOtf}`,
         block,
         parry,
+        parryFencing,
+        blockRetreat,
       },
     })
   }

--- a/src/module/action/ranged-attack.ts
+++ b/src/module/action/ranged-attack.ts
@@ -3,7 +3,7 @@ import { DisplayRangedAttack } from '@gurps-types/gurps/display-item.js'
 import { ActorType } from '@module/actor/types.js'
 import { LengthUnit } from '@module/data/common/length.js'
 import { PseudoDocument } from '@module/pseudo-document/pseudo-document.js'
-import { makeRegexPatternFrom } from '@util/utilities.js'
+import { makeRegexPatternFrom, quotedAttackName } from '@util/utilities.js'
 import { AnyMutableObject, AnyObject } from 'fvtt-types/utils'
 
 import { BaseAttack } from './base-attack.js'
@@ -364,7 +364,10 @@ class RangedAttackModel extends BaseAttack<RangedAttackSchema> {
   /* ---------------------------------------- */
 
   override toDisplayItem(): DisplayRangedAttack {
-    const fullName = super.toDisplayItem().fullName
+    const name = this._displayName || ''
+    const mode = this.mode || null
+
+    const baseOtf = quotedAttackName({ name, mode })
 
     return foundry.utils.mergeObject(super.toDisplayItem(), {
       acc: this.accText,
@@ -377,8 +380,8 @@ class RangedAttackModel extends BaseAttack<RangedAttackSchema> {
       rof: this.rofText,
       shots: this.shotsText,
       otf: {
-        level: `R:"${fullName}"`,
-        damage: `D:"${fullName}"`,
+        level: `R:${baseOtf}`,
+        damage: `D:${baseOtf}`,
       },
     })
   }

--- a/src/module/item/data/skill.ts
+++ b/src/module/item/data/skill.ts
@@ -1,7 +1,7 @@
 import { fields } from '@gurps-types/foundry/index.js'
 import { DisplaySkill } from '@gurps-types/gurps/display-item.js'
 import { parselink } from '@util/parselink.js'
-import { makeRegexPatternFrom } from '@util/utilities.js'
+import { makeRegexPatternFrom, quotedAttackName } from '@util/utilities.js'
 import { AnyObject } from 'fvtt-types/utils'
 
 import { ItemType } from '../types.js'
@@ -122,10 +122,9 @@ class SkillModel extends BaseItemModel<SkillSchema> {
   /* ---------------------------------------- */
 
   override toDisplayItem(): DisplaySkill {
-    let fullName = this.parent.name
+    const fullName = this._displayName
 
-    if (this.techlevel) fullName += `/TL${this.techlevel}`
-    if (this.specialization) fullName += ` (${this.specialization})`
+    const baseOtf = quotedAttackName({ name: fullName })
 
     return foundry.utils.mergeObject(super.toDisplayItem(), {
       techLevel: this.techlevel,
@@ -135,10 +134,23 @@ class SkillModel extends BaseItemModel<SkillSchema> {
       fullName,
       points: this.points,
       otf: {
-        level: `Sk:"${this.parent.name}"`,
-        relativeLevel: `Sk:"${this.parent.name}"`,
+        level: `Sk:${baseOtf}`,
+        relativeLevel: `Sk:${baseOtf}`,
       },
     })
+  }
+
+  /* ---------------------------------------- */
+  /*  Derived Values                          */
+  /* ---------------------------------------- */
+
+  get _displayName(): string {
+    let fullName = this.parent.name
+
+    if (this.techlevel) fullName += `/TL${this.techlevel}`
+    if (this.specialization) fullName += ` (${this.specialization})`
+
+    return fullName
   }
 }
 

--- a/src/module/item/data/spell.ts
+++ b/src/module/item/data/spell.ts
@@ -1,7 +1,7 @@
 import { fields } from '@gurps-types/foundry/index.js'
 import { DisplaySpell } from '@gurps-types/gurps/display-item.js'
 import { parselink } from '@util/parselink.js'
-import { makeRegexPatternFrom } from '@util/utilities.js'
+import { makeRegexPatternFrom, quotedAttackName } from '@util/utilities.js'
 import { AnyObject } from 'fvtt-types/utils'
 
 import { ItemType } from '../types.js'
@@ -123,9 +123,9 @@ class SpellModel extends BaseItemModel<SpellSchema> {
   /* ---------------------------------------- */
 
   override toDisplayItem(): DisplaySpell {
-    let fullName = this.parent.name
+    const fullName = this._displayName
 
-    if (this.techlevel) fullName += `/TL${this.techlevel}`
+    const baseOtf = quotedAttackName({ name: fullName })
 
     return foundry.utils.mergeObject(super.toDisplayItem(), {
       level: this.level,
@@ -141,10 +141,22 @@ class SpellModel extends BaseItemModel<SpellSchema> {
       castingTime: this.casttime,
       techLevel: this.techlevel,
       otf: {
-        level: `Sp:"${this.parent.name}"`,
-        relativeLevel: `Sp:"${this.parent.name}"`,
+        level: `Sp:${baseOtf}`,
+        relativeLevel: `Sp:${baseOtf}`,
       },
     })
+  }
+
+  /* ---------------------------------------- */
+  /*  Derived Values                          */
+  /* ---------------------------------------- */
+
+  get _displayName(): string {
+    let fullName = this.parent.name
+
+    if (this.techlevel) fullName += `/TL${this.techlevel}`
+
+    return fullName
   }
 }
 

--- a/src/types/gurps/display-item.ts
+++ b/src/types/gurps/display-item.ts
@@ -189,7 +189,9 @@ interface DisplayMeleeAttack extends BaseDisplayAttack {
     level: string
     damage: string
     parry: string | null
+    parryFencing: string | null
     block: string | null
+    blockRetreat: string | null
   }
 }
 


### PR DESCRIPTION
This PR:
- Adds `parryFencing` and `blockRetreat` to the `otf` object for `MeleeAttackModel#toDisplayItem`
- Changes OTF text in `toDisplayItem` to use the `quotedAttackName` function instead of just using `"` quotes. 