### PR TITLE
Fix: Legacy attack accessors use wrong return type

### DIFF
--- a/src/module/action/legacy/meleev1.ts
+++ b/src/module/action/legacy/meleev1.ts
@@ -36,8 +36,8 @@ class MeleeV1 {
     return []
   }
 
-  get damage() {
-    return this.meleeV2.damage
+  get damage(): string {
+    return [...this.meleeV2.damage].join(' ')
   }
 
   get extraAttacks() {

--- a/src/module/action/legacy/rangedv1.ts
+++ b/src/module/action/legacy/rangedv1.ts
@@ -40,8 +40,8 @@ class RangedV1 {
     return [] // this.rangedV2.contains
   }
 
-  get damage() {
-    return this.rangedV2.damage
+  get damage(): string {
+    return [...this.rangedV2.damage].join(' ')
   }
 
   get extraAttacks() {


### PR DESCRIPTION
This PR changes the return type of `damage` for legacy Melee and Ranged attack objects to `string` (it was `Set<string>`).