### PR TITLE
Fix quick roll menu vor 1.0.0

### DIFF
--- a/src/module/actor/data/character.ts
+++ b/src/module/actor/data/character.ts
@@ -1498,6 +1498,7 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
                 value: displayItem.level,
                 mode: displayItem.usage,
                 otf: displayItem.otf.level,
+                damage: displayItem.damage,
                 isOTF: true,
                 otfDamage: displayItem.otf.damage,
                 type: attack.type === 'meleeAttack' ? 'melee' : 'ranged',

--- a/src/module/actor/data/character.ts
+++ b/src/module/actor/data/character.ts
@@ -11,12 +11,13 @@ import { ModelCollection } from '@module/data/model-collection.js'
 import * as HitLocations from '@module/hitlocation/hitlocation.js'
 import { BaseItemModel } from '@module/item/data/base.js'
 import { ConditionalModifier, ReactionModifier } from '@module/item/data/conditional-modifier.js'
+import { GurpsItemV2 } from '@module/item/gurps-item.js'
 import { EquipmentV1 } from '@module/item/legacy/equipment-adapter.js'
 import { SkillV1 } from '@module/item/legacy/skill-adapter.js'
 import { SpellV1 } from '@module/item/legacy/spell-adapter.js'
 import { TraitV1 } from '@module/item/legacy/trait-adapter.js'
 import { ItemType } from '@module/item/types.js'
-import { COSTS_REGEX } from '@module/otf/parselink.js'
+import { COSTS_REGEX, parselink } from '@module/otf/parselink.js'
 import { OtfActionType, OtfAction } from '@module/otf/types.js'
 import { TrackerInstance } from '@module/resource-tracker/resource-tracker.js'
 import { TaggedModifiersSettings } from '@module/tagged-modifiers/index.js'
@@ -1483,22 +1484,23 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
         checks.push(
           ...this.parent.items
             .reduce((acc: (MeleeAttackModel | RangedAttackModel)[], item) => {
-              acc.push(...(item as Item.Implementation).getItemAttacks())
+              acc.push(...(item as Item.Implementation).getItemAttacks().filter(attack => attack.addToQuickRoll))
 
               return acc
             }, [])
             .map(attack => {
-              const otfName = attack.mode ? `${attack.name} (${attack.mode})` : attack.name
+              const displayItem = attack.toDisplayItem()
 
               return {
                 img: attack.img ?? '',
-                symbol: game.i18n?.localize(`GURPS.attack${attack.name}`) ?? '',
-                label: attack.name ?? '',
-                value: attack.importedLevel,
-                mode: attack.mode,
-                otf: attack.type === 'meleeAttack' ? `M:"${otfName}"` : `R:"${otfName}"`,
+                symbol: game.i18n?.localize(`TYPES.Action.${attack.type}`) ?? '',
+                label: displayItem.name,
+                value: displayItem.level,
+                mode: displayItem.usage,
+                otf: displayItem.otf.level,
                 isOTF: true,
-                otfDamage: `D:"${otfName}"`,
+                otfDamage: displayItem.otf.damage,
+                type: attack.type === 'meleeAttack' ? 'melee' : 'ranged',
               }
             })
         )
@@ -1507,71 +1509,81 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
       case 'defenseChecks':
         checks.push(
           {
-            symbol: 'dodge',
+            symbol: game.i18n?.localize('GURPS.dodge') ?? '',
             label: game.i18n?.localize('GURPS.dodge') ?? '',
             value: this.currentdodge,
-            otf: 'dodge',
+            otf: 'Dodge',
             isOTF: true,
+            type: 'dodge',
           }
           // TODO: implement getItemAttacks on actor
         )
-        this.parent.getItemAttacks({ attackType: 'melee' }).reduce((acc, attack) => {
-          const symbol = game.i18n?.localize(`GURPS.${attack.name}`) ?? ''
-          const img = attack.img
-          const otfName = attack.mode ? `"${attack.name} (${attack.mode})"` : `"${attack.name}"`
+        this.parent
+          .getItemAttacks({ attackType: 'melee' })
+          .filter(attack => attack.addToQuickRoll)
+          .reduce((acc, attack) => {
+            const img = attack.img
+            const displayItem = attack.toDisplayItem()
 
-          if (attack.parry.canParry)
-            acc.push({
-              symbol,
-              img: img ?? '',
-              label: attack.name ?? '',
-              value: attack.parryLevel,
-              mode: attack.mode,
-              otf: `P:${otfName}`,
-              isOTF: true,
-            })
+            if (attack.parry.canParry)
+              acc.push({
+                symbol: game.i18n?.localize(`GURPS.parry`) ?? '',
+                img: img ?? '',
+                label: displayItem.name,
+                value: displayItem.parry,
+                mode: displayItem.usage,
+                otf: displayItem.otf.parry ?? '',
+                isOTF: true,
+                type: 'parry',
+              })
 
-          if (attack.block.canBlock)
-            acc.push({
-              symbol,
-              img: img ?? '',
-              label: attack.name ?? '',
-              value: attack.blockLevel,
-              mode: attack.mode,
-              otf: `B:${otfName}`,
-              isOTF: true,
-            })
+            if (attack.block.canBlock)
+              acc.push({
+                symbol: game.i18n?.localize(`GURPS.block`) ?? '',
+                img: img ?? '',
+                label: displayItem.name ?? '',
+                value: displayItem.block,
+                mode: displayItem.usage,
+                otf: displayItem.otf.block ?? '',
+                isOTF: true,
+                type: 'block',
+              })
 
-          return acc
-        }, checks)
+            return acc
+          }, checks)
 
         return { data: checks, size: checks.length }
 
       case 'markedChecks': {
-        const items = this.parent.items.filter(item =>
-          (item as Item.Implementation).isOfType(ItemType.Trait, ItemType.Skill, ItemType.Spell)
+        const skills: (GurpsItemV2<ItemType.Skill> | GurpsItemV2<ItemType.Spell>)[] = this.allSkillsV2.filter(
+          skill => skill.system.addToQuickRoll
         )
+        const spells: (GurpsItemV2<ItemType.Skill> | GurpsItemV2<ItemType.Spell>)[] = this.allSpellsV2.filter(
+          spell => spell.system.addToQuickRoll
+        )
+        const traits: GurpsItemV2<ItemType.Trait>[] = this.allAdsV2.filter(trait => trait.system.addToQuickRoll)
+        const skillsAndSpells = [...skills, ...spells]
 
-        for (const item of items) {
+        for (const item of skillsAndSpells) {
           if (item.system.addToQuickRoll) {
-            const type = item.type === ItemType.Trait ? 'ad' : item.type
-            let value = 0
-
-            if ((item as Item.Implementation).isOfType(ItemType.Skill))
-              value = (item as Item.OfType<ItemType.Skill>).system.importedLevel
-            if ((item as Item.Implementation).isOfType(ItemType.Spell))
-              value = (item as Item.OfType<ItemType.Spell>).system.importedLevel
+            const displayItem = item.system.toDisplayItem()
 
             checks.push({
-              symbol: game.i18n?.localize(`GURPS.${type}`) ?? '',
+              symbol: game.i18n?.localize(`TYPES.Item.${item.type}`) ?? '',
               img: item.img ?? '',
-              label: item.name,
-              value,
+              label: displayItem.fullName,
+              value: displayItem.level,
               notes: item.system.notes,
-              otf: `${type}:"${item.name}"`,
+              otf: displayItem.otf.level,
               isOTF: false,
             })
           }
+
+          extractOTFS(item)
+        }
+
+        for (const item of traits) {
+          extractOTFS(item)
         }
 
         return { data: checks, size: checks.length }
@@ -1579,6 +1591,29 @@ class CharacterModel extends BaseActorModel<CharacterSchema> {
 
       default:
         return { data: [], size: 0 }
+    }
+
+    function extractOTFS(
+      item: GurpsItemV2<ItemType.Skill> | GurpsItemV2<ItemType.Spell> | GurpsItemV2<ItemType.Trait>
+    ) {
+      const combinedNotes = item.system.notes + (item.system.vttNotes ?? '')
+      const possibleOTFs = combinedNotes.match(/\[.*?\]/g) || []
+
+      for (const otf of possibleOTFs) {
+        const parsed = parselink(otf)
+
+        if (parsed) {
+          checks.push({
+            symbol: `${game.i18n?.localize(`TYPES.Item.${item.type}`) ?? ''} ${item.name} `,
+            img: item.img ?? '',
+            label: parsed.text.replace(/[[\]]/g, ''),
+            value: '',
+            notes: item.system.notes,
+            otf: `/r ${parsed.text}`,
+            isOTF: true,
+          })
+        }
+      }
     }
   }
 

--- a/src/module/actor/types.ts
+++ b/src/module/actor/types.ts
@@ -17,8 +17,8 @@ interface CheckInfo {
   otf: string
   otfDamage?: string
   isOTF?: boolean
+  type?: string
 }
-
 /* ---------------------------------------- */
 
 interface CanRollResult {

--- a/src/module/combat-tracker/quick-roll-menu.ts
+++ b/src/module/combat-tracker/quick-roll-menu.ts
@@ -43,7 +43,7 @@ export const addQuickRollButton = async (html: HTMLElement, combatant: Combatant
     // Let the #combat-popout has the correct height based on opened menu
     if (menu.is(':visible')) {
       // Set menu top position to quick roll button position + offset
-      const menuOffset = $(this).position().top + 40
+      const menuOffset = this.offsetTop + this.offsetHeight
 
       menu.css('top', `${menuOffset}px`)
 

--- a/src/module/combat-tracker/quick-roll-menu.ts
+++ b/src/module/combat-tracker/quick-roll-menu.ts
@@ -1,8 +1,6 @@
 import { GurpsToken } from '@module/token/gurps-token.js'
 import * as Settings from '@module/util/miscellaneous-settings.js'
 
-import { TokenActions } from '../token-actions.js'
-
 export const addQuickRollButton = async (html: HTMLElement, combatant: Combatant, token: GurpsToken) => {
   const quickRollSettings = game.settings?.get(GURPS.SYSTEM_NAME, Settings.SETTING_USE_QUICK_ROLLS)
   const canShowButtons = quickRollSettings?.enabled && (game.user?.isGM || combatant.isOwner)
@@ -95,14 +93,12 @@ export const addQuickRollButton = async (html: HTMLElement, combatant: Combatant
   combatantControlsDiv?.prepend(quickRollButton)
 
   // Add Quick Roll Menu
-  const actions = await TokenActions.fromToken(token)
   const { actor } = token
   const quickRollMenu = await foundry.applications.handlebars.renderTemplate(
     'systems/gurps/templates/quick-roll-menu.hbs',
     {
       actor,
       combatant,
-      blindRoll: actions.blindAsDefault ?? true,
       attributeChecks: actor.getChecks('attributeChecks'),
       otherChecks: actor.getChecks('otherChecks'),
       attackChecks: actor.getChecks('attackChecks'),
@@ -137,35 +133,6 @@ export const addQuickRollListeners = (html: HTMLElement) => {
       }
     })
   }
-
-  // Resolve Roll Type Toggle
-  html.querySelectorAll('.quick-roll-blind-toggle').forEach(element =>
-    element.addEventListener('click', async function (event: Event) {
-      event.preventDefault()
-      event.stopPropagation()
-      const combatantId = (event.target as HTMLElement).dataset.combatantId
-
-      if (!combatantId) return
-
-      const combatant = game.combat?.combatants.get(combatantId)
-
-      if (!combatant || !combatant.token?.id) {
-        console.warn(`Combatant not found for id: ${combatantId}`)
-
-        return
-      }
-
-      const token = canvas?.tokens?.get(combatant.token.id)
-      const actions = await TokenActions.fromToken(token)
-
-      actions.blindAsDefault = !actions.blindAsDefault
-
-      await actions.save()
-      ;(event.target as HTMLElement).querySelectorAll('.qr-blind').forEach(function (element: Element) {
-        element.classList.toggle('active')
-      })
-    })
-  )
 
   // Resolve Ctrl Key when hovering Quick Roll menu
   html.addEventListener('mouseover', function (event: Event) {
@@ -215,14 +182,13 @@ export const addQuickRollListeners = (html: HTMLElement) => {
         return
       }
 
-      const actions = await TokenActions.fromToken(token)
       const actor = token.actor
 
       const otf = button.dataset.otf
       const damage = button.dataset.otfDamage
       const formula = event.ctrlKey && damage ? damage : otf
 
-      await actor.runOTF(`${actions.blindAsDefault ? '!' : ''}${formula}`)
+      await actor.runOTF(formula ?? '')
     })
   })
 }

--- a/src/module/combat-tracker/quick-roll-menu.ts
+++ b/src/module/combat-tracker/quick-roll-menu.ts
@@ -10,7 +10,7 @@ export const addQuickRollButton = async (html: HTMLElement, combatant: Combatant
   if (!canShowButtons || !token?.actor) return html
 
   const buttonClass = `combatant-control`
-  const quickRollButton = $(
+  const quickRollButton = foundry.utils.parseHTML(
     `<a class="${buttonClass}"
           aria-label="Quick Roll"
           role="button"
@@ -18,56 +18,81 @@ export const addQuickRollButton = async (html: HTMLElement, combatant: Combatant
           data-combatant-id="${combatant.id}"
           data-tooltip="GURPS.quickRollMenu"
           id="quick-roll-${combatant.id}">
-          <i class="fa-solid fa-dice-five"></i>`
-  )
+          <i class="fa-solid fa-dice-five"></i>
+    </a>`
+  ) as HTMLElement
 
   // Add Quick Button and Menu Listeners
-  quickRollButton.on('click', async function (event) {
+  quickRollButton.addEventListener('click', async function (event) {
     event.preventDefault()
     event.stopPropagation()
 
-    const clickedMenuId = $(this).data('combatant-id')
+    const clickedMenuId = this.dataset.combatantId
 
-    $(`.${buttonClass}`).each(function () {
-      const menuId = $(this).data('combatant-id')
+    document.querySelectorAll(`.${buttonClass}`).forEach(function (element) {
+      const menuId = (element as HTMLElement).dataset.combatantId
 
       if (!!menuId && clickedMenuId !== menuId) {
-        $(this).parents().siblings('.quick-roll-menu').hide()
+        const otherMenu = (element as HTMLElement).closest('li')?.querySelector('.quick-roll-menu')
+
+        if (otherMenu) (otherMenu as HTMLElement).style.display = 'none'
       }
     })
 
-    const menu = $(this).parents().siblings('.quick-roll-menu')
+    const menu = this.closest('li')?.querySelector('.quick-roll-menu') as HTMLElement | null
 
-    menu.toggle()
+    if (!menu) {
+      console.warn(`Quick Roll Menu not found for combatant: ${combatant.name ?? 'unknown'}`)
 
-    // Let the #combat-popout has the correct height based on opened menu
-    if (menu.is(':visible')) {
+      return
+    }
+
+    menu.style.display = menu.style.display === 'none' ? 'block' : 'none'
+
+    if (menu.style.display !== 'none') {
       // Set menu top position to quick roll button position + offset
       const menuOffset = this.offsetTop + this.offsetHeight
 
-      menu.css('top', `${menuOffset}px`)
+      menu.style.top = `${menuOffset}px`
+    }
 
-      // Find the selected <li> element
-      const selectedLi = $(this).closest('[class*="combatant actor directory-item flexrow"]')
-      const allLis = $('#combat-tracker [class*="combatant actor directory-item flexrow"]')
-      const selectedIndex = allLis.index(selectedLi)
+    const popOut = this.closest('#combat-popout') as HTMLElement | null
 
-      // Count the number of <li> elements below the selected one
-      const lisBelow = allLis.slice(selectedIndex + 1).length
-      const popout = $('#combat-popout')
-      const menuHeight = menu.outerHeight(true) ?? 0
-      const trackerHeight = popout.outerHeight(true) ?? 0
-      const additionalHeight = lisBelow * (selectedLi.outerHeight(true) ?? 0)
+    if (popOut) {
+      // Let the #combat-popout has the correct height based on opened menu
+      if (menu.style.display !== 'none') {
+        // Find the selected <li> element
+        const selectedLi = this.closest('li.combatant')
 
-      popout.css('min-height', `${menuHeight + trackerHeight - additionalHeight}px`)
-    } else {
-      $('#combat-popout').css('min-height', `unset`).css('height', `auto`)
+        if (!selectedLi) {
+          console.warn(`Selected <li> element not found for combatant: ${combatant.name ?? 'unknown'}`)
+
+          return
+        }
+
+        const allLis = popOut.querySelectorAll('li.combatant')
+        const selectedIndex = Array.from(allLis).indexOf(selectedLi)
+
+        // Count the number of <li> elements below the selected one
+        const lisBelow = allLis.length - selectedIndex - 1
+        const menuHeight = menu.offsetHeight ?? 0
+        const trackerHeight = popOut.offsetHeight ?? 0
+        const additionalHeight =
+          lisBelow *
+          ((selectedLi as HTMLElement)?.offsetHeight +
+            (parseInt(getComputedStyle(selectedLi as HTMLElement).marginBottom) || 0))
+
+        popOut.style.minHeight = `${menuHeight + trackerHeight - additionalHeight}px`
+      } else {
+        popOut.style.minHeight = `unset`
+        popOut.style.height = `auto`
+      }
     }
   })
 
-  const combatantControlsDiv = $(html).find('.combatant-controls').first()
+  const combatantControlsDiv = html.querySelector('.combatant-controls')
 
-  combatantControlsDiv.prepend(quickRollButton)
+  combatantControlsDiv?.prepend(quickRollButton)
 
   // Add Quick Roll Menu
   const actions = await TokenActions.fromToken(token)
@@ -77,7 +102,7 @@ export const addQuickRollButton = async (html: HTMLElement, combatant: Combatant
     {
       actor,
       combatant,
-      blindRoll: actions.blindAsDefault,
+      blindRoll: actions.blindAsDefault ?? true,
       attributeChecks: actor.getChecks('attributeChecks'),
       otherChecks: actor.getChecks('otherChecks'),
       attackChecks: actor.getChecks('attackChecks'),
@@ -85,36 +110,43 @@ export const addQuickRollButton = async (html: HTMLElement, combatant: Combatant
       markedChecks: actor.getChecks('markedChecks'),
     }
   )
-  const quickMenu = $(quickRollMenu)
 
-  $(html).append(quickMenu)
+  const quickRollMenuElement = foundry.utils.parseHTML(quickRollMenu) as HTMLElement
+
+  quickRollMenuElement.style.display = 'none'
+
+  addQuickRollListeners(quickRollMenuElement)
+
+  html.append(quickRollMenuElement)
 
   return html
 }
 
-export const addQuickRollListeners = () => {
-  const updateText = (event : any) => {
+export const addQuickRollListeners = (html: HTMLElement) => {
+  const updateText = (event: any) => {
     // find all buttons and make the change
-    const buttons = $(document).find('.quick-roll-button.sm.atk')
+    const buttons = html.querySelectorAll('.quick-roll-button.lg.atk') as NodeListOf<HTMLElement>
 
-    buttons.each(function () {
-      const attackValue = $(this).find('.qr-attack-value')
+    buttons.forEach(function (button) {
+      const attackValue = button.querySelector('.qr-attack-value') as HTMLSpanElement
 
       if (event.ctrlKey) {
-        attackValue.text($(this).data('damage'))
+        attackValue.textContent = button.dataset.damage ?? ''
       } else {
-        attackValue.text($(this).data('skill'))
+        attackValue.textContent = button.dataset.skill ?? ''
       }
     })
   }
 
   // Resolve Roll Type Toggle
-  $(document)
-    .off('click', '.quick-roll-blind-toggle')
-    .on('click', '.quick-roll-blind-toggle', async function (event) {
+  html.querySelectorAll('.quick-roll-blind-toggle').forEach(element =>
+    element.addEventListener('click', async function (event: Event) {
       event.preventDefault()
       event.stopPropagation()
-      const combatantId = $(this).data('combatant-id')
+      const combatantId = (event.target as HTMLElement).dataset.combatantId
+
+      if (!combatantId) return
+
       const combatant = game.combat?.combatants.get(combatantId)
 
       if (!combatant || !combatant.token?.id) {
@@ -127,51 +159,53 @@ export const addQuickRollListeners = () => {
       const actions = await TokenActions.fromToken(token)
 
       actions.blindAsDefault = !actions.blindAsDefault
+
       await actions.save()
-      $(this)
-        .find('.qr-blind')
-        .each(function () {
-          $(this).toggleClass('active')
-        })
+      ;(event.target as HTMLElement).querySelectorAll('.qr-blind').forEach(function (element: Element) {
+        element.classList.toggle('active')
+      })
     })
+  )
 
   // Resolve Ctrl Key when hovering Quick Roll menu
-  $(document)
-    .off('mouseover', '.quick-roll-menu')
-    .on('mouseover', '.quick-roll-menu', function (event) {
-      $(document).on('keydown', updateText)
-      $(document).on('keyup', updateText)
+  html.addEventListener('mouseover', function (event: Event) {
+    document.addEventListener('keydown', updateText)
+    document.addEventListener('keyup', updateText)
 
-      updateText(event)
-    })
-  $(document)
-    .off('mouseout', '.quick-roll-menu')
-    .on('mouseout', '.quick-roll-menu', function () {
-      const button = $(this)
-      const attackValue = button.find('.qr-attack-value')
+    updateText(event)
+  })
 
-      attackValue.text(button.data('skill'))
+  html.addEventListener('mouseout', function (event: Event) {
+    if (!event.currentTarget) return
+    const button = (event.currentTarget as HTMLElement).querySelectorAll(
+      '.quick-roll-button.lg.atk'
+    ) as NodeListOf<HTMLElement>
 
-      $(document).off('keydown', updateText)
-      $(document).off('keyup', updateText)
-    })
+    for (const btn of button) {
+      const attackValue = btn.querySelector('.qr-attack-value') as HTMLSpanElement
+
+      attackValue.textContent = btn.dataset.skill ?? ''
+    }
+
+    document.removeEventListener('keydown', updateText)
+    document.removeEventListener('keyup', updateText)
+  })
 
   // Resolve Quick Roll Menu Button Click
-  $(document)
-    .off('click', '.quick-roll-button')
-    .on('click', '.quick-roll-button', async function (event) {
+  html.querySelectorAll('.quick-roll-button').forEach(item => {
+    ;(item as HTMLElement).addEventListener('click', async function (event: PointerEvent) {
       event.preventDefault()
       event.stopPropagation()
 
-      const button = $(this)
-      const combatantId = button.data('combatant-id')
-      const combatant = game.combat?.combatants.get(combatantId)
+      const button = event.currentTarget as HTMLElement
+      const combatantId = button.dataset.combatantId
+      const combatant = game.combat?.combatants.get(combatantId ?? '')
 
-     if (!combatant || !combatant.token?.id) {
-              console.warn(`Combatant not found for id: ${combatantId}`)
+      if (!combatant || !combatant.token?.id) {
+        console.warn(`Combatant not found for id: ${combatantId}`)
 
-              return
-            }
+        return
+      }
 
       const token = canvas?.tokens?.get(combatant.token.id)
 
@@ -184,10 +218,11 @@ export const addQuickRollListeners = () => {
       const actions = await TokenActions.fromToken(token)
       const actor = token.actor
 
-      const otf = button.data('otf')
-      const damage = button.data('otf-damage')
+      const otf = button.dataset.otf
+      const damage = button.dataset.otfDamage
       const formula = event.ctrlKey && damage ? damage : otf
 
       await actor.runOTF(`${actions.blindAsDefault ? '!' : ''}${formula}`)
     })
+  })
 }

--- a/src/module/combat-tracker/quick-roll-menu.ts
+++ b/src/module/combat-tracker/quick-roll-menu.ts
@@ -1,15 +1,16 @@
+import { GurpsToken } from '@module/token/gurps-token.js'
 import * as Settings from '@module/util/miscellaneous-settings.js'
 
 import { TokenActions } from '../token-actions.js'
 
-export const addQuickRollButton = async (html, combatant, token) => {
-  const quickRollSettings = game.settings.get(GURPS.SYSTEM_NAME, Settings.SETTING_USE_QUICK_ROLLS)
-  const canShowButtons = quickRollSettings.enabled && (game.user.isGM || combatant.isOwner)
+export const addQuickRollButton = async (html: HTMLElement, combatant: Combatant, token: GurpsToken) => {
+  const quickRollSettings = game.settings?.get(GURPS.SYSTEM_NAME, Settings.SETTING_USE_QUICK_ROLLS)
+  const canShowButtons = quickRollSettings?.enabled && (game.user?.isGM || combatant.isOwner)
 
   if (!canShowButtons || !token?.actor) return html
 
   const buttonClass = `combatant-control`
-  let quickRollButton = $(
+  const quickRollButton = $(
     `<a class="${buttonClass}"
           aria-label="Quick Roll"
           role="button"
@@ -54,9 +55,9 @@ export const addQuickRollButton = async (html, combatant, token) => {
       // Count the number of <li> elements below the selected one
       const lisBelow = allLis.slice(selectedIndex + 1).length
       const popout = $('#combat-popout')
-      const menuHeight = menu.outerHeight(true)
-      const trackerHeight = popout.outerHeight(true)
-      const additionalHeight = lisBelow * selectedLi.outerHeight(true)
+      const menuHeight = menu.outerHeight(true) ?? 0
+      const trackerHeight = popout.outerHeight(true) ?? 0
+      const additionalHeight = lisBelow * (selectedLi.outerHeight(true) ?? 0)
 
       popout.css('min-height', `${menuHeight + trackerHeight - additionalHeight}px`)
     } else {
@@ -92,7 +93,7 @@ export const addQuickRollButton = async (html, combatant, token) => {
 }
 
 export const addQuickRollListeners = () => {
-  const updateText = event => {
+  const updateText = (event : any) => {
     // find all buttons and make the change
     const buttons = $(document).find('.quick-roll-button.sm.atk')
 
@@ -114,8 +115,15 @@ export const addQuickRollListeners = () => {
       event.preventDefault()
       event.stopPropagation()
       const combatantId = $(this).data('combatant-id')
-      const combatant = game.combat.combatants.get(combatantId)
-      const token = canvas.tokens.get(combatant.token.id)
+      const combatant = game.combat?.combatants.get(combatantId)
+
+      if (!combatant || !combatant.token?.id) {
+        console.warn(`Combatant not found for id: ${combatantId}`)
+
+        return
+      }
+
+      const token = canvas?.tokens?.get(combatant.token.id)
       const actions = await TokenActions.fromToken(token)
 
       actions.blindAsDefault = !actions.blindAsDefault
@@ -157,8 +165,22 @@ export const addQuickRollListeners = () => {
 
       const button = $(this)
       const combatantId = button.data('combatant-id')
-      const combatant = game.combat.combatants.get(combatantId)
-      const token = canvas.tokens.get(combatant.token.id)
+      const combatant = game.combat?.combatants.get(combatantId)
+
+     if (!combatant || !combatant.token?.id) {
+              console.warn(`Combatant not found for id: ${combatantId}`)
+
+              return
+            }
+
+      const token = canvas?.tokens?.get(combatant.token.id)
+
+      if (!token || !token.actor) {
+        console.warn(`Token or actor not found for combatant: ${combatant.name ?? 'unknown'}`)
+
+        return
+      }
+
       const actions = await TokenActions.fromToken(token)
       const actor = token.actor
 

--- a/src/module/combat-tracker/render-combat-tracker.ts
+++ b/src/module/combat-tracker/render-combat-tracker.ts
@@ -1,7 +1,7 @@
 import { DragDropType } from '../drag-drop-types.js'
 
 import { addManeuverMenu } from './maneuver-menu.js'
-import { addQuickRollButton, addQuickRollListeners } from './quick-roll-menu.js'
+import { addQuickRollButton } from './quick-roll-menu.js'
 
 export async function renderCombatTracker(_app: any, element: HTMLElement, _options: any, _context: any) {
   if (!element.classList.contains('bound')) {
@@ -156,6 +156,4 @@ export async function renderCombatTracker(_app: any, element: HTMLElement, _opti
     await addManeuverMenu(combatantElement, combatant, token)
   }
 
-  // Add Quick Roll Listeners.
-  addQuickRollListeners()
 }

--- a/src/module/token-actions.js
+++ b/src/module/token-actions.js
@@ -183,7 +183,10 @@ export class TokenActions {
     this.evaluateTurns = savedTokenData.evaluateTurns || 0
     this.readyTurns = savedTokenData.readyTurns || 0
     this.moveTurns = savedTokenData.moveTurns || 0
-    this.blindAsDefault = savedTokenData.blindAsDefault !== null ? savedTokenData.blindAsDefault : game.user.isGM
+    this.blindAsDefault =
+      savedTokenData.blindAsDefault !== null && savedTokenData.blindAsDefault !== undefined
+        ? savedTokenData.blindAsDefault
+        : game.user.isGM
 
     return this
   }

--- a/src/module/token-actions.js
+++ b/src/module/token-actions.js
@@ -122,7 +122,6 @@ export class TokenActions {
     this.readyTurns = 0
     this.moveTurns = 0
 
-    this.blindAsDefault = game.user.isGM
     this.lastAttack = {}
   }
 
@@ -183,10 +182,6 @@ export class TokenActions {
     this.evaluateTurns = savedTokenData.evaluateTurns || 0
     this.readyTurns = savedTokenData.readyTurns || 0
     this.moveTurns = savedTokenData.moveTurns || 0
-    this.blindAsDefault =
-      savedTokenData.blindAsDefault !== null && savedTokenData.blindAsDefault !== undefined
-        ? savedTokenData.blindAsDefault
-        : game.user.isGM
 
     return this
   }
@@ -222,7 +217,6 @@ export class TokenActions {
       evaluateTurns: this.evaluateTurns,
       readyTurns: this.readyTurns,
       moveTurns: this.moveTurns,
-      blindAsDefault: this.blindAsDefault,
     }
 
     await this.token.document.setFlag('gurps', 'tokenActions', newData)

--- a/src/styles/apps.css
+++ b/src/styles/apps.css
@@ -54,6 +54,8 @@ Global Override body {
   --gga-bordercolor-glinkmodminus: hsl(5, 68%, 15%);
   --gga-color-glinkmodminus: hsl(5, 68%, 25%);
   --gga-color-popup-glinkmodminus: hsl(5, 68%, 12%);
+  --gga-quickroll-background: url(../../../ui/parchment.jpg);
+  --gga-quickroll-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
 }
 
 .system-gurps.theme-dark,
@@ -78,6 +80,8 @@ Global Override body {
   --gga-color-glinkmodminus: hsl(5, 32%, 80%);
   --gga-background-glinkmodminus-hover: hsl(5, 32%, 60%);
   --gga-color-popup-glinkmodminus: hsl(5, 32%, 12%);
+  --gga-quickroll-background: var(--color-cool-5);
+  --gga-quickroll-shadow: 0 2px 10px rgba(255, 255, 255, 0.1);
 }
 
 .system-gurps .control-icon[data-palette='maneuvers'] img,
@@ -2688,13 +2692,19 @@ li.combatant.active {
 
 .maneuver-combat-tracker-menu {
   position: absolute;
-  background-color: rgba(0, 0, 0, 0.95);
   border: 2px solid #337244;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
   z-index: 300;
   display: none;
   padding: 5px;
   margin-bottom: 5px;
+  background: var(--gga-quickroll-background, var(--color-cool-5-90));
+  .cant-do-icon {
+    color: var(--color-text-subtle);
+   }
+  .can-do-icon {
+    color: var(--color-text-primary);
+   }
 }
 
 .maneuver-combat-tracker-menu ul {
@@ -2733,7 +2743,7 @@ li.combatant.active {
   line-height: 1.2;
   font-size: 0.95em;
   margin-right: 5px;
-  color: white;
+  color: var(--color-text-emphatic);
 }
 
 .maneuver-select-hint {
@@ -2787,11 +2797,11 @@ li.combatant.active {
 .quick-roll-menu {
   position: absolute;
   top: 48px;
-  background-color: rgba(0, 0, 0, 0.9);
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--gga-quickroll-shadow, 0 2px 10px rgba(0, 0, 0, 0.2));
   display: none;
   flex: 0 0 100%;
   z-index: 100;
+  background: var(--gga-quickroll-background, var(--color-cool-5-90));
 }
 
 .quick-roll-row {
@@ -2823,15 +2833,15 @@ li.combatant.active {
   background-color: rgba(255, 255, 255, 0.05);
   border: none;
   border-radius: 0;
-  color: whitesmoke;
+  color: var(--color-text-emphatic);
   width: auto;
   flex-grow: 1;
-  margin-bottom: 3px;
+  margin-bottom: 0.4rem;
   justify-content: center;
   align-items: center;
 }
 
-button.quick-roll-button.sm.atk {
+button.quick-roll-button.lg {
   display: inline-flex;
   align-items: center;
 }
@@ -2839,13 +2849,16 @@ button.quick-roll-button.sm.atk {
 .w100 {
   width: 100%;
 }
+
 .flex4 {
   flex-grow: 4;
   min-width: 33%;
 }
+
 .mw25 {
   min-width: 25%;
 }
+
 .mw50 {
   min-width: 49%;
 }
@@ -2853,12 +2866,14 @@ button.quick-roll-button.sm.atk {
 .quick-roll-button {
   position: relative;
   display: inline-block;
+  min-height: 0;
+  height: auto;
 }
 
 .quick-roll-button .tooltip {
   visibility: hidden;
-  background-color: black;
-  color: #fff;
+  background-color: var(--color-cool-5-90);
+  color: var(--color-light-1);
   text-align: center;
   border-radius: 5px;
   padding: 5px;
@@ -2870,6 +2885,7 @@ button.quick-roll-button.sm.atk {
   opacity: 0;
   transition: opacity 0.3s;
   width: 100px;
+  border: 1px solid #202020;
 }
 
 .quick-roll-button.sm.dmg:first-child .tooltip,
@@ -2878,6 +2894,7 @@ button.quick-roll-button.sm.atk {
   right: 0;
   margin-left: 0;
 }
+
 .quick-roll-button:first-child .tooltip {
   left: 0;
   margin-left: 0;
@@ -2900,6 +2917,7 @@ button.quick-roll-button.sm.atk {
   right: 10px;
   margin-left: 0;
 }
+
 .quick-roll-button:first-child .tooltip::after {
   left: 10px;
   margin-left: 0;
@@ -2922,15 +2940,18 @@ button.quick-roll-button.sm.atk {
 .quick-roll-section h4 {
   text-transform: uppercase;
   font-size: 0.82em;
-  padding: 15px 0 5px 0;
+  padding: 10px 0px 5px 5px;;
   line-height: 1.1;
   border-bottom: 1px solid #772e21;
+  margin: 0 0 0.5rem 0;
 }
+
 .image-column {
   display: flex;
   flex-direction: column;
   max-width: 138px;
 }
+
 .add-quick-roll-option {
   display: flex;
   margin-top: 5px;
@@ -2959,16 +2980,23 @@ button.quick-roll-button.sm.atk {
 .qr-label.hidden {
   display: none;
 }
+
 .hr-notes {
   border: none;
   border-top: 1px solid rgba(194, 193, 183, 0.5);
   margin: 8px 5px;
 }
+
+.qr-image {
+    display: inline-flex;
+}
+
 .qr-image img {
   max-width: 20px;
   max-height: 20px;
   margin-bottom: -10px;
 }
+
 .qr-sk-image {
   max-width: 20px;
   max-height: 20px;

--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -452,7 +452,7 @@
     "atLeast": "Mindestens",
     "atNextTurn": "In der nächsten Runde",
     "attackRoll": "Angriffswurf",
-    "attackTab": "Angriffe",
+    "attackTab": "Angriffe (drücke STRG, um Schaden zu würfeln)",
     "attributes": "Attribute",
     "attributesDX": "DX",
     "attributesDXNAME": "Geschicklichkeit",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -452,7 +452,7 @@
     "atLeast": "At least",
     "atNextTurn": "At Next Turn",
     "attackRoll": "Attack Roll",
-    "attackTab": "Attacks",
+    "attackTab": "Attacks (press Ctrl to roll damage)",
     "attributes": "Attributes",
     "attributesDX": "DX",
     "attributesDXNAME": "Dexterity",

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -452,7 +452,7 @@
     "atLeast": "Au moins",
     "atNextTurn": "Au prochain tour",
     "attackRoll": "Jet d'Attaque",
-    "attackTab": "Attaques",
+    "attackTab": "Attaques (appuyez sur Ctrl pour lancer les dégâts)",
     "attributes": "Caractéristiques",
     "attributesDX": "DX",
     "attributesDXNAME": "Dextérité",

--- a/static/lang/pt_br.json
+++ b/static/lang/pt_br.json
@@ -452,7 +452,7 @@
     "atLeast": "Pelo menos",
     "atNextTurn": "Na próxima rodada",
     "attackRoll": "Rolagem de Ataque",
-    "attackTab": "Ataques",
+    "attackTab": "Ataques (pressione Ctrl para rolar dano)",
     "attributes": "Atributos",
     "attributesDX": "DX",
     "attributesDXNAME": "Destreza",

--- a/static/lang/ru.json
+++ b/static/lang/ru.json
@@ -452,7 +452,7 @@
     "atLeast": "По крайней мере",
     "atNextTurn": "В следующем раунде",
     "attackRoll": "Бросок атаки",
-    "attackTab": "Атаки",
+    "attackTab": "Атаки (нажмите Ctrl, чтобы бросить урон)",
     "attributes": "Атрибуты",
     "attributesDX": "ЛВ",
     "attributesDXNAME": "Ловкость",

--- a/static/templates/action/partials/details-melee-attack.hbs
+++ b/static/templates/action/partials/details-melee-attack.hbs
@@ -13,6 +13,7 @@
   <div class="ms-field-row">
     {{formGroup fields.st value=source.st}}
     {{formGroup fields.consumeAction value=source.consumeAction}}
+    {{formGroup fields.addToQuickRoll value=source.addToQuickRoll}}
   </div>
 
   <div class="ms-field-row" style="--ms-cols: 1;">
@@ -31,7 +32,8 @@
 
   <div class="ms-field-row">
     {{formGroup fields.parry.fields.canParry value=source.parry.canParry }}
-    {{formGroup fields.parry.fields.fencing value=source.parry.fencing }}
+    {{formGroup fields.parry.fields.fencing value=source.parry.fencing }}    
+
   </div>
 
   <div class="ms-field-row">

--- a/static/templates/action/partials/details-ranged-attack.hbs
+++ b/static/templates/action/partials/details-ranged-attack.hbs
@@ -13,6 +13,7 @@
   <div class="ms-field-row">
     {{formGroup fields.st value=source.st}}
     {{formGroup fields.consumeAction value=source.consumeAction}}
+    {{formGroup fields.addToQuickRoll value=source.addToQuickRoll}}
   </div>
 
   <div class="ms-field-row" style="--ms-cols: 1;">

--- a/static/templates/quick-roll-menu.hbs
+++ b/static/templates/quick-roll-menu.hbs
@@ -1,12 +1,4 @@
 <div class="quick-roll-menu" data-actor-id="{{actor.id}}">
-  <div class="quick-roll-blind-toggle" data-combatant-id="{{combatant.id}}" title="{{localize "GURPS.quickRoll"}}">
-      <div class="qr-blind qr-blue {{#if blindRoll}}active{{/if}}">
-        <i class="fa-solid fa-eye-slash" title="{{localize 'GURPS.blindRollAsDefault'}}"></i>
-      </div>
-      <div class="qr-blind qr-green {{#unless blindRoll}}active{{/unless}}">
-        <i class="fa-solid fa-eye" title="{{localize 'GURPS.publicRollAsDefault'}}"></i>
-      </div>
-  </div>
   {{#if (gt otherChecks.size 0)}}
     <div class="quick-roll-section">
       <h4>{{localize "GURPS.otherTab"}}</h4>

--- a/static/templates/quick-roll-menu.hbs
+++ b/static/templates/quick-roll-menu.hbs
@@ -12,19 +12,10 @@
       <h4>{{localize "GURPS.otherTab"}}</h4>
       <div class="quick-roll-row">
         <div class="quick-roll-hor">
-          {{#each otherChecks.data.checks as |check|}}
+          {{#each otherChecks.data as |check|}}
             <button class="quick-roll-button sm" data-otf="{{check.otf}}" data-combatant-id="{{../combatant.id}}">
               <div><i class="{{check.symbol}}"></i></div>
               <div>{{check.value}}</div>
-              <span class="tooltip">{{check.label}}-{{check.value}}</span>
-            </button>
-          {{/each}}
-        </div>
-        <div class="quick-roll-col mw25">
-          {{#each otherChecks.data.dmg as |check|}}
-            <button class="quick-roll-button sm dmg" data-otf="{{check.otf}}" data-combatant-id="{{../combatant.id}}">
-              <div class="quick-roll-dmg"><i class="{{check.symbol}}"></i><span
-                style="margin-left: 4px;">{{check.value}}</span></div>
               <span class="tooltip">{{check.label}}-{{check.value}}</span>
             </button>
           {{/each}}
@@ -36,26 +27,14 @@
   <div class="quick-roll-section">
     <h4>{{localize "GURPS.attackTab"}}</h4>
     <div class="quick-roll-row">
-      {{#each attackChecks.data.melee as |check|}}
+      {{#each attackChecks.data as |check|}}
         <button class="quick-roll-button sm atk" data-otf="{{check.otf}}" data-skill="{{check.value}}" data-otf-damage="{{check.otfDamage}}" data-damage="{{check.damage}}" data-combatant-id="{{../combatant.id}}">
           <div class="qr-image">{{#if check.img}}<img src="{{check.img}}" alt="{{check.label}}" />{{else}}
-            <i class="fa-solid fa-hand-fist"></i>{{/if}}</div>
+            <i class="fa-solid  {{#if (eq check.type 'melee')}}fa-hand-fist{{else}}fa-bow-arrow{{/if}}"></i>{{/if}}</div>
           <div class="qr-line">
             <div class="qr-label {{#if (gt ../attackChecks.size 6)}}hidden{{/if}}">{{check.label}}&nbsp;</div>
             <span class="qr-attack-value">{{check.value}}</span>
           </div>
-          <span class="tooltip">{{check.symbol}}:<br>{{check.label}}{{#if check.mode}}
-            ({{check.mode}}){{/if}}-{{check.value}}<br>{{localize 'GURPS.damage'}}:{{check.damage}}{{#if check.notes}}
-            <hr class="hr-notes">{{check.notes}}{{/if}}</span>
-        </button>
-      {{/each}}
-      {{#each attackChecks.data.ranged as |check|}}
-        <button class="quick-roll-button sm atk" data-otf="{{check.otf}}" data-skill="{{check.value}}" data-otf-damage="{{check.otfDamage}}" data-damage="{{check.damage}}" data-combatant-id="{{../combatant.id}}">
-          <div class="qr-image">{{#if check.img}}<img src="{{check.img}}" alt="{{check.label}}" />{{else}}
-            <i class="fa-solid fa-bow-arrow"></i>{{/if}}</div>
-          <div class="qr-line">
-            <div class="qr-label {{#if (gt ../attackChecks.size 6)}}hidden{{/if}}">{{check.label}}&nbsp;</div>
-            <span>{{check.value}}</span></div>
           <span class="tooltip">{{check.symbol}}:<br>{{check.label}}{{#if check.mode}}
             ({{check.mode}}){{/if}}-{{check.value}}<br>{{localize 'GURPS.damage'}}:{{check.damage}}{{#if check.notes}}
             <hr class="hr-notes">{{check.notes}}{{/if}}</span>
@@ -67,36 +46,30 @@
     <div class="quick-roll-section">
       <h4>{{localize "GURPS.defenseTab"}}</h4>
       <div class="quick-roll-row">
-        <div class="quick-roll-col flex4">
-          <button class="quick-roll-button lg" data-otf="{{defenseChecks.data.dodge.otf}}" data-combatant-id="{{combatant.id}}">
-            <div><i class="fa-solid fa-arrow-right-arrow-left"></i></div>
-            <div>{{defenseChecks.data.dodge.label}}-{{defenseChecks.data.dodge.value}}</div>
-            <span class="tooltip">{{defenseChecks.data.dodge.label}}-{{defenseChecks.data.dodge.value}}</span>
-          </button>
-        </div>
-        {{#each defenseChecks.data.parry as |check|}}
-          <button class="quick-roll-button sm" data-otf="{{check.otf}}" data-combatant-id="{{../combatant.id}}">
-            <div class="qr-image">{{#if check.img}}<img src="{{check.img}}" alt="{{check.label}}" />{{else}}
-              <i class="fa-solid fa-swords"></i>{{/if}}</div>
-            <div class="qr-line">
-              <div class="qr-label {{#if (gt ../defenseChecks.size 6)}}hidden{{/if}}">{{check.label}}-</div>
-              <span>{{check.value}}</span></div>
-            <span class="tooltip">{{check.symbol}}:<br>{{check.label}}{{#if check.mode}}
-              ({{check.mode}}){{/if}}-{{check.value}}{{#if check.notes}}
-              <hr class="hr-notes">{{check.notes}}{{/if}}</span>
-          </button>
-        {{/each}}
-        {{#each defenseChecks.data.block as |check|}}
-          <button class="quick-roll-button sm" data-otf="{{check.otf}}" data-combatant-id="{{../combatant.id}}">
-            <div class="qr-image">{{#if check.img}}<img src="{{check.img}}" alt="{{check.label}}" />{{else}}
-              <i class="fa-solid fa-shield-blank"></i>{{/if}}</div>
-            <div class="qr-line">
-              <div class="qr-label {{#if (gt ../defenseChecks.size 4)}}hidden{{/if}}">{{check.label}}-</div>
-              <span>{{check.value}}</span></div>
-            <span class="tooltip">{{check.symbol}}:<br>{{check.label}}{{#if check.mode}}
-              ({{check.mode}}){{/if}}-{{check.value}}{{#if check.notes}}
-              <hr class="hr-notes">{{check.notes}}{{/if}}</span>
-          </button>
+        {{#each defenseChecks.data as |check|}}
+          {{#if (eq check.type "dodge")}}
+            <div class="quick-roll-col flex4">
+            <button class="quick-roll-button lg" data-otf="{{check.otf}}" data-combatant-id="{{../combatant.id}}">
+                <div><i class="fa-solid fa-arrow-right-arrow-left"></i></div>
+                <div>{{check.label}}-{{check.value}}</div>
+                <span class="tooltip">{{check.label}}-{{check.value}}</span>
+            </button>
+            </div>
+          {{else}}
+              <button class="quick-roll-button lg" data-otf="{{check.otf}}" data-combatant-id="{{../combatant.id}}">
+                <div class="qr-image">{{#if check.img}}<img src="{{check.img}}" alt="{{check.label}}" />{{else}}
+                  <i class="fa-solid {{#if (eq check.type 'parry')}}fa-swords{{else}} fa-shield-blank{{/if}}"></i>{{/if}}
+                </div>
+                <div class="qr-line">
+                  <div class="qr-label {{#if (gt ../defenseChecks.size 6)}}hidden{{/if}}">{{check.label}}-</div>
+                  <span>{{check.value}}</span>
+                </div>
+                <span class="tooltip">{{check.symbol}}:<br>
+                  {{check.label}}{{#if check.mode}}({{check.mode}}){{/if}}-{{check.value}}
+                  {{#if check.notes}}<hr class="hr-notes">{{check.notes}}{{/if}}
+                </span>
+              </button>
+          {{/if}}
         {{/each}}
       </div>
     </div>

--- a/static/templates/quick-roll-menu.hbs
+++ b/static/templates/quick-roll-menu.hbs
@@ -28,11 +28,11 @@
     <h4>{{localize "GURPS.attackTab"}}</h4>
     <div class="quick-roll-row">
       {{#each attackChecks.data as |check|}}
-        <button class="quick-roll-button sm atk" data-otf="{{check.otf}}" data-skill="{{check.value}}" data-otf-damage="{{check.otfDamage}}" data-damage="{{check.damage}}" data-combatant-id="{{../combatant.id}}">
+        <button class="quick-roll-button lg atk" data-otf="{{check.otf}}" data-skill="{{check.value}}" data-otf-damage="{{check.otfDamage}}" data-damage="{{check.damage}}" data-combatant-id="{{../combatant.id}}">
           <div class="qr-image">{{#if check.img}}<img src="{{check.img}}" alt="{{check.label}}" />{{else}}
             <i class="fa-solid  {{#if (eq check.type 'melee')}}fa-hand-fist{{else}}fa-bow-arrow{{/if}}"></i>{{/if}}</div>
           <div class="qr-line">
-            <div class="qr-label {{#if (gt ../attackChecks.size 6)}}hidden{{/if}}">{{check.label}}&nbsp;</div>
+            <div class="qr-label {{#if (gt ../attackChecks.size 6)}}hidden{{/if}}">{{check.label}}-</div>
             <span class="qr-attack-value">{{check.value}}</span>
           </div>
           <span class="tooltip">{{check.symbol}}:<br>{{check.label}}{{#if check.mode}}
@@ -79,7 +79,7 @@
       <h4>{{localize "GURPS.markedTab"}}</h4>
       <div class="quick-roll-row">
         {{#each markedChecks.data as |check|}}
-          <button class="quick-roll-button sm" data-otf="{{check.otf}}" data-combatant-id="{{../combatant.id}}">
+          <button class="quick-roll-button lg" data-otf="{{check.otf}}" data-combatant-id="{{../combatant.id}}">
             <div style="display: flex; align-items: center;">
               {{#if check.img}}<img class="qr-sk-image" src="{{check.img}}" alt="{{check.label}}" />{{/if}}
             <span {{#if check.isOTF}}class="qr-otf"{{/if}}>{{check.label}}{{#unless check.isOTF}}-{{check.value}}{{/unless}}</span>


### PR DESCRIPTION
Fixes #2868 
There was a lot of stuff broken. I did the following fixes:

- character.getChecks returned a different structure than in V0.18. I mostly keep the V1.0.0 structure and adapted the HBS, as the v0.18 structure was needlessly complicated.
- many of the OTFs returned by character.getChecks where wrong and some other data was missing or wrong. I tried to use values from the display items where possible, to avoid duplication of logic.
- character.getChecks did not honor the addToQuickRoll Flag of attacks.
- The addToQuickRoll flag of attacks was missing in the action edit sheet.
- character.getChecks did not return entries for OTFs of selected items. 
- The menu did not honor the UI Theme and was partially unreadable in light mode. Also fixed this for the maneuver dropdown.
- The switch from attack to damage rolls on CRLT did not work.
- I tried  for a slightly more compact and consistent layout.
-  I converted the file to TS and fixed  the Type errors.
- I removed JQuery in favor of plain JS

There is a non functional, invisible Blind Roll switch in the HTML and some of the code. I like to remove it, as it doesn't make sense to have a blind roll switch as a global switch exists. This ties this code to the TokenActions, where the state of the switch is stored. Removing it would reduce code complexity and dependencies. What do you think?