### PR TITLE
Fix: Silence v14 deprecatioon warnings in v1.0.0

### DIFF
--- a/src/module/actor/maneuver.js
+++ b/src/module/actor/maneuver.js
@@ -99,10 +99,14 @@ class Maneuver {
     changes.push({
       key: 'system.conditions.maneuver',
       value: this._data.name,
-      mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+      mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
     })
 
-    changes.push({ key: PROPERTY_MOVEOVERRIDE_MANEUVER, value: this.move, mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE })
+    changes.push({
+      key: PROPERTY_MOVEOVERRIDE_MANEUVER,
+      value: this.move,
+      mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
+    })
 
     return changes
   }

--- a/src/module/actor/sheets/gcs-actor-sheet.ts
+++ b/src/module/actor/sheets/gcs-actor-sheet.ts
@@ -707,9 +707,11 @@ class GurpsActorGcsSheet extends GurpsBaseActorSheet<
   protected _createItemContextOptions(): foundry.applications.ux.ContextMenu.Entry<HTMLElement>[] {
     return [
       {
-        name: 'Delete',
+        // @ts-expect-error: label replaces name in FoundryVTT v14 but fvtt-types is not up to date
+        label: 'GURPS.delete',
         icon: '<i class="fa-solid fa-fw fa-trash"></i>',
-        condition: target => target.dataset.uuid !== undefined,
+        // @ts-expect-error: visible replaces condition in FoundryVTT v14 but fvtt-types is not up to date
+        visible: target => target.dataset.uuid !== undefined,
         callback: async target => {
           const handler = this.options.actions['deleteEmbedded'] as Application.ClickAction | null
           const event = new PointerEvent('click', { bubbles: true })
@@ -725,9 +727,11 @@ class GurpsActorGcsSheet extends GurpsBaseActorSheet<
   protected _createPseudoDocumentContextOptions(): foundry.applications.ux.ContextMenu.Entry<HTMLElement>[] {
     return [
       {
-        name: 'Delete',
+        // @ts-expect-error: label replaces name in FoundryVTT v14 but fvtt-types is not up to date
+        label: 'GURPS.delete',
         icon: '<i class="fa-solid fa-fw fa-trash"></i>',
-        condition: target => target.dataset.uuid !== undefined,
+        // @ts-expect-error: visible replaces condition in FoundryVTT v14 but fvtt-types is not up to date
+        visible: target => target.dataset.uuid !== undefined,
         callback: async target => {
           const handler = this.options.actions['deleteEmbedded'] as Application.ClickAction | null
           const event = new PointerEvent('click', { bubbles: true })

--- a/src/module/chat/frightcheck.js
+++ b/src/module/chat/frightcheck.js
@@ -215,7 +215,7 @@ export class FrightCheckChatProcessor extends ChatProcessor {
     )
 
     await ChatMessage.create({
-      type: CONST.CHAT_MESSAGE_STYLES.ROLL,
+      style: CONST.CHAT_MESSAGE_STYLES.ROLL,
       speaker: ChatMessage.getSpeaker(actor),
       content: content,
       roll: JSON.stringify(roll),

--- a/src/module/combat-tracker/maneuver-menu.js
+++ b/src/module/combat-tracker/maneuver-menu.js
@@ -36,13 +36,14 @@ export const addManeuverMenu = async (html, combatant, token) => {
   const maxMove = actions.getMaxMove()
   const label = Maneuvers.getManeuver(actions.currentManeuver).label
   const allIcons = TokenActions.getManeuverIcons(actions.currentManeuver)
-  // COMPATIBILITY: Foundry v12 and earlier
-  // const tooltipHtmlString = await foundry.applications.handlebars.renderTemplate(
-  const tooltipHtmlString = await renderTemplate('systems/gurps/templates/maneuver-button-tooltip.hbs', {
-    label,
-    maxMove,
-    allIcons,
-  })
+  const tooltipHtmlString = await foundry.applications.handlebars.renderTemplate(
+    'systems/gurps/templates/maneuver-button-tooltip.hbs',
+    {
+      label,
+      maxMove,
+      allIcons,
+    }
+  )
 
   currentManeuver.setAttribute('aria-label', 'Maneuver Badge')
   currentManeuver.setAttribute('data-tooltip-html', tooltipHtmlString)
@@ -85,12 +86,13 @@ export const addManeuverMenu = async (html, combatant, token) => {
 
   // Build the maneuvers menu from template.
   const maneuvers = Maneuvers.getAll()
-  // COMPATIBILITY: Foundry v12 and earlier
-  // const menuHtmlString = await foundry.applications.handlebars.renderTemplate(
-  const menuHtmlString = await renderTemplate('systems/gurps/templates/maneuver-menu.hbs', {
-    combatant,
-    maneuvers,
-  })
+  const menuHtmlString = await foundry.applications.handlebars.renderTemplate(
+    'systems/gurps/templates/maneuver-menu.hbs',
+    {
+      combatant,
+      maneuvers,
+    }
+  )
 
   // Convert HTML string to DOM element and append to html.
   const tempDiv = document.createElement('div')

--- a/src/module/combat-tracker/render-combat-tracker.ts
+++ b/src/module/combat-tracker/render-combat-tracker.ts
@@ -4,9 +4,6 @@ import { addManeuverMenu } from './maneuver-menu.js'
 import { addQuickRollButton, addQuickRollListeners } from './quick-roll-menu.js'
 
 export async function renderCombatTracker(_app: any, element: HTMLElement, _options: any, _context: any) {
-  // @ts-expect-error: FVTT v12 compatibility
-  if ((game.release?.generation ?? 12) < 13) element = element[0] // FVTT v12 compatibility
-
   if (!element.classList.contains('bound')) {
     element.classList.add('bound')
 

--- a/src/module/damage/applydamage.js
+++ b/src/module/damage/applydamage.js
@@ -752,7 +752,7 @@ export default class ApplyDamageDialog extends Application {
     let msgData = {
       content: message,
       author: game.user.id,
-      type: CONST.CHAT_MESSAGE_STYLES.OOC,
+      style: CONST.CHAT_MESSAGE_STYLES.OOC,
     }
 
     if (game.settings.get(GURPS.SYSTEM_NAME, Settings.SETTING_WHISPER_STATUS_EFFECTS)) {
@@ -850,7 +850,7 @@ export default class ApplyDamageDialog extends Application {
         user: game.user.id,
         speaker: speaker,
         content: html,
-        type: CONST.CHAT_MESSAGE_STYLES.OTHER,
+        style: CONST.CHAT_MESSAGE_STYLES.OTHER,
       }
 
       if (!publicly) {

--- a/src/module/dierolls/dieroll.js
+++ b/src/module/dierolls/dieroll.js
@@ -697,7 +697,9 @@ async function _doRoll({
   let creatOptions = {}
 
   try {
-    isCtrl = !!optionalArgs.event && game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.CONTROL)
+    isCtrl =
+      !!optionalArgs.event &&
+      game.keyboard.isModifierActive(foundry.helpers.interaction.KeyboardManager.MODIFIER_KEYS.CONTROL)
   } catch {
     // Keyboard manager may not be available during initialization
   }

--- a/src/module/effects/active-effect-config.js
+++ b/src/module/effects/active-effect-config.js
@@ -1,6 +1,4 @@
 export default class GurpsActiveEffectConfig extends foundry.applications.sheets.ActiveEffectConfig {
-  // COMPATIBILITY: v12
-  // export default class GurpsActiveEffectConfig extends ActiveEffectConfig {
   constructor(object = {}) {
     super(object)
   }
@@ -32,47 +30,4 @@ export default class GurpsActiveEffectConfig extends foundry.applications.sheets
 
     return super.render(force, options)
   }
-
-  // async getData() {
-  //   const sheetData = await super.getData()
-  //   sheetData.changes = GURPSActiveEffectsChanges
-  //   sheetData.worldTime = game.time.worldTime
-  //   return sheetData
-  // }
-
-  // activateListeners(html) {
-  //   super.activateListeners(html)
-
-  //   html.find('.effect-control').on('click', this._onEffectControl.bind(this))
-  // }
-
-  // async _onEffectControl(event) {
-  //   event.preventDefault()
-  //   const a = event.currentTarget
-  //   const effect = a.dataset.effectId ? this.actor.effects.get(a.dataset.effectId) : null
-
-  //   switch (a.dataset.action) {
-  //     case 'create':
-  //   }
-  // }
-
-  // /** @inheritdoc */
-  // async _updateObject(event, formData) {
-  //   // If there is an EndCondition, this is a temporary effect. Signal this by setting the core.statusId value.
-  //   let newEndCondition = formData.flags?.gurps?.endCondition
-
-  //   // TODO Monitor this -- ActiveEffect.flags.core.status is deprecated
-  //   // formData.flags['core.statusId'] = !!newEndCondition ? this.object.label : null
-
-  //   // Flip the "Disabled" flag.
-  //   formData.disabled = !formData.disabled
-
-  //   let result = await super._updateObject(event, formData)
-
-  //   // Tell the Active Effects List window to refresh its data.
-  //   if (this._parentWindow) this._parentWindow.render(true)
-
-  //   console.log('effect', result)
-  //   return result
-  // }
 }

--- a/src/module/effects/active-effect.ts
+++ b/src/module/effects/active-effect.ts
@@ -1,6 +1,6 @@
 export class GurpsActiveEffect<SubType extends ActiveEffect.SubType> extends ActiveEffect<SubType> {
   /**
-   * On Actor.applyEffect: Applies only to changes that have mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM.
+   * On Actor.applyEffect: Applies only to changes that have mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.custom.
    */
   static _apply(
     actor: Actor.Implementation | Actor.Implementation,

--- a/src/module/effects/effects.js
+++ b/src/module/effects/effects.js
@@ -102,27 +102,27 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureProneDefend', [defenseTag]),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureProneMelee', [meleeTag]),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
           {
             key: 'system.conditions.target.modifiers',
             value: getTaggedValue('GURPS.modifierPostureProneRanged', [rangedTag]),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
           {
             key: 'system.conditions.posture',
             value: 'prone',
-            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
           },
           {
             key: PROPERTY_MOVEOVERRIDE_POSTURE,
             value: MOVE_ONE,
-            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
             priority: 10,
           },
         ],
@@ -141,27 +141,27 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureKneelDefend', [defenseTag]),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureKneelMelee', [meleeTag]),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
           {
             key: 'system.conditions.target.modifiers',
             value: getTaggedValue('GURPS.modifierPostureCrouchRanged', [rangedTag]),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
           {
             key: PROPERTY_MOVEOVERRIDE_POSTURE,
             value: MOVE_ONETHIRD,
-            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
           },
           {
             key: 'system.conditions.posture',
             value: 'kneel',
-            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
           },
         ],
         flags: {
@@ -179,22 +179,22 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureCrouchMelee', [meleeTag]),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
           {
             key: 'system.conditions.target.modifiers',
             value: getTaggedValue('GURPS.modifierPostureCrouchRanged', [rangedTag]),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
           {
             key: PROPERTY_MOVEOVERRIDE_POSTURE,
             value: MOVE_TWOTHIRDS,
-            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
           },
           {
             key: 'system.conditions.posture',
             value: 'crouch',
-            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
           },
         ],
         flags: {
@@ -212,27 +212,27 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureKneelMelee', [meleeTag]),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureKneelDefend', [defenseTag]),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
           {
             key: 'system.conditions.target.modifiers',
             value: getTaggedValue('GURPS.modifierPostureProneRanged', [rangedTag]),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
           {
             key: PROPERTY_MOVEOVERRIDE_POSTURE,
             value: MOVE_NONE,
-            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
           },
           {
             key: 'system.conditions.posture',
             value: 'sit',
-            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
           },
         ],
         flags: {
@@ -250,27 +250,27 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureProneMelee', [meleeTag]),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureProneDefend', [defenseTag]),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
           {
             key: 'system.conditions.target.modifiers',
             value: getTaggedValue('GURPS.modifierPostureProneRanged', [rangedTag]),
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
           {
             key: PROPERTY_MOVEOVERRIDE_POSTURE,
             value: MOVE_ONETHIRD,
-            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
           },
           {
             key: 'system.conditions.posture',
             value: 'crawl',
-            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
           },
         ],
         flags: {
@@ -324,7 +324,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.reeling',
             value: true,
-            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
           },
         ],
         flags: {
@@ -343,12 +343,12 @@ export class StatusEffect {
           {
             key: 'system.conditions.exhausted',
             value: true,
-            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
           },
           {
             key: 'system.attributes.ST.import',
             value: 0.5,
-            mode: CONST.ACTIVE_EFFECT_MODES.MULTIPLY,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.multiply,
           },
         ],
         flags: {
@@ -564,7 +564,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad+1',
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
         ],
       },
@@ -576,7 +576,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad+2',
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
         ],
       },
@@ -588,7 +588,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad+3',
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
         ],
       },
@@ -600,7 +600,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad+4',
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
         ],
       },
@@ -612,7 +612,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad+5',
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
         ],
       },
@@ -624,7 +624,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad-1',
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
         ],
       },
@@ -636,7 +636,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad-2',
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
         ],
       },
@@ -648,7 +648,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad-3',
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
         ],
       },
@@ -660,7 +660,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad-4',
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
         ],
       },
@@ -672,7 +672,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad-5',
-            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           },
         ],
       },
@@ -703,7 +703,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierStatusShock1',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag, hitTag, spellTag, skillTag],
         },
       ],
@@ -721,7 +721,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierStatusShock2',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag, hitTag, spellTag, skillTag],
         },
       ],
@@ -739,7 +739,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierStatusShock3',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag, hitTag, spellTag, skillTag],
         },
       ],
@@ -757,7 +757,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierStatusShock4',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag, hitTag, spellTag, skillTag],
         },
       ],
@@ -775,13 +775,13 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierStatusStunned',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [defenseTag],
         },
         {
           key: 'system.conditions.maneuver',
           value: 'do_nothing',
-          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.custom,
         },
       ],
       flags: {
@@ -799,13 +799,13 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierStatusStunned',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [defenseTag],
         },
         {
           key: 'system.conditions.maneuver',
           value: 'do_nothing',
-          mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.custom,
         },
       ],
       flags: {
@@ -823,7 +823,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierGrappling',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag],
         },
       ],
@@ -838,13 +838,13 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionNausea',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [attributesTag],
         },
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionNauseaDef',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [defenseTag],
         },
       ],
@@ -859,13 +859,13 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionCough',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag],
         },
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionCoughIQ',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [iqTag],
         },
       ],
@@ -880,7 +880,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionRetch',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag, perTag],
         },
       ],
@@ -899,7 +899,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionDrowsy',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag, perTag],
         },
       ],
@@ -914,13 +914,13 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionTipsy',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag],
         },
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionTipsyCR',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [crTag],
         },
       ],
@@ -935,13 +935,13 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionDrunk',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag],
         },
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionDrunkCR',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [crTag],
         },
       ],
@@ -956,7 +956,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionEuphoria',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag, crTag],
         },
       ],
@@ -971,7 +971,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionModerateHPT',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag, crTag],
         },
       ],
@@ -986,7 +986,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionModerate',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag, crTag],
         },
       ],
@@ -1001,7 +1001,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionTerribleHPT',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag, crTag],
         },
       ],
@@ -1016,7 +1016,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionSevere',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag, crTag],
         },
       ],
@@ -1031,7 +1031,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionTerrible',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag, crTag],
         },
       ],
@@ -1046,7 +1046,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierSuffocate',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [dxTag, iqTag, crTag],
         },
       ],
@@ -1064,13 +1064,13 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifiersBlindAttack',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [hitTag],
         },
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifiersBlindDefend',
-          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
           tags: [defenseTag],
         },
       ],

--- a/src/module/file-handlers/chrome-file-handler.js
+++ b/src/module/file-handlers/chrome-file-handler.js
@@ -57,8 +57,7 @@ export class ChromiumFileHandler {
           callback: () => (handle ? resolve(handle) : reject(`no ${mode} were chosen`)),
         },
         render: (event, dialog) => {
-          // COMPATIBILITY: v12
-          const element = game.release.generation >= 13 ? dialog.element : dialog
+          const element = dialog.element
 
           const fileChosenDiv = element.querySelector('#selectedFile')
 

--- a/src/module/gurps-wiring.js
+++ b/src/module/gurps-wiring.js
@@ -124,9 +124,10 @@ export default class GurpsWiring {
   static #createPdfLinkMenu(link) {
     const options = {
       fixed: true,
+      JQuery: false,
     }
 
-    if (link instanceof HTMLElement) options.JQuery = false
+    if (!(link instanceof HTMLElement)) link = link[0]
 
     let users = GURPS.LastActor?.getOwners()?.filter(user => !user.isGM) || []
     let names = users.map(user => user.name).join(' ')

--- a/src/module/gurps-wiring.js
+++ b/src/module/gurps-wiring.js
@@ -124,7 +124,7 @@ export default class GurpsWiring {
   static #createPdfLinkMenu(link) {
     const options = {
       fixed: true,
-      JQuery: false,
+      jQuery: false,
     }
 
     if (!(link instanceof HTMLElement)) link = link[0]

--- a/src/module/gurps.js
+++ b/src/module/gurps.js
@@ -559,7 +559,7 @@ if (!globalThis.GURPS) {
     async chat({ action, actor, event }) {
       // @ts-expect-error - Foundry VTT API not fully typed
       const chat = `/setEventFlags ${!!action.quiet} ${!!event?.shiftKey} ${game.keyboard.isModifierActive(
-        KeyboardManager.MODIFIER_KEYS.CONTROL
+        foundry.helpers.interaction.KeyboardManager.MODIFIER_KEYS.CONTROL
       )}\n${action.orig}`
 
       if (action.overridetxt) {

--- a/src/module/gurps.js
+++ b/src/module/gurps.js
@@ -2486,7 +2486,7 @@ const handleChatLogDrop = function (event) {
     const cmd = buildCommandFromDragData(data)
     let messageData = {
       user: game.user.id,
-      type: CONST.CHAT_MESSAGE_STYLES.OOC,
+      style: CONST.CHAT_MESSAGE_STYLES.OOC,
       content: cmd,
     }
 

--- a/src/module/modifier-bucket/bucket-app.js
+++ b/src/module/modifier-bucket/bucket-app.js
@@ -604,7 +604,7 @@ export class ModifierBucket extends Application {
     if (game.user?.hasRole('GAMEMASTER'))
       // Only actual GMs can update other user's flags
       users.forEach(user => user.setFlag('gurps', 'modifierstack', mb)) // Only used by /showmbs.   Not used by local users.
-    let ctrl = game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.CONTROL)
+    let ctrl = game.keyboard.isModifierActive(foundry.helpers.interaction.KeyboardManager.MODIFIER_KEYS.CONTROL)
 
     game.socket?.emit('system.gurps', {
       type: 'updatebucket',

--- a/src/module/modifier-bucket/bucket-app.js
+++ b/src/module/modifier-bucket/bucket-app.js
@@ -862,7 +862,7 @@ export class ModifierBucket extends Application {
       if (!game.user?.isGM) {
         let messageData = {
           content: this.chatString(this.modifierStack),
-          type: CONST.CHAT_MESSAGE_STYLES.OOC,
+          style: CONST.CHAT_MESSAGE_STYLES.OOC,
         }
 
         ChatMessage.create(messageData, {})

--- a/src/module/modifier-bucket/bucket-app.js
+++ b/src/module/modifier-bucket/bucket-app.js
@@ -427,9 +427,7 @@ class ModifierStack {
  * This class owns the modifierStack, while the ModifierBucketEditor
  * modifies it.
  */
-// export class ModifierBucket extends foundry.appv1.api.Application {
-// COMPATIBILITY: v12
-export class ModifierBucket extends Application {
+export class ModifierBucket extends foundry.appv1.api.Application {
   constructor(options = {}) {
     super(options)
 

--- a/src/module/ui/get-number-input.ts
+++ b/src/module/ui/get-number-input.ts
@@ -14,9 +14,7 @@ async function GetNumberInput(options: GetNumberInputOptions): Promise<number> {
   try {
     return await foundry.applications.api.DialogV2.prompt({
       window: { title: options.title },
-      // COMPATIBILITY: Foundry v12 and earlier
-      // content: await foundry.applications.handlebars.renderTemplate(
-      content: await renderTemplate('systems/gurps/templates/ui/get-number-input.hbs', {
+      content: await foundry.applications.handlebars.renderTemplate('systems/gurps/templates/ui/get-number-input.hbs', {
         headerText: options.headerText,
         promptText: options.promptText,
         label: options.label,


### PR DESCRIPTION
This PR changes namespaces, keys, and forces some function parameter type changes (such as converting JQuery input to HTMLElement) to silence FoundryVTT deprecation warnings.