### PR TITLE
fix: deleting entries from unlinked token deletes from actor

### DIFF
--- a/module/gurps.js
+++ b/module/gurps.js
@@ -1609,7 +1609,9 @@ if (!globalThis.GURPS) {
    * @param {string} path
    */
   async function removeKey(actor, path) {
-    const targetActor = game.actors.get(actor.id) ?? actor
+    // For synthetic (unlinked token) actors, game.actors.get(actor.id) returns the base world
+    // actor, not the synthetic one. Always use the actor passed in for token actors.
+    const targetActor = actor.isToken ? actor : (game.actors.get(actor.id) ?? actor)
     const objectData = foundry.utils.duplicate(GURPS.decode(targetActor, path.substring(0, path.lastIndexOf('.'))))
     const { deleteKey, objectPath, updatedObject } = prepareRemoveKey(path, objectData)
 


### PR DESCRIPTION
during my testing for this bug I found that when deleting an item from an unlinked token nothing initially happens but the item is then removed from the source actor after refreshing.

fixes #2052 