### PR TITLE
fix tagged modifiers applying to all rolls

### DIFF
--- a/src/module/actor/data/character.ts
+++ b/src/module/actor/data/character.ts
@@ -1700,7 +1700,7 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
       const userModsTags: string[] = (mod.match(/#(\S+)/g) ?? [])?.map((tag: string) => tag.slice(1).toLowerCase())
 
       for (const tag of userModsTags) {
-        let canApply = true
+        let canApply = allTags.includes(tag)
 
         if (mod.includes('#maneuver'))
           canApply = allTags.includes(tag) && (mod.includes(itemRef) || mod.includes('@man:'))


### PR DESCRIPTION
This is a minimal fix for #2660.

But I think this function (character.addTaggedRollModifiers) has several more bugs, like not identifying defenses rolls (and probably some more) and some edge case where the same mod could be added more than once. I have not yet fully confirmed these bugs yet, but i am quite sure there is something more wrong here.

The function does a lot of things, some of them should not even be in the responsibility of the actor, IMHO, like determine the type of a roll and the appropriate tags of the roll. It also mixes data access and game logic in one function, making the game logic hard to test. 
This makes debugging and fixing this thing very hard. Some of this things had better structure in 0.18.
if you want, I could refactor it and move most of the game logic into testable functions in a different file (probably under tagged-modifiers and leave just the data access in the actor model ).

But if you prefer, I am also open to identifying the individual bugs and fixing them as minimal as possible.