### PR TITLE
Fix duplicated Committed Attack (Ranged) in the Modifier Bucket

### DIFF
--- a/module/modifier-bucket/tooltip-window.js
+++ b/module/modifier-bucket/tooltip-window.js
@@ -481,10 +481,8 @@ const ModifierLiterals = {
 
     if (useOnTarget) {
       defenseMods.push(
+        `[-2 ${game.i18n.localize('GURPS.modifiers_.committedAimDefense')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.committedAimDefense')}]`,
         `[-2 ${game.i18n.localize('GURPS.modifiers_.committedAttackRanged')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.committedAttackRanged')}]`,
-        `[-2 ${game.i18n.localize('GURPS.modifiers_.committedAttackRanged')}] [PDF:${game.i18n.localize(
-          'GURPS.modifiers_.pdf.committedAttackRanged'
-        )}]`
       )
     }
 


### PR DESCRIPTION
The On Target block in the bucket's Defense section pushed the same -2 Committed Attack (Ranged) line twice. The second was meant to be Committed Aim's -2 to defense: PY77 gives both maneuvers a defense penalty, and `GURPS.modifiers_.committedAimDefense` has been sitting in en.json unreferenced since the On Target options were added.

So the bucket offered a duplicate entry and no way at all to apply the Committed Aim penalty.

| Before | After |
| --- | --- |
|  <img width="355" height="117" alt="image" src="https://github.com/user-attachments/assets/c5de04b8-3d24-4d64-9a9c-33d42bc51107" />  |  <img width="384" height="150" alt="image" src="https://github.com/user-attachments/assets/696b61f6-02f6-4ec3-857a-bc9a46decdc1" /> |
