### PR TITLE
Allow HP/FP above base value

### DIFF
--- a/src/module/actor/data/character-components.ts
+++ b/src/module/actor/data/character-components.ts
@@ -26,7 +26,7 @@ class CharacterPool extends DataModel<PoolSchema> {
 
 const poolSchema = () => {
   return {
-    damage: new fields.NumberField({ required: true, nullable: false, initial: 0, min: 0 }),
+    damage: new fields.NumberField({ required: true, nullable: false, initial: 0 }),
     min: new fields.NumberField({ required: true, nullable: false, initial: 0 }),
     max: new fields.NumberField({ required: true, nullable: false, initial: 0 }),
     points: new fields.NumberField({ required: true, nullable: false, initial: 0 }),

--- a/src/module/actor/sheets/gcs-actor-sheet.ts
+++ b/src/module/actor/sheets/gcs-actor-sheet.ts
@@ -449,7 +449,7 @@ class GurpsActorGcsSheet extends GurpsBaseActorSheet<
     const systemSource = this.actor.system._source
 
     const currentValue = this.actor.system[key].value
-    const state = thresholds.find(threshold => threshold.value >= currentValue)
+    const state = thresholds.find(threshold => threshold.value >= currentValue) ?? thresholds.at(-1) //treat the last bin as unlimited, when the value is above max (for temporary hit points or such)
 
     const color = getColorForState(key, state?.state, this.options.classes?.includes('theme-dark') ? 'dark' : 'light')
     const text = getTextForState(key, state?.state)

--- a/src/module/actor/sheets/gcs-actor-sheet.ts
+++ b/src/module/actor/sheets/gcs-actor-sheet.ts
@@ -470,7 +470,7 @@ class GurpsActorGcsSheet extends GurpsBaseActorSheet<
         value: systemSource[key].max,
         label: 'GURPS.sheet.gcsActorSheet.poolBase',
       },
-      atMax: systemSource[key].damage === 0,
+      atMax: false,
       name: `GURPS.${key}`,
       state: text,
       color,

--- a/src/module/ui/pool-value.ts
+++ b/src/module/ui/pool-value.ts
@@ -38,7 +38,7 @@ export class PoolValueElement extends foundry.applications.elements.AbstractForm
   /* ---------------------------------------- */
 
   protected override _setValue(value: number): void {
-    this._value = Math.max(Number(value) || 0, 0)
+    this._value = Number(value) || 0
   }
 
   /* ---------------------------------------- */


### PR DESCRIPTION
Modified the data model and the GCS Sheet to allow  for attribute pool values above base value for things like temporary HP.
Fixes #2757 
Should also work with the modern sheet, but that is blocked by #2794 