### PR TITLE
refactor addTaggedRollModifiers

### DIFF
--- a/src/module/actor/data/character.ts
+++ b/src/module/actor/data/character.ts
@@ -21,6 +21,8 @@ import { OtfActionType, OtfAction } from '@module/otf/types.js'
 import { TrackerInstance } from '@module/resource-tracker/resource-tracker.js'
 import { TaggedModifiersSettings } from '@module/tagged-modifiers/index.js'
 import { taggedModToApply } from '@module/tagged-modifiers/tagged-modifiers.js'
+import { GurpsToken } from '@module/token/index.js'
+import { TokenActions } from '@module/token-actions.js'
 import { getGame } from '@module/util/guards.js'
 import * as Settings from '@module/util/miscellaneous-settings.js'
 import { multiplyDice } from '@util/damage-utils.js'
@@ -580,7 +582,7 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
 
   /* ---------------------------------------- */
 
-  #prepareUserModifiers() {
+  async #prepareUserModifiers() {
     
     this.parent.items
         .filter( (item : Item.Implementation) => item.isOfType(ItemType.Trait, ItemType.Skill, ItemType.Spell, ItemType.Equipment))
@@ -611,7 +613,24 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
         )
         .forEach( mod => this.conditions.usermods.add(mod))
 
+
+    //if this actor has a token in combat, we need to get the modifiers from the TokenActions
+    const token = getTokenFromCombat(this.parent)
+
+    if (token){
+        const actions = await TokenActions.fromToken(token)
+
+        if (actions) {
+            actions.getModifiers()
+            .forEach( mod => this.conditions.usermods.add(mod))
+        }
     }
+
+    function getTokenFromCombat(actor: Actor) {
+        //we need to find the token from then combatant, because we don't get the actual token from the actor  
+        return game.combats?.active?.combatants.find(combatant => combatant.actor === actor)?.token?.object as GurpsToken
+    }
+  }
 
   #getCurrentMove(base: number): number {
     const doUpdateMove = this.getSetting(Settings.SETTING_MANEUVER_UPDATES_MOVE, false) && this.parent.inCombat

--- a/src/module/actor/data/character.ts
+++ b/src/module/actor/data/character.ts
@@ -589,7 +589,7 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
                         .split('\n')
                         .map(line => line.trim())
                         .filter( (line : string) => line.length > 0)
-                        .map( (mod : string) => `${mod} @${item.id}`)                                              
+                        .map( (mod : string) => `${mod} @${item.id === this.holderItemId ? 'custom' : item.id}`)                                              
         )
         .forEach( mod => this.conditions.usermods.add(mod))
 

--- a/src/module/actor/data/character.ts
+++ b/src/module/actor/data/character.ts
@@ -20,6 +20,7 @@ import { COSTS_REGEX } from '@module/otf/parselink.js'
 import { OtfActionType, OtfAction } from '@module/otf/types.js'
 import { TrackerInstance } from '@module/resource-tracker/resource-tracker.js'
 import { TaggedModifiersSettings } from '@module/tagged-modifiers/index.js'
+import { taggedModToApply } from '@module/tagged-modifiers/tagged-modifiers.js'
 import { getGame } from '@module/util/guards.js'
 import * as Settings from '@module/util/miscellaneous-settings.js'
 import { multiplyDice } from '@util/damage-utils.js'
@@ -1545,126 +1546,9 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
 
   /* ---------------------------------------- */
 
-  async addTaggedRollModifiers(
-    chatThing: string,
-    optionalArgs: { obj?: AnyObject },
-    attack?: MeleeAttackModel | RangedAttackModel
-  ): Promise<boolean> {
-    let isDamageRoll = false
-
-    const taggedSettings = this.getSetting(
-      Settings.SETTING_USE_TAGGED_MODIFIERS,
-      null
-    ) as TaggedModifiersSettings | null
-
-    if (!taggedSettings) return false
-
-    const allRollTags: string[] = taggedSettings.allRolls.split(',').map((tag: string) => tag.trim().toLowerCase())
-
-    let itemRef = ''
-    let allTags: string[] = []
-    let refTags: string[] = []
-    let modifierTags: string[] = []
-
-    if (optionalArgs.obj) {
-      // Get modifiers from action object
-      const correspondingTags: Record<string, (keyof typeof taggedSettings)[]> = {
-        m: ['allAttackRolls', 'allMeleeRolls'],
-        r: ['allAttackRolls', 'allRangedRolls'],
-        p: ['allDefenseRolls', 'allDefenseRolls'],
-        b: ['allDefenseRolls', 'allBlockRolls'],
-        d: ['allDamageRolls'],
-        sk: ['allSkillRolls'],
-        sp: ['allSpellRolls'],
-      }
-
-      const ref = chatThing
-        .split('@')
-        .pop()!
-        .match(/(\S+):/)?.[1]
-        .toLowerCase()
-
-      if (ref && correspondingTags[ref]) {
-        if (ref === 'd') isDamageRoll = true
-
-        for (const tag of correspondingTags[ref]) {
-          refTags.push(
-            ...(taggedSettings[tag] as string).split(',').map((tagValue: string) => tagValue.trim().toLowerCase())
-          )
-        }
-      }
-
-      switch (typeof optionalArgs.obj.modifierTags) {
-        case 'object': {
-          if (Array.isArray(optionalArgs.obj.modifierTags)) {
-            modifierTags = optionalArgs.obj.modifierTags
-          } else if (optionalArgs.obj.modifierTags instanceof Set) {
-            modifierTags = [...optionalArgs.obj.modifierTags]
-          }
-
-          break
-        }
-        case 'string': {
-          modifierTags = optionalArgs.obj.modifierTags
-            .split(/\s*,\s*|\s+/)
-            .map((tag: string) => tag.trim().toLowerCase())
-            .filter((tag: string) => tag.length > 0)
-        }
-      }
-
-      allTags = [...modifierTags, ...allRollTags, ...refTags]
-      itemRef = (optionalArgs.obj.name as string) ?? ''
-    } else if (chatThing) {
-      // Get modifiers from chat string
-      const correspondingTags: Record<string, (keyof typeof taggedSettings)[]> = {
-        st: ['allAttributesRolls', 'allSTRolls'],
-        dx: ['allAttributesRolls', 'allDXRolls'],
-        iq: ['allAttributesRolls', 'allIQRolls'],
-        ht: ['allAttributesRolls', 'allHTRolls'],
-        will: ['allWILLRolls'],
-        per: ['allPERRolls'],
-        frightcheck: ['allFRIGHTCHECKRolls'],
-        vision: ['allVISIONRolls'],
-        hearing: ['allHEARINGRolls'],
-        tastesmell: ['allTASTESMELLRolls'],
-        touch: ['allTOUCHRolls'],
-        cr: ['allCRRolls'],
-        dodge: ['allDefenseRolls', 'allDODGERolls'],
-        p: ['allDefenseRolls', 'allParryRolls'],
-        b: ['allDefenseRolls', 'allBlockRolls'],
-      }
-
-      const ref = chatThing.split('@').pop()!.toLowerCase().replace(' ', '').slice(0, -1).toLowerCase().split(':')[0]
-      const regex = /(?<="|:).+(?=\s\(|"|])/gm
-
-      if (ref && correspondingTags[ref]) {
-        if (ref === 'p' || ref === 'b') {
-          itemRef = chatThing.match(regex)?.[0] ?? ''
-          if (itemRef !== '') itemRef = itemRef.replace(/"/g, '').split('(')[0].trim()
-        }
-
-        for (const tag of correspondingTags[ref]) {
-          refTags.push(
-            ...(taggedSettings[tag] as string).split(',').map((tagValue: string) => tagValue.trim().toLowerCase())
-          )
-        }
-      }
-    } else {
-      // Get modifiers from attack/damage roll
-      if (!attack) {
-        refTags = taggedSettings.allDamageRolls.split(',').map((tag: string) => tag.trim().toLowerCase())
-        isDamageRoll = true
-      } else {
-        refTags = taggedSettings.allAttackRolls.split(',').map((tag: string) => tag.trim().toLowerCase())
-      }
-
-      const attackMods = attack?.modifierTags ?? []
-
-      modifierTags = [...allRollTags, ...attackMods, ...refTags]
-      itemRef = attack?.name ?? ''
-    }
-
-    // Get modifiers from user mods
+  
+allModifiers() :  string[] {
+      // Get modifiers from user mods
     const userMods = this.conditions.usermods ?? []
 
     // Get modifiers from self mods
@@ -1693,36 +1577,29 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
         return acc
       }, []) ?? []
 
+    return [...userMods, ...selfMods, ...targetMods]
+}
+
+  async addTaggedRollModifiers(
+    chatThing: string,
+    optionalArgs: { obj?: AnyObject },
+    attack?: MeleeAttackModel | RangedAttackModel
+  ): Promise<boolean> {
+    const taggedSettings = (game.settings as any)?.get(GURPS.SYSTEM_NAME, Settings.SETTING_USE_TAGGED_MODIFIERS) ?? null as TaggedModifiersSettings | null
+
+    if (!taggedSettings) return false;
     const actorInCombat = this.parent.inCombat
-    const allMods: string[] = [...userMods, ...selfMods, ...targetMods]
+    const allMods = this.allModifiers()
+    
+    const { modsToApply, isDamageRoll } = taggedModToApply(chatThing, attack, optionalArgs, taggedSettings, allMods, actorInCombat)
 
-    for (const mod of allMods) {
-      const userModsTags: string[] = (mod.match(/#(\S+)/g) ?? [])?.map((tag: string) => tag.slice(1).toLowerCase())
-
-      for (const tag of userModsTags) {
-        let canApply = true
-
-        if (mod.includes('#maneuver'))
-          canApply = allTags.includes(tag) && (mod.includes(itemRef) || mod.includes('@man:'))
-
-        // If the modifier should apply only to a specific item (e.g. specific usage of a weapon) account for this
-        if ('itemPath' in optionalArgs && typeof optionalArgs.itemPath === 'string')
-          canApply = canApply && (mod.includes(optionalArgs.itemPath) || !mod.includes('@system'))
-
-        if (actorInCombat)
-          canApply =
-            canApply && (!taggedSettings.nonCombatOnlyTag || !allTags.includes(taggedSettings.nonCombatOnlyTag))
-        else canApply = canApply && (!taggedSettings.combatOnlyTag || !allTags.includes(taggedSettings.combatOnlyTag))
-
-        if (canApply) {
+    for (const mod of modsToApply) {          
           const regex = new RegExp(/^[+-]\d+(.*?)(?=[#@])/)
           const desc = mod.match(regex)?.[1].trim() || ''
           const effectiveMod = mod.match(/[-+]\d+/)?.[0] || '0'
 
           // TODO: evaluate whether this causes too many data preparation cycles
           await GURPS.ModifierBucket.addModifier(effectiveMod, desc, undefined, true)
-        }
-      }
     }
 
     return isDamageRoll

--- a/src/module/actor/data/character.ts
+++ b/src/module/actor/data/character.ts
@@ -581,27 +581,37 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
   /* ---------------------------------------- */
 
   #prepareUserModifiers() {
-    this.parent.items.forEach(item => {
-      if (!(item as Item.Implementation).isOfType(ItemType.Trait, ItemType.Skill, ItemType.Spell, ItemType.Equipment))
-        return
+    
+    this.parent.items
+        .filter( (item : Item.Implementation) => item.isOfType(ItemType.Trait, ItemType.Skill, ItemType.Spell, ItemType.Equipment))
+        .flatMap( 
+            item => item.system.itemModifiers
+                        .split('\n')
+                        .map(line => line.trim())
+                        .filter( (line : string) => line.length > 0)
+                        .map( (mod : string) => `${mod} @${item.id}`)                                              
+        )
+        .forEach( mod => this.conditions.usermods.add(mod))
 
-      for (const modifier of (item.system as BaseItemModel).itemModifiers.split('\n').map(line => line.trim())) {
-        const modifierDescription = `${modifier} ${item.id}`
+    this.meleeV2.flatMap(
+        (attack, index) => attack.itemModifiers
+            .split('\n')
+            .map(line => line.trim())
+            .filter( (line : string) => line.length > 0)
+            .map( (mod : string) => `${mod} @system.meleeV2.${index}`)                                
+        )
+        .forEach( mod => this.conditions.usermods.add(mod))
 
-        if (!this.conditions.usermods.has(modifierDescription)) this.conditions.usermods.add(modifierDescription)
-      }
+    this.rangedV2.flatMap(
+        (attack, index) => attack.itemModifiers
+            .split('\n')
+            .map(line => line.trim())
+            .filter( (line : string) => line.length > 0)
+            .map( (mod : string) => `${mod} @system.rangedV2.${index}`)                                
+        )
+        .forEach( mod => this.conditions.usermods.add(mod))
 
-      for (const attack of (item as Item.Implementation).getItemAttacks()) {
-        if ((item.system as BaseItemModel).itemModifiers === '') continue
-
-        for (const modifier of attack.itemModifiers.split('\n').map(line => line.trim())) {
-          const modifierDescription = `${modifier} ${item.id}`
-
-          if (!this.conditions.usermods.has(modifierDescription)) this.conditions.usermods.add(modifierDescription)
-        }
-      }
-    })
-  }
+    }
 
   #getCurrentMove(base: number): number {
     const doUpdateMove = this.getSetting(Settings.SETTING_MANEUVER_UPDATES_MOVE, false) && this.parent.inCombat

--- a/src/module/actor/data/character.ts
+++ b/src/module/actor/data/character.ts
@@ -635,6 +635,12 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
     }
   }
 
+  async refreshUserModifier() {
+    this.conditions.usermods.clear()
+
+    await this.#prepareUserModifiers()
+  }
+
   #getCurrentMove(base: number): number {
     const doUpdateMove = this.getSetting(Settings.SETTING_MANEUVER_UPDATES_MOVE, false) && this.parent.inCombat
 

--- a/src/module/actor/data/character.ts
+++ b/src/module/actor/data/character.ts
@@ -626,6 +626,9 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
         }
     }
 
+    //don't know why ts doesn't recognizes the refresh method on the EffectModifierControl type
+    (GURPS.EffectModifierControl as any)?.refresh()
+
     function getTokenFromCombat(actor: Actor) {
         //we need to find the token from then combatant, because we don't get the actual token from the actor  
         return game.combats?.active?.combatants.find(combatant => combatant.actor === actor)?.token?.object as GurpsToken

--- a/src/module/actor/effect-modifier-popout.js
+++ b/src/module/actor/effect-modifier-popout.js
@@ -115,7 +115,7 @@ export class EffectModifierPopout extends Application {
     let selfMods = []
 
     selfMods = this.convertModifiers(this._token.actor.system.conditions.self.modifiers)
-    selfMods.push(...this.convertModifiers(this._token.actor.system.conditions.usermods))
+    selfMods.push(...this.convertModifiers([...this._token.actor.system.conditions.usermods]))
     selfMods.sort((left, right) => {
       if (left.itemName === right.itemName) {
         return left.desc.localeCompare(right.desc)
@@ -237,7 +237,8 @@ export class EffectModifierPopout extends Application {
             obj = this._token?.actor.items.get(itemReference) || {}
           }
 
-          const itemName = obj?.name || itemReference
+          const attackName = obj?.item?.name && obj?.mode ? `${obj?.item?.name} (${obj?.mode})` : undefined
+          const itemName = attackName ?? obj?.name ?? itemReference
           const itemType = obj?.type
             ? obj.type
             : it.includes('#maneuver')

--- a/src/module/actor/effect-modifier-popout.js
+++ b/src/module/actor/effect-modifier-popout.js
@@ -2,11 +2,10 @@ import { parselink } from '@module/otf/parselink.js'
 import { OtfActionType } from '@module/otf/types.js'
 import * as Settings from '@module/util/miscellaneous-settings.js'
 import { gurpslink } from '@util/gurpslink.js'
-import { recurselist, sanitize } from '@util/utilities.js'
+import {  sanitize } from '@util/utilities.js'
 
 import { Length } from '../data/common/length.js'
 import GurpsWiring from '../gurps-wiring.js'
-import { TokenActions } from '../token-actions.js'
 
 import Maneuvers from './maneuver.js'
 
@@ -317,54 +316,7 @@ export class EffectModifierPopout extends Application {
   }
 
   async refreshUserMods() {
-    const actor = this.getToken()?.actor
-
-    if (actor) {
-      const userMods = foundry.utils.getProperty(actor, 'system.conditions.usermods') || []
-      const customMods = userMods.filter(it => it.includes('@custom'))
-      const itemMods = actor.applyItemModEffects({})
-      let sheetMods = []
-
-      const taggedSettings = game.settings.get(GURPS.SYSTEM_NAME, Settings.SETTING_USE_TAGGED_MODIFIERS)
-
-      if (taggedSettings.checkConditionals) {
-        const conditionalMods = foundry.utils.getProperty(actor, 'system.conditionalmods') || {}
-
-        recurselist(conditionalMods, (conditionalModifier, _k, _d) => {
-          const mod = parseInt(conditionalModifier.modifier) || 0
-          const signal = mod > 0 ? '+' : '-'
-          const source = `system.conditionalmods.${_k}`
-
-          if (mod !== 0) sheetMods.push(`${signal}${Math.abs(mod)} ${conditionalModifier.situation} @${source}`)
-        })
-      }
-
-      if (taggedSettings.checkReactions) {
-        const reactionMods = foundry.utils.getProperty(actor, 'system.reactions') || {}
-
-        recurselist(reactionMods, (reaction, _k, _d) => {
-          const mod = parseInt(reaction.modifier) || 0
-          const signal = mod > 0 ? '+' : '-'
-          const source = `system.reactions.${_k}`
-
-          if (mod !== 0) sheetMods.push(`${signal}${Math.abs(mod)} ${reaction.situation} @${source}`)
-        })
-      }
-
-      const newMods = [...itemMods['system.conditions.usermods'], ...customMods, ...sheetMods]
-
-      await actor.internalUpdate({ 'system.conditions.usermods': newMods })
-
-      // Check if combat
-      if (game.combat?.isActive) {
-        const actions = await TokenActions.fromToken(this.getToken())
-
-        await actions.addModifiers()
-      }
-
       await this.render(true)
-      ui.notifications.info(game.i18n.localize('GURPS.userModsRefreshed'))
-    }
   }
 
   async clearUserMods() {
@@ -377,7 +329,7 @@ export class EffectModifierPopout extends Application {
 
     if (proceed) {
       if (actor) {
-        await actor.update({ 'system.conditions.usermods': [] })
+        await this._deleteAllUserMod()
         await this.render(true)
       }
     }
@@ -402,7 +354,8 @@ export class EffectModifierPopout extends Application {
         if (mod) {
           let action = parselink(mod)
 
-          if (action.action?.type === OtfActionType.modifier) this._addUserMod(mod)
+          if (action.action?.type === OtfActionType.modifier)
+             await this._addUserMod(mod)
           else ui.notifications.warn(game.i18n.localize('GURPS.chatUnrecognizedFormat'))
         }
       }
@@ -457,17 +410,10 @@ export class EffectModifierPopout extends Application {
       return
     }
 
-    let token = this.getToken()
+    if (itemId === 'custom'){
+        this._deleteUserMod (this.getDescription(text))
 
-    if (token && token.actor) {
-      let umods = token.actor.system.conditions.usermods
-
-      if (umods) {
-        let mods = umods.filter(i => !sanitize(i).includes(this.getDescription(text)))
-
-        if (umods.length !== mods.length)
-          token.actor.update({ 'system.conditions.usermods': mods }).then(() => this.render(true))
-      }
+        return
     }
   }
 
@@ -498,15 +444,49 @@ export class EffectModifierPopout extends Application {
     this._addUserMod(add)
   }
 
-  _addUserMod(mod) {
-    let token = this.getToken()
+  async _addUserMod(mod) {
+    const token = this.getToken()
 
-    if (token && token.actor) {
-      mod += ' (' + game.i18n.localize('GURPS.equipmentUserCreated') + ')'
-      let mods = token.actor.system.conditions.usermods ? [...token.actor.system.conditions.usermods] : []
+    if (token && token.actor?.system?.holderItem) {
+      const modifier = `${mod} (${game.i18n.localize('GURPS.equipmentUserCreated')})`
 
-      mods.push(`${mod} @custom`)
-      token.actor.update({ 'system.conditions.usermods': mods }).then(() => this.render(true))
+      const item = token.actor.system.holderItem
+
+      const mods = item.system.itemModifiers
+        .split('\n')
+        .filter( it => it ==! modifier)
+        .concat([modifier])
+        .join('\n')
+
+      item.update({ 'system.itemModifiers': mods }).then(() => this.render(true))
+    } else ui.notifications.warn(game.i18n.localize('GURPS.chatYouMustHaveACharacterSelected'))
+  }
+
+  async _deleteUserMod(mod) {
+    const token = this.getToken()
+
+    if (token && token.actor?.system?.holderItem) {
+      
+      const item = token.actor.system.holderItem
+
+      const mods = item.system.itemModifiers
+        .split('\n')
+        .filter( it => it ==! mod)
+        .join('\n')
+
+      item.update({ 'system.itemModifiers': mods }).then(() => this.render(true))
+    } else ui.notifications.warn(game.i18n.localize('GURPS.chatYouMustHaveACharacterSelected'))
+  }
+
+  async _deleteAllUserMod() {
+    const token = this.getToken()
+
+    if (token && token.actor?.system?.holderItem) {
+      
+      const item = token.actor.system.holderItem
+
+
+      item.update({ 'system.itemModifiers': '' }).then(() => this.render(true))
     } else ui.notifications.warn(game.i18n.localize('GURPS.chatYouMustHaveACharacterSelected'))
   }
 

--- a/src/module/effects/effects.js
+++ b/src/module/effects/effects.js
@@ -102,27 +102,27 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureProneDefend', [defenseTag]),
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureProneMelee', [meleeTag]),
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
           {
             key: 'system.conditions.target.modifiers',
             value: getTaggedValue('GURPS.modifierPostureProneRanged', [rangedTag]),
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
           {
             key: 'system.conditions.posture',
             value: 'prone',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
+            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
           },
           {
             key: PROPERTY_MOVEOVERRIDE_POSTURE,
             value: MOVE_ONE,
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
+            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
             priority: 10,
           },
         ],
@@ -141,27 +141,27 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureKneelDefend', [defenseTag]),
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureKneelMelee', [meleeTag]),
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
           {
             key: 'system.conditions.target.modifiers',
             value: getTaggedValue('GURPS.modifierPostureCrouchRanged', [rangedTag]),
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
           {
             key: PROPERTY_MOVEOVERRIDE_POSTURE,
             value: MOVE_ONETHIRD,
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
+            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
           },
           {
             key: 'system.conditions.posture',
             value: 'kneel',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
+            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
           },
         ],
         flags: {
@@ -179,22 +179,22 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureCrouchMelee', [meleeTag]),
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
           {
             key: 'system.conditions.target.modifiers',
             value: getTaggedValue('GURPS.modifierPostureCrouchRanged', [rangedTag]),
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
           {
             key: PROPERTY_MOVEOVERRIDE_POSTURE,
             value: MOVE_TWOTHIRDS,
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
+            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
           },
           {
             key: 'system.conditions.posture',
             value: 'crouch',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
+            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
           },
         ],
         flags: {
@@ -212,27 +212,27 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureKneelMelee', [meleeTag]),
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureKneelDefend', [defenseTag]),
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
           {
             key: 'system.conditions.target.modifiers',
             value: getTaggedValue('GURPS.modifierPostureProneRanged', [rangedTag]),
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
           {
             key: PROPERTY_MOVEOVERRIDE_POSTURE,
             value: MOVE_NONE,
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
+            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
           },
           {
             key: 'system.conditions.posture',
             value: 'sit',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
+            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
           },
         ],
         flags: {
@@ -250,27 +250,27 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureProneMelee', [meleeTag]),
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
           {
             key: 'system.conditions.self.modifiers',
             value: getTaggedValue('GURPS.modifierPostureProneDefend', [defenseTag]),
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
           {
             key: 'system.conditions.target.modifiers',
             value: getTaggedValue('GURPS.modifierPostureProneRanged', [rangedTag]),
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
           {
             key: PROPERTY_MOVEOVERRIDE_POSTURE,
             value: MOVE_ONETHIRD,
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
+            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
           },
           {
             key: 'system.conditions.posture',
             value: 'crawl',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
+            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
           },
         ],
         flags: {
@@ -324,7 +324,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.reeling',
             value: true,
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
+            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
           },
         ],
         flags: {
@@ -343,12 +343,12 @@ export class StatusEffect {
           {
             key: 'system.conditions.exhausted',
             value: true,
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.override,
+            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
           },
           {
             key: 'system.attributes.ST.import',
             value: 0.5,
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.multiply,
+            mode: CONST.ACTIVE_EFFECT_MODES.MULTIPLY,
           },
         ],
         flags: {
@@ -564,7 +564,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad+1',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
         ],
       },
@@ -576,7 +576,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad+2',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
         ],
       },
@@ -588,7 +588,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad+3',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
         ],
       },
@@ -600,7 +600,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad+4',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
         ],
       },
@@ -612,7 +612,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad+5',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
         ],
       },
@@ -624,7 +624,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad-1',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
         ],
       },
@@ -636,7 +636,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad-2',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
         ],
       },
@@ -648,7 +648,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad-3',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
         ],
       },
@@ -660,7 +660,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad-4',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
         ],
       },
@@ -672,7 +672,7 @@ export class StatusEffect {
           {
             key: 'system.conditions.self.modifiers',
             value: 'GURPS.status.Bad-5',
-            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           },
         ],
       },
@@ -703,7 +703,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierStatusShock1',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag, hitTag, spellTag, skillTag],
         },
       ],
@@ -721,7 +721,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierStatusShock2',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag, hitTag, spellTag, skillTag],
         },
       ],
@@ -739,7 +739,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierStatusShock3',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag, hitTag, spellTag, skillTag],
         },
       ],
@@ -757,7 +757,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierStatusShock4',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag, hitTag, spellTag, skillTag],
         },
       ],
@@ -775,13 +775,13 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierStatusStunned',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [defenseTag],
         },
         {
           key: 'system.conditions.maneuver',
           value: 'do_nothing',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.custom,
+          mode: CONST.ACTIVE_EFFECT_MODES.custom,
         },
       ],
       flags: {
@@ -799,13 +799,13 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierStatusStunned',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [defenseTag],
         },
         {
           key: 'system.conditions.maneuver',
           value: 'do_nothing',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.custom,
+          mode: CONST.ACTIVE_EFFECT_MODES.custom,
         },
       ],
       flags: {
@@ -823,7 +823,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierGrappling',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag],
         },
       ],
@@ -838,13 +838,13 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionNausea',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [attributesTag],
         },
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionNauseaDef',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [defenseTag],
         },
       ],
@@ -859,13 +859,13 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionCough',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag],
         },
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionCoughIQ',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [iqTag],
         },
       ],
@@ -880,7 +880,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionRetch',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag, perTag],
         },
       ],
@@ -899,7 +899,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionDrowsy',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag, perTag],
         },
       ],
@@ -914,13 +914,13 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionTipsy',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag],
         },
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionTipsyCR',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [crTag],
         },
       ],
@@ -935,13 +935,13 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionDrunk',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag],
         },
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionDrunkCR',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [crTag],
         },
       ],
@@ -956,7 +956,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionEuphoria',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag, crTag],
         },
       ],
@@ -971,7 +971,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionModerateHPT',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag, crTag],
         },
       ],
@@ -986,7 +986,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionModerate',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag, crTag],
         },
       ],
@@ -1001,7 +1001,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionTerribleHPT',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag, crTag],
         },
       ],
@@ -1016,7 +1016,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionSevere',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag, crTag],
         },
       ],
@@ -1031,7 +1031,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierAfflictionTerrible',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag, crTag],
         },
       ],
@@ -1046,7 +1046,7 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifierSuffocate',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [dxTag, iqTag, crTag],
         },
       ],
@@ -1064,13 +1064,13 @@ const _getActiveEffectsData = function (id) {
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifiersBlindAttack',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [hitTag],
         },
         {
           key: 'system.conditions.self.modifiers',
           value: 'GURPS.modifiersBlindDefend',
-          mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+          mode: CONST.ACTIVE_EFFECT_MODES.ADD,
           tags: [defenseTag],
         },
       ],

--- a/src/module/tagged-modifiers/tagged-modifiers.ts
+++ b/src/module/tagged-modifiers/tagged-modifiers.ts
@@ -1,0 +1,220 @@
+import { MeleeAttackModel } from "@module/action/melee-attack.js"
+import { RangedAttackModel } from "@module/action/ranged-attack.js"
+import { ActionType } from "@module/action/types.js"
+import { cleanTags } from "@module/actor/effect-modifier-popout.js"
+import { AnyObject } from "fvtt-types/utils"
+
+import { TaggedModifiersSettings } from "./index.js"
+
+
+enum ROLL_TYPE {
+  MELEE = 'm',
+  RANGED = 'r',
+  PARRY = 'p',
+  BLOCK = 'b',
+  DAMAGE ='d',
+  SKILL = 'sk',
+  SPELL = 'sp',
+  DODGE = 'dodge',
+  ST = 'st',
+  DX = 'dx',
+  IQ = 'iq',
+  HT = 'ht',
+  WILL = 'will',
+  PER = 'per',
+  FRIGHT_CHECK = 'frightcheck',
+  VISION = 'vision',
+  HEARING = 'hearing',
+  TASTE_SMELL = 'tastesmell',
+  TOUCH = 'touch',
+  CR = 'cr',
+  UNKNOWN ='unknown'
+}
+
+const rollTypeTagSettings : Record<ROLL_TYPE, (keyof TaggedModifiersSettings)[]> =
+{
+    [ROLL_TYPE.MELEE]: ['allAttackRolls', 'allMeleeRolls', 'allRolls' ],
+    [ROLL_TYPE.RANGED]: ['allAttackRolls', 'allRangedRolls', 'allRolls'],
+    [ROLL_TYPE.PARRY]: ['allDefenseRolls', 'allParryRolls', 'allRolls'],
+    [ROLL_TYPE.BLOCK]: ['allDefenseRolls', 'allBlockRolls', 'allRolls'],
+    [ROLL_TYPE.DAMAGE]: ['allDamageRolls', 'allRolls'],
+    [ROLL_TYPE.SKILL]: ['allSkillRolls', 'allRolls'],
+    [ROLL_TYPE.SPELL]: ['allSpellRolls', 'allRolls'],
+    [ROLL_TYPE.DODGE]: ['allDefenseRolls', 'allDODGERolls', 'allRolls'],
+    [ROLL_TYPE.ST]: ['allAttributesRolls', 'allSTRolls', 'allRolls'],
+    [ROLL_TYPE.DX]: ['allAttributesRolls', 'allDXRolls', 'allRolls'],
+    [ROLL_TYPE.IQ]: ['allAttributesRolls', 'allIQRolls', 'allRolls'],
+    [ROLL_TYPE.HT]: ['allAttributesRolls', 'allHTRolls', 'allRolls'],
+    [ROLL_TYPE.WILL]: ['allWILLRolls', 'allRolls'],
+    [ROLL_TYPE.PER]: ['allPERRolls', 'allRolls'],
+    [ROLL_TYPE.FRIGHT_CHECK]: ['allFRIGHTCHECKRolls', 'allRolls'],
+    [ROLL_TYPE.VISION]: ['allVISIONRolls', 'allRolls'],
+    [ROLL_TYPE.HEARING]: ['allHEARINGRolls', 'allRolls'],
+    [ROLL_TYPE.TASTE_SMELL]: ['allTASTESMELLRolls', 'allRolls'],
+    [ROLL_TYPE.TOUCH]: ['allTOUCHRolls', 'allRolls'],
+    [ROLL_TYPE.CR]: ['allCRRolls', 'allRolls'],
+    [ROLL_TYPE.UNKNOWN]: ['allRolls']
+}
+
+function toValidRoleType(value : string | undefined) : ROLL_TYPE {
+    if (!value) return ROLL_TYPE.UNKNOWN
+
+    const enumValues = Object.values(ROLL_TYPE) as string[];
+
+    return enumValues.includes(value) ? value as ROLL_TYPE : ROLL_TYPE.UNKNOWN
+}
+
+function tagsForRollType(rollType: ROLL_TYPE, taggedSettings : TaggedModifiersSettings) : string[] {
+    return rollTypeTagSettings[rollType]
+        .flatMap( 
+            (setting) => 
+                (taggedSettings[setting] as string)
+                    .split(',')
+                    .map(it => it.trim().toLowerCase())
+                )
+}
+
+  /**
+ * Extract the roll/attribute reference code from a chat thing string with attribute format: `[ST]` or `dodge` or the roll format like `@R:attackname` or `@sk:skillname`
+ * @param {string} chatThing - The chat thing string
+ * @returns {ROLL_TYPE} The reference code (e.g., 'st', 'dodge')
+ */
+function extractRollTypeFromChatThing(chatThing: string) : ROLL_TYPE {
+    const ref = chatThing
+        .split('@')
+        ?.pop()
+        ?.toLowerCase()
+        ?.replace(' ', '')
+        ?.slice(0, -1)
+        ?.split(':')[0]
+
+    return toValidRoleType(ref)
+}
+
+function getRollTypeFromData(chatThing: string, attack: MeleeAttackModel | RangedAttackModel | undefined) {
+    function defaultRef() {
+        return attack ? attack.isOfType(ActionType.MeleeAttack) ? ROLL_TYPE.MELEE : ROLL_TYPE.RANGED : ROLL_TYPE.DAMAGE
+    }
+
+    const rollType = chatThing ? extractRollTypeFromChatThing(chatThing) : defaultRef()
+
+    return rollType
+}
+
+/*
+* Extracts the applicable tags from the roll data
+*
+* We get the roll type from the chat string and add the appropriate tags from the taggedSettings
+* For some roll types the optionalArgs contain the item or element the roll origins from in the obj property. We also get the tags from the modifierTags property of this element.
+* If chatThing is empty, we treat the roll as an attack roll if the attack parameter is provided or as a damage roll otherwise
+* 
+*/
+export function getTagsForRoll(
+    taggedSettings : TaggedModifiersSettings,
+    rollType : ROLL_TYPE,
+    optionalArgs: { obj?: {system?: AnyObject}}, 
+): Set<string> {
+
+    const rollTypeTags = tagsForRollType(rollType, taggedSettings)
+
+    // the modifierTags should always be a set stored in obj.system in GGA 1.0.0 or higher
+    const itemTags = (optionalArgs.obj?.system?.modifierTags instanceof Set) ? [...optionalArgs.obj.system.modifierTags] : [] 
+
+    const spellTags = 
+        (rollType === ROLL_TYPE.SPELL && taggedSettings.useSpellCollegeAsTag && optionalArgs.obj?.system?.colleges instanceof Set) 
+        ? Array.from(optionalArgs.obj?.system?.colleges).map(college => cleanTags(college))
+        : []
+
+    return new Set([...rollTypeTags, ...itemTags, ...itemTags, ...spellTags])
+}
+
+
+function getItemRefFromChatThing(chatThing: string): string | undefined {
+    const regex = /(?<="|:).+(?=\s\(|"|])/gm
+    let itemRef = chatThing.match(regex)?.[0]
+
+    if (itemRef) {
+      itemRef = itemRef.replace(/"/g, '').split('(')[0].trim()
+    }
+
+    return itemRef
+}
+
+function getItemRef(
+    chatThing: string, 
+    optionalArgs: { obj?: {name?: string, system?: AnyObject}}, 
+    attack?: MeleeAttackModel | RangedAttackModel,
+): string {
+   return optionalArgs?.obj?.name as string ?? getItemRefFromChatThing(chatThing) ?? attack?.name ?? ''
+}
+
+
+/*
+* tests if a mod should be applied
+*/
+function canModApply(
+    taggedSettings : TaggedModifiersSettings, 
+    itemRef : string,
+    actorInCombat : boolean,
+    allTags: Set<string>,
+    mod : string, 
+) : boolean {
+    const userModsTags: string[] = (mod.match(/#(\S+)/g) ?? [])?.map((tag: string) => tag.slice(1).toLowerCase())
+    
+    //do any tags match
+    const tagHit = userModsTags.some( tag => allTags.has(tag))
+    
+    //mods that include '#maneuver' are added by then TokenActions to the . If they include '@man:' they ar from the current manuever should be applied if a tag matches
+    //otherwise they are from multiple parrys oder previous aim manuevers, exists per attack row and haf the system path of the attack as source. 
+    // These should be applied only, if the attack of the roll matches the item reference.
+    // ToDo: In V1.0.0 the item references from the roll don't match, because the rolls uses the names, and TockenActions use keys.
+    // To fix this I have to fix the UserModifiers first.
+    // This whole logic here is quite fragile, the item matching should use item IDs.  
+    const tokenActionModsFits = !mod.includes('#maneuver') || mod.includes('@man:') || mod.includes(itemRef)
+
+    //check for combat/noncombat
+    const nonCombatModFits =  !actorInCombat || !taggedSettings.nonCombatOnlyTag || !allTags.has(taggedSettings.nonCombatOnlyTag)
+    const combatModFits =  actorInCombat || !taggedSettings.combatOnlyTag || !allTags.has(taggedSettings.combatOnlyTag)
+    
+    //ToDo: the original code has the following code. I have no clear idea how this is supposed to work and I can find on documentation of such a feature
+    /*
+        // If the modifier should apply only to a specific item (e.g. specific usage of a weapon) account for this
+        if ('itemPath' in optionalArgs && typeof optionalArgs.itemPath === 'string')
+          canApply = canApply && (mod.includes(optionalArgs.itemPath) || !mod.includes('@system')
+    */
+   // It seem to assume that be the intention, if the optional args include a itemPath (but the code path that set this property seem never to be called in V1)
+   // and the source of the mod dont't starts with @system (what his never then case in V1)  
+   // then the mod should ony apply to rolls originating from this item. 
+
+    return tagHit && tokenActionModsFits && nonCombatModFits && combatModFits
+}
+  
+  /**
+ * Finds all tagged modifiers that should be applied to a roll 
+ * @param {string} chatThing - The chat thing string fro the roll
+ * @param {MeleeAttackModel | RangedAttackModel | undefined} attack --attack from the roll
+ * @param {{ obj?: AnyObject }} optionalArgs optional arguments from the roll
+ * @param {TaggedModifiersSettings} taggedSettings - settings
+ * @param {string[]} allMods - all mods of the actor
+ * @param {boolean} actorInCombat - is the actor in combat
+ * @returns {{ modsToApply: string[], isDamageRoll: boolean }} 
+ */
+export function taggedModToApply(
+    chatThing: string, 
+    attack: MeleeAttackModel | RangedAttackModel | undefined, 
+    optionalArgs: { obj?: AnyObject },
+    taggedSettings: TaggedModifiersSettings, 
+    allMods: string[], 
+    actorInCombat: boolean
+): { modsToApply: string[], isDamageRoll: boolean } {
+
+    const rollType = getRollTypeFromData(chatThing, attack)
+    const allTags = getTagsForRoll(taggedSettings, rollType, optionalArgs)
+    const itemRef = getItemRef(chatThing, optionalArgs, attack)
+    const isDamageRoll = rollType === ROLL_TYPE.DAMAGE
+
+    const modsToApply = allMods.filter(mod => canModApply(taggedSettings, itemRef, actorInCombat, allTags, mod))
+
+    return { modsToApply, isDamageRoll }
+}
+

--- a/src/module/token-actions.js
+++ b/src/module/token-actions.js
@@ -704,6 +704,10 @@ export class TokenActions {
     }
 
     await this.save()
+    
+    if (this.token?.actor?.system?.refreshUserModifier) {
+        await this.token.actor.system.refreshUserModifier()
+    }
   }
 
   static getManeuverIcons(maneuverName) {
@@ -867,7 +871,11 @@ export class TokenActions {
         break
     }
 
-     await this.save()
+    await this.save()
+    
+     if (this.token?.actor?.system?.refreshUserModifier) {
+        await this.token.actor.system.refreshUserModifier()
+    }
   }
 
   /**
@@ -892,7 +900,7 @@ export class TokenActions {
     }
 
     await this.save()
-  }
+}
 
   getNextTurnEffects() {
     return this.lastManeuvers[this.currentTurn]?.nextTurnEffects || []

--- a/src/module/token-actions.js
+++ b/src/module/token-actions.js
@@ -136,18 +136,10 @@ export class TokenActions {
 
   async clear() {
     this.initValues()
-    await this.removeManeuverModifiers()
     await this.removeCombatTempMods()
     await this.token.document.unsetFlag('gurps', 'tokenActions')
     await this.save()
     await this.token.setManeuver('do_nothing')
-  }
-
-  async removeManeuverModifiers() {
-    const allModifiers = await foundry.utils.getProperty(this.actor, 'system.conditions.usermods')
-    const validModifiers = allModifiers.filter(modifierText => !modifierText.includes('#maneuver'))
-
-    await this.actor.update({ 'system.conditions.usermods': validModifiers })
   }
 
   async init() {
@@ -392,38 +384,14 @@ export class TokenActions {
     return Math.min(skillLevel - Math.max(2, weaponBulk), 9)
   }
 
-  /**
-   * Remove Effect Modifiers created by the Maneuver.
-   *
-   * We found the maneuver modifiers by the '#maneuver' tag in effect description.
-   *
-   * @returns {Promise<void>}
-   */
-  async removeModifiers() {
-    const allModifiers = (await foundry.utils.getProperty(this.actor, 'system.conditions.usermods')) || []
-    const nonManeuverModifiers = allModifiers.filter(modifierText => !modifierText.includes('#maneuver'))
-
-    await this.actor.update({ 'system.conditions.usermods': nonManeuverModifiers })
-  }
-
-  /**
-   * Add Effect Modifiers created by the Maneuver.
+    /**
+   * Get Effect Modifiers created by the Maneuver.
    *
    * We mark the maneuver modifiers with the '#maneuver' tag in effect description.
    * And to the source reference, we use the '@man:<maneuverName>' identifier.
    *
-   * @returns {Promise<void>}
-   */
-  async addModifiers() {
-    const addModifier = mod => {
-      if (!maneuverModifiers.includes(mod) && !allModifiers.includes(mod)) {
-        maneuverModifiers.push(mod)
-      }
-    }
-
-    const allModifiers = await [...foundry.utils.getProperty(this.actor, 'system.conditions.usermods')].filter(
-      modifierText => !modifierText.includes('#maneuver') && !modifierText.includes('@eft:')
-    )
+    */
+   getModifiers() {
 
     const maneuverModifiers = []
 
@@ -434,26 +402,26 @@ export class TokenActions {
       if (this.currentManeuver === 'move_and_attack') {
         const rangedBulkLabel = game.i18n.localize('GURPS.modifiers_.moveAndAttackRangedBulk')
 
-        addModifier(
+        maneuverModifiers.push(
           `${signal}${Math.abs(this.toHitBonus)} ${signalLabel} *Max:9 #melee #maneuver @man:${this.currentManeuver}`
         )
-        addModifier(
+        maneuverModifiers.push(
           `${signal}${Math.abs(this.toHitBonus / 2)} ${rangedBulkLabel} #ranged #maneuver @man:${this.currentManeuver}`
         )
       } else {
-        addModifier(`${signal}${Math.abs(this.toHitBonus)} ${signalLabel} #hit #maneuver @man:${this.currentManeuver}`)
+        maneuverModifiers.push(`${signal}${Math.abs(this.toHitBonus)} ${signalLabel} #hit #maneuver @man:${this.currentManeuver}`)
       }
     }
 
     if (this.evaluateTurns > 0) {
-      addModifier(`+${this.evaluateTurns} ${game.i18n.localize('GURPS.toHitBonus')} #hit #maneuver @man:evaluate`)
+      maneuverModifiers.push(`+${this.evaluateTurns} ${game.i18n.localize('GURPS.toHitBonus')} #hit #maneuver @man:evaluate`)
     }
 
     if (this.defenseBonus !== 0) {
       const signal = this.defenseBonus > 0 ? '+' : '-'
       const signalLabel = game.i18n.localize(signal === '+' ? 'GURPS.toDefenseBonus' : 'GURPS.toDefensePenalty')
 
-      addModifier(
+      maneuverModifiers.push(
         `${signal}${Math.abs(this.defenseBonus)} ${signalLabel} #parry #block #dodge #maneuver @man:${this.currentManeuver}`
       )
     }
@@ -465,7 +433,7 @@ export class TokenActions {
         const signal = parry.currentPenalty > 0 ? '+' : '-'
         const signalLabel = game.i18n.localize(signal === '+' ? 'GURPS.toParryBonus' : 'GURPS.toParryPenalty')
 
-        addModifier(
+        maneuverModifiers.push(
           `${signal}${Math.abs(parry.currentPenalty)} ${signalLabel} ${parry.name} #parry #maneuver #${parry.mode} @${parry.key}`
         )
       }
@@ -478,13 +446,11 @@ export class TokenActions {
         const signal = aim.aimBonus > 0 ? '+' : '-'
         const signalLabel = game.i18n.localize(signal === '+' ? 'GURPS.toAimBonus' : 'GURPS.toAimPenalty')
 
-        addModifier(`${signal}${Math.abs(aim.aimBonus)} ${signalLabel} ${aim.name} #hit #maneuver @${aim.key}`)
+        maneuverModifiers.push(`${signal}${Math.abs(aim.aimBonus)} ${signalLabel} ${aim.name} #hit #maneuver @${aim.key}`)
       }
     })
 
-    await this.actor.update({
-      'system.conditions.usermods': [...allModifiers, ...maneuverModifiers],
-    })
+    return maneuverModifiers
   }
 
   resetTurnValues() {
@@ -521,8 +487,6 @@ export class TokenActions {
 
     this.lastManeuvers[round].maneuver = maneuver.flags.gurps.name
     console.info(`Select Maneuver: '${this.currentManeuver}' for Token: ${this.token.name}`)
-
-    await this.removeModifiers()
 
     this.maxMove = this.getMaxMove()
     this.maxParries = Infinity
@@ -624,7 +588,6 @@ export class TokenActions {
         break
     }
 
-    await this.addModifiers()
     await this.save()
   }
 
@@ -740,7 +703,6 @@ export class TokenActions {
       await this.token.actor.toggleStatusEffect(effect, { active: true })
     }
 
-    await this.addModifiers()
     await this.save()
   }
 
@@ -807,22 +769,38 @@ export class TokenActions {
 
     return icon
   }
+
+    /**
+   * Remove user defined custom modifiers marked as temporary.
+   * Called when combat ends
+   *
+   * @returns {Promise<void>}
+   */
   async removeCombatTempMods() {
     const taggedSettings = game.settings.get(GURPS.SYSTEM_NAME, Settings.SETTING_USE_TAGGED_MODIFIERS)
     const combatTempTags = taggedSettings.combatTempTag
       .split(',')
       .map(it => it.trim().toLowerCase())
       .filter(it => !!it)
+      .map(it => `#${it}`)
 
-    if (!combatTempTags.length) return
-    const userMods = foundry.utils.getProperty(this.actor, 'system.conditions.usermods')
-    const validMods = userMods.filter(mod => {
-      const tags = mod.match(/#(\S+)/g) || []
+    if (combatTempTags.length < 1) return
 
-      return tags.every(tag => !combatTempTags.includes(tag.toLowerCase()))
-    })
+    if (this.actor.system?.holderItem) {
+      
+      const item = this.actor.system.holderItem
 
-    await this.actor.update({ 'system.conditions.usermods': validMods })
+      const mods = item.system.itemModifiers
+        .split('\n')
+        .filter( mod => {
+            const tags = mod.match(/#(\S+)/g) || []
+
+            return tags.every(tag => !combatTempTags.includes(tag.toLowerCase()))
+            })
+        .join('\n')
+
+      await item.update({ 'system.itemModifiers': mods })
+    }
   }
 
   /**
@@ -889,8 +867,7 @@ export class TokenActions {
         break
     }
 
-    await this.addModifiers()
-    await this.save()
+     await this.save()
   }
 
   /**

--- a/src/module/token/gurps-token.ts
+++ b/src/module/token/gurps-token.ts
@@ -41,6 +41,10 @@ class GurpsToken extends foundry.canvas.placeables.Token {
 
     maneuver.name = game.i18n?.localize(maneuver.name ?? maneuver.label) ?? maneuver.name
 
+    const actions = await TokenActions.fromToken(this)
+
+    await actions.selectManeuver(maneuver, game.combat?.round)
+
     const activeManeuvers = Maneuvers.getActiveEffectManeuvers(
       Array.from(this.actor?.effects.values() ?? []) as ActiveEffect.Implementation[]
     )
@@ -62,10 +66,7 @@ class GurpsToken extends foundry.canvas.placeables.Token {
       await this.actor?.createEmbeddedDocuments('ActiveEffect', [maneuver])
     }
 
-    const actions = await TokenActions.fromToken(this)
-
-    await actions.selectManeuver(maneuver, game.combat?.round)
-  }
+   }
 
   /* ---------------------------------------- */
 

--- a/static/templates/action/partials/details-melee-attack.hbs
+++ b/static/templates/action/partials/details-melee-attack.hbs
@@ -22,6 +22,10 @@
   <div class="ms-field-row" style="--ms-cols: 1;">
     {{formGroup fields.modifierTags value=source.modifierTags }}
   </div>
+  
+  <div class="ms-field-row" style="--ms-cols: 1;">
+    {{formGroup fields.itemModifiers value=source.itemModifiers elementType="textarea"}}
+  </div>
 
   <h3>Parry</h3>
 

--- a/static/templates/action/partials/details-ranged-attack.hbs
+++ b/static/templates/action/partials/details-ranged-attack.hbs
@@ -23,6 +23,10 @@
     {{formGroup fields.modifierTags value=source.modifierTags }}
   </div>
 
+  <div class="ms-field-row" style="--ms-cols: 1;">
+    {{formGroup fields.itemModifiers value=source.itemModifiers elementType="textarea"}}
+  </div>
+  
   <h3>Accuracy</h3>
 
   <div class="ms-field-row" style="--ms-cols: 3;">


### PR DESCRIPTION
Refactors addTaggedRollModifiers to be more robust an readable,
Can't be fully tested yet, because for much of the functionality to work, I have first to fix #2710 (User Modifiers).

This is a first step. It is a bit absurd, that we basically have all necessary information about the roll in GURPS.performAction and then encode it in some strings and have to decode it here AND look at some other optional data .
If we could make sure that doRoll is for all rolls only called from performAction, it should be possible to work with just the Action Object for all this.
We could also consider storing the tagged modifiers as a structured object instead of encoding tags and source in the string,

I am not sure  how big the scope of this PR should be. I think I would prefer to limit it to this function and fixing the user modifiers and do more later,

Update: now fixes #2710 and #2761 
I opted to store the user created custom modifiers in the holderItem of the actor. This seem to be a appropriate place to me and integrates nicely with the modifiers from regular items.