### PR TITLE
Fix pseudo document updates on synthetic actors

### DIFF
--- a/src/module/data/model-collection.ts
+++ b/src/module/data/model-collection.ts
@@ -235,7 +235,10 @@ class ModelCollection<Model extends PseudoDocument.Any = PseudoDocument.Any> ext
   #initializeDocument(data: AnyMutableObject, options: AnyMutableObject): Model | null {
     let doc = this.get(data._id as string)
 
-    if (doc) {
+    // if the parent is the synthetic actor of an unlinked token, the source of the stored document can be out of sync with the source of the synthetic actor.
+    // I am unclear why this happens.
+    // but in this case we cannot just reinitialize the document, we need to create a new one.
+    if (doc && doc._source === data) {
       // @ts-expect-error: Accessing protected property.
       doc._initialize(options)
 


### PR DESCRIPTION
fixes #2714

Please review critically, I am quite  sure this fixes the issue, but I am not sure that  I am not just fixing the symptom of a deeper problem.

The issue is that the source of the stored document in the collection does not refer to the source of the parent document in the case of synthetic actor ( and only in this case).  So it doesn't receive the changes from a update and the document is not updated in the collection. 

But I could not find what causes this inconsistency.  So I fixed it in initializeDocument. Once fixed, it stays fixed, so the document is not recreate on ever initialization of the actor, but only on the first per session.