### PR TITLE
Switch modern sheet item display from name to fullName

### DIFF
--- a/static/templates/actor/modern/partials/item-table.hbs
+++ b/static/templates/actor/modern/partials/item-table.hbs
@@ -10,7 +10,7 @@
     >
     <span class='ms-col-name indent{{indent}} {{ifThen (eq section "traits") (pointsClass points) ""}}'>
       {{#if hasChildren}}<i class='fas fa-caret-down ms-container-icon {{ifThen childrenOpen "" "container-collapsed"}}'></i>{{/if}}
-      <span class='ms-col-name-text'>{{stripOtfs this.name}}</span>
+      <span class='ms-col-name-text'>{{stripOtfs this.fullName}}</span>
     </span>
     {{#if flags.college}}<span class='ms-col-college'>{{college}}</span>{{/if}}
     {{#if flags.level}}


### PR DESCRIPTION
Fixes #2812
Note that this , beside displaying skill Specializations, also displays Skill and Spell TL and Traits Level with the name. This is consistent with the display on the GCS sheet