### PR TITLE
Extract the Modifier Bucket's combat options into a registry

### DIFF
--- a/module/combat/combat-options.ts
+++ b/module/combat/combat-options.ts
@@ -1,0 +1,72 @@
+/**
+ * Registry of the attack and defense options (B365, B374, MA99-100, Pyramid #3/77) shown in the
+ * Modifier Bucket's Melee Attack, Ranged and Defense sections.
+ *
+ * These used to be hardcoded arrays of OTF strings in `tooltip-window.js`, which made the rendered
+ * text the only representation of what options exist.
+ */
+
+export type CombatOptionSection = 'melee' | 'ranged' | 'defense'
+
+export interface CombatOption {
+  /** Stable key. Doubles as the `GURPS.modifiers_.<id>` and `GURPS.modifiers_.pdf.<id>` lookup. */
+  id: string
+  section: CombatOptionSection
+  /** Signed modifier as it is rendered, including the en-dash entries the original list used. */
+  mod: string
+  /** Appended inside the OTF, e.g. the `*Max:9` cap on Move and Attack. */
+  suffix?: string
+  /** Only offered when the Use On Target setting is on. */
+  requiresOnTarget?: boolean
+}
+
+export const COMBAT_OPTIONS: readonly CombatOption[] = [
+  // --- Melee Attack (B365, MA99-100, MA113, B369-370) ---
+  { id: 'aoaDetermined', section: 'melee', mod: '+4' },
+  { id: 'aoaStrong', section: 'melee', mod: '+2' },
+  { id: 'committedDetermined', section: 'melee', mod: '+2' },
+  { id: 'committedStrong', section: 'melee', mod: '+1' },
+  { id: 'telegraphic', section: 'melee', mod: '+4' },
+  { id: 'moveAndAttack', section: 'melee', mod: '-4', suffix: ' *Max:9' },
+  { id: 'deceptive', section: 'melee', mod: '-2' },
+  { id: 'defensive', section: 'melee', mod: '-2' },
+  { id: 'rapidStrike', section: 'melee', mod: '-6' },
+
+  // --- Ranged (B364, B365, B390) ---
+  { id: 'aim', section: 'ranged', mod: '+1' },
+  { id: 'popup', section: 'ranged', mod: '–2' },
+  { id: 'aoaRangedDetermined', section: 'ranged', mod: '+1' },
+
+  // --- Ranged, On Target (Pyramid #3/77) ---
+  { id: 'aoaRanged', section: 'ranged', mod: '+2', requiresOnTarget: true },
+  { id: 'committedRanged', section: 'ranged', mod: '+1', requiresOnTarget: true },
+  { id: 'allOutAim', section: 'ranged', mod: '+4', requiresOnTarget: true },
+  { id: 'allOutAimBraced', section: 'ranged', mod: '+2', requiresOnTarget: true },
+  { id: 'committedAim', section: 'ranged', mod: '+2', requiresOnTarget: true },
+  { id: 'committedAimBraced', section: 'ranged', mod: '+1', requiresOnTarget: true },
+
+  // --- Defense (B366, B374, B377, B390, MA100, MA124) ---
+  { id: 'aodIncreased', section: 'defense', mod: '+2' },
+  { id: 'shieldDB', section: 'defense', mod: '+1' },
+  { id: 'dodgeAcrobatic', section: 'defense', mod: '+2' },
+  { id: 'dodgeAndDrop', section: 'defense', mod: '+3' },
+  { id: 'dodgeRetreat', section: 'defense', mod: '+3' },
+  { id: 'blockRetreat', section: 'defense', mod: '+1' },
+  { id: 'fencingRetreat', section: 'defense', mod: '+3' },
+  { id: 'defensiveDefense', section: 'defense', mod: '+1' },
+  { id: 'dodgeAcrobaticFail', section: 'defense', mod: '-2' },
+  { id: 'defenseSide', section: 'defense', mod: '-2' },
+  { id: 'deceptiveDefense', section: 'defense', mod: '-1' },
+  { id: 'riposte', section: 'defense', mod: '–1' },
+
+  // --- Defense, On Target (Pyramid #3/77) ---
+  { id: 'committedAimDefense', section: 'defense', mod: '-2', requiresOnTarget: true },
+  { id: 'committedAttackRanged', section: 'defense', mod: '-2', requiresOnTarget: true },
+]
+
+export function enabledOptions(
+  section: CombatOptionSection,
+  { useOnTarget }: { useOnTarget: boolean }
+): CombatOption[] {
+  return COMBAT_OPTIONS.filter(option => option.section === section && (useOnTarget || !option.requiresOnTarget))
+}

--- a/module/modifier-bucket/tooltip-window.js
+++ b/module/modifier-bucket/tooltip-window.js
@@ -3,6 +3,7 @@ import * as Settings from '../../lib/miscellaneous-settings.js'
 import { parselink } from '../../lib/parselink.js'
 import { displayMod, horiz } from '../../lib/utilities.js'
 import { gurpslink } from '../../module/utilities/gurpslink.js'
+import { enabledOptions } from '../combat/combat-options.js'
 import { Combat } from '../combat/index.js'
 import GurpsWiring from '../gurps-wiring.js'
 import * as HitLocations from '../hitlocation/hitlocation.js'
@@ -423,70 +424,39 @@ const ModifierLiterals = {
     return this._HitLocationModifiers
   },
 
+  /** The combat options offered in one section of the bucket. */
+  _maneuverOptions(section) {
+    return enabledOptions(section, { useOnTarget: Combat.isUsingOnTarget() })
+  },
+
+  _maneuverOtf(option) {
+    const label = game.i18n.localize(`GURPS.modifiers_.${option.id}`)
+    const pdf = game.i18n.localize(`GURPS.modifiers_.pdf.${option.id}`)
+
+    return `[${option.mod} ${label}${option.suffix ?? ''}] [PDF:${pdf}]`
+  },
+
   get MeleeMods() {
-    return [
-      `[+4 ${game.i18n.localize('GURPS.modifiers_.aoaDetermined')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.aoaDetermined')}]`,
-      `[+2 ${game.i18n.localize('GURPS.modifiers_.aoaStrong')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.aoaStrong')}]`,
-      `[+2 ${game.i18n.localize('GURPS.modifiers_.committedDetermined')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.committedDetermined')}]`,
-      `[+1 ${game.i18n.localize('GURPS.modifiers_.committedStrong')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.committedStrong')}]`,
-      `[+4 ${game.i18n.localize('GURPS.modifiers_.telegraphic')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.telegraphic')}]`,
-      `[-4 ${game.i18n.localize('GURPS.modifiers_.moveAndAttack')} *Max:9] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.moveAndAttack')}]`,
-      `[-2 ${game.i18n.localize('GURPS.modifiers_.deceptive')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.deceptive')}]`,
-      `[-2 ${game.i18n.localize('GURPS.modifiers_.defensive')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.defensive')}]`,
-      `[-6 ${game.i18n.localize('GURPS.modifiers_.rapidStrike')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.rapidStrike')}]`,
-    ]
+    return this._maneuverOptions('melee').map(option => this._maneuverOtf(option))
   },
 
   get RangedMods() {
-    const useOnTarget = Combat.isUsingOnTarget()
+    const options = this._maneuverOptions('ranged')
+    const mods = []
 
-    const rangedMods = [
-      `[+1 ${game.i18n.localize('GURPS.modifiers_.aim')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.aim')}]`,
-      `[–2 ${game.i18n.localize('GURPS.modifiers_.popup')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.popup')}]`,
-      `[+1 ${game.i18n.localize('GURPS.modifiers_.aoaRangedDetermined')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.aoaRangedDetermined')}]`,
-    ]
+    for (const [index, option] of options.entries()) {
+      // The On Target aiming options are grouped under their own heading within the Ranged section.
+      if (option.requiresOnTarget && !options[index - 1]?.requiresOnTarget)
+        mods.push(horiz(game.i18n.localize('GURPS.modifiers_.onTargetAiming')))
 
-    if (useOnTarget) {
-      rangedMods.push(
-        `${horiz(game.i18n.localize('GURPS.modifiers_.onTargetAiming'))}`,
-        `[+2 ${game.i18n.localize('GURPS.modifiers_.aoaRanged')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.aoaRanged')}]`,
-        `[+1 ${game.i18n.localize('GURPS.modifiers_.committedRanged')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.committedRanged')}]`,
-        `[+4 ${game.i18n.localize('GURPS.modifiers_.allOutAim')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.allOutAim')}]`,
-        `[+2 ${game.i18n.localize('GURPS.modifiers_.allOutAimBraced')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.allOutAimBraced')}]`,
-        `[+2 ${game.i18n.localize('GURPS.modifiers_.committedAim')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.committedAim')}]`,
-        `[+1 ${game.i18n.localize('GURPS.modifiers_.committedAimBraced')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.committedAimBraced')}]`
-      )
+      mods.push(this._maneuverOtf(option))
     }
 
-    return rangedMods
+    return mods
   },
 
   get DefenseMods() {
-    const useOnTarget = Combat.isUsingOnTarget()
-
-    const defenseMods = [
-      `[+2 ${game.i18n.localize('GURPS.modifiers_.aodIncreased')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.aodIncreased')}]`,
-      `[+1 ${game.i18n.localize('GURPS.modifiers_.shieldDB')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.shieldDB')}]`,
-      `[+2 ${game.i18n.localize('GURPS.modifiers_.dodgeAcrobatic')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.dodgeAcrobatic')}]`,
-      `[+3 ${game.i18n.localize('GURPS.modifiers_.dodgeAndDrop')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.dodgeAndDrop')}]`,
-      `[+3 ${game.i18n.localize('GURPS.modifiers_.dodgeRetreat')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.dodgeRetreat')}]`,
-      `[+1 ${game.i18n.localize('GURPS.modifiers_.blockRetreat')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.blockRetreat')}]`,
-      `[+3 ${game.i18n.localize('GURPS.modifiers_.fencingRetreat')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.fencingRetreat')}]`,
-      `[+1 ${game.i18n.localize('GURPS.modifiers_.defensiveDefense')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.defensiveDefense')}]`,
-      `[-2 ${game.i18n.localize('GURPS.modifiers_.dodgeAcrobaticFail')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.dodgeAcrobaticFail')}]`,
-      `[-2 ${game.i18n.localize('GURPS.modifiers_.defenseSide')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.defenseSide')}]`,
-      `[-1 ${game.i18n.localize('GURPS.modifiers_.deceptiveDefense')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.deceptiveDefense')}]`,
-      `[–1 ${game.i18n.localize('GURPS.modifiers_.riposte')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.riposte')}]`,
-    ]
-
-    if (useOnTarget) {
-      defenseMods.push(
-        `[-2 ${game.i18n.localize('GURPS.modifiers_.committedAimDefense')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.committedAimDefense')}]`,
-        `[-2 ${game.i18n.localize('GURPS.modifiers_.committedAttackRanged')}] [PDF:${game.i18n.localize('GURPS.modifiers_.pdf.committedAttackRanged')}]`,
-      )
-    }
-
-    return defenseMods
+    return this._maneuverOptions('defense').map(option => this._maneuverOtf(option))
   },
 
   get OtherMods1() {

--- a/test/combat-options.test.ts
+++ b/test/combat-options.test.ts
@@ -1,0 +1,48 @@
+import { COMBAT_OPTIONS, CombatOptionSection, enabledOptions } from '../module/combat/combat-options.js'
+
+const SECTIONS: CombatOptionSection[] = ['melee', 'ranged', 'defense']
+
+describe('COMBAT_OPTIONS ordering', () => {
+  // RangedMods emits the "On Target" sub-heading when an option's requiresOnTarget differs from its
+  // predecessor's, so an On Target entry slipped into the middle of a section would emit a second one.
+  it('groups the On Target options of every section into a single run at the end', () => {
+    const interleaved = SECTIONS.filter(section => {
+      const flags = COMBAT_OPTIONS.filter(o => o.section === section).map(o => Number(!!o.requiresOnTarget))
+      return flags.some((flag, index) => index > 0 && flag < flags[index - 1])
+    })
+
+    expect(interleaved).toEqual([])
+  })
+
+  it('gives every option a unique id', () => {
+    const ids = COMBAT_OPTIONS.map(o => o.id)
+
+    expect(ids).toHaveLength(new Set(ids).size)
+  })
+})
+
+describe('enabledOptions', () => {
+  it('returns only options from the requested section', () => {
+    const ids = enabledOptions('melee', { useOnTarget: false }).map(o => o.id)
+
+    expect(ids).toEqual(COMBAT_OPTIONS.filter(o => o.section === 'melee' && !o.requiresOnTarget).map(o => o.id))
+  })
+
+  test('On Target is disabled', () => {
+    const ids = enabledOptions('ranged', { useOnTarget: false }).map(o => o.id)
+
+    expect(ids).not.toContain('allOutAim')
+  })
+
+  test('On Target is enabled', () => {
+    const ids = enabledOptions('ranged', { useOnTarget: true }).map(o => o.id)
+
+    expect(ids).toContain('allOutAim')
+  })
+
+  it('includes the Committed Aim defense penalty in the defense section', () => {
+    const ids = enabledOptions('defense', { useOnTarget: true }).map(o => o.id)
+
+    expect(ids).toContain('committedAimDefense')
+  })
+})


### PR DESCRIPTION
`MeleeMods`, `RangedMods` and `DefenseMods` were three hardcoded arrays of interpolated OTF strings, each line repeating the same `[${mod} ${localize(id)}] [PDF:${localize(pdf.id)}]` shape by hand. The bucket was the only place in the system that knew which attack and defense options exist, and knew them only as rendered text. 

`module/combat/combat-options.ts` holds the same 32 options as data. The bucket keeps the rendering, and now builds each line from one template instead of thirty-two, so a new option is a row in a table rather than a string to get the punctuation right in.

`CombatOption` rather than something like BucketModifier, because the point of pulling the list out is that the bucket stops being the only possible consumer.